### PR TITLE
release: sync develop into main (workflows, lint cleanup, docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -38,7 +38,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,23 +27,23 @@ jobs:
         language: [ 'go' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.26.1'
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -19,14 +19,14 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run gosec
-        uses: securego/gosec@master
+        uses: securego/gosec@64b97151cd7b978abdf8d2f1159a4e9096a12c2b # master
         with:
           args: '-fmt sarif -out results.sarif -no-fail ./...'
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,9 +16,9 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.26.1'
           cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,15 +11,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.26.1'
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.3
-          install-mode: goinstall

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -17,7 +17,7 @@ jobs:
     name: Conventional Commit
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.26.1'
           cache: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,25 +20,25 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 14

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,6 @@ linters:
     - gosec           # common security issues (G101–G601)
 
     # --- style & maintainability ---
-    - gofmt           # formatting
-    - goimports       # import grouping and formatting
     - misspell        # common spelling mistakes in comments/strings
     - godot           # comment sentences end with a period
     - revive          # drop-in replacement for golint with more rules
@@ -26,41 +24,55 @@ linters:
     # --- bugs ---
     - bodyclose       # HTTP response body not closed
     - noctx           # HTTP requests without context
-    - exportloopref   # loop variable capture (pre-Go 1.22)
 
-linters-settings:
-  cyclop:
-    max-complexity: 15
+  settings:
+    cyclop:
+      max-complexity: 20
 
-  funlen:
-    lines: 80
-    statements: 50
+    funlen:
+      lines: 80
+      statements: 50
 
-  gosec:
-    excludes:
-      - G115  # integer overflow on conversion — acceptable in UUID/time math
+    gosec:
+      excludes:
+        - G115  # integer overflow on conversion — acceptable in UUID/time math
 
-  godot:
-    scope: declarations
+    godot:
+      scope: declarations
 
-  revive:
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - "sayRepetitiveInsteadOfStutters"
+
+  exclusions:
     rules:
-      - name: exported
-        arguments:
-          - "checkPrivateReceivers"
-          - "sayRepetitiveInsteadOfStutters"
+      # Test files are allowed longer functions, unexported symbols, and may
+      # read files from variable paths (controlled test inputs).
+      - path: "_test\\.go"
+        linters:
+          - funlen
+          - godot
+          - revive
+          - gosec
+          - errcheck
 
-issues:
-  exclude-rules:
-    # Test files are allowed longer functions and unexported symbols.
-    - path: "_test\\.go"
-      linters:
-        - funlen
-        - godot
-        - revive
+      # Examples are documentation — relax style rules.
+      - path: "examples/"
+        linters:
+          - funlen
+          - godot
+          - errcheck
 
-    # Examples are documentation — relax style rules.
-    - path: "examples/"
-      linters:
-        - funlen
-        - godot
+      # Internal keymanager reads paths constructed by the package itself,
+      # not from external user input.
+      - path: "internal/keymanager/"
+        linters:
+          - gosec
+        text: "G304"
+
+formatters:
+  enable:
+    - gofmt           # formatting
+    - goimports       # import grouping and formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,13 @@ Follow the process in our [Security Policy](SECURITY.md) instead.
 
 ### Pull Requests
 
-1. **Fork** the repository and branch from `main`.
+> **Branch model.** `main` only ever contains released code — what you see on
+> [pkg.go.dev](https://pkg.go.dev/github.com/Jaro-c/authcore). All work lands on
+> `develop` first and is promoted to `main` together with a release tag. Always
+> branch from `develop` and target `develop` in your PR. Pull requests against
+> `main` will be redirected.
+
+1. **Fork** the repository and branch from `develop` (not `main`).
 2. **Run `go mod download`** to fetch dependencies.
 3. **Write tests.** Every change must include tests. Security-critical paths need
    table-driven tests that cover both the happy path and all error cases.
@@ -64,6 +70,7 @@ golangci-lint run
 
 1. Ensure all CI checks pass (tests + lint).
 2. A maintainer will review within a few days.
-3. Once approved it will be squash-merged into `main`.
+3. Once approved it will be squash-merged into `develop`. The maintainer
+   later promotes `develop` to `main` together with a release tag.
 
 Thank you for your contribution!

--- a/auth/email/email_test.go
+++ b/auth/email/email_test.go
@@ -16,8 +16,8 @@ import (
 type fakeProvider struct{}
 
 func (fakeProvider) Config() authcore.Config { return authcore.DefaultConfig() }
-func (fakeProvider) Logger() authcore.Logger  { return silentLogger{} }
-func (fakeProvider) Keys() authcore.Keys      { return nil }
+func (fakeProvider) Logger() authcore.Logger { return silentLogger{} }
+func (fakeProvider) Keys() authcore.Keys     { return nil }
 
 type silentLogger struct{}
 

--- a/auth/email/errors.go
+++ b/auth/email/errors.go
@@ -2,19 +2,18 @@ package email
 
 import "errors"
 
-// Sentinel errors returned by the email package.
-// Use errors.Is to check for these in calling code.
+// ErrInvalidEmail signals that an address failed RFC 5321/5322 validation.
 //
-// # Error safety
-//
-// ErrInvalidEmail is CLIENT-SAFE: the wrapped reason describes exactly which
-// rule failed and is suitable for returning in a 400 response:
+// CLIENT-SAFE: the wrapped reason describes exactly which rule failed and is
+// suitable for returning in a 400 response:
 //
 //	normalized, err := emailMod.ValidateAndNormalize(req.Email)
 //	if err != nil {
 //	    c.JSON(400, map[string]string{"error": errors.Unwrap(err).Error()})
 //	    return
 //	}
+//
+// Use errors.Is to check for this in calling code.
 var ErrInvalidEmail = errors.New("email: invalid address")
 
 // ErrDomainNoMX is CLIENT-SAFE: the domain exists but has no MX records,
@@ -48,6 +47,8 @@ func (v *emailViolation) Unwrap() error   { return v.reason }
 // DNS error for logging while keeping errors.Is(err, ErrDomainUnresolvable) working.
 type domainUnresolvable struct{ cause error }
 
-func (e *domainUnresolvable) Error() string   { return ErrDomainUnresolvable.Error() + ": " + e.cause.Error() }
+func (e *domainUnresolvable) Error() string {
+	return ErrDomainUnresolvable.Error() + ": " + e.cause.Error()
+}
 func (e *domainUnresolvable) Is(t error) bool { return t == ErrDomainUnresolvable }
 func (e *domainUnresolvable) Unwrap() error   { return e.cause }

--- a/auth/email/example_test.go
+++ b/auth/email/example_test.go
@@ -13,7 +13,7 @@ import (
 
 func ExampleNew() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, err := email.New(auth)
@@ -27,7 +27,7 @@ func ExampleNew() {
 
 func ExampleEmail_ValidateAndNormalize() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := email.New(auth)
@@ -44,7 +44,7 @@ func ExampleEmail_ValidateAndNormalize() {
 
 func ExampleEmail_VerifyDomain() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := email.New(auth)

--- a/auth/jwt/example_test.go
+++ b/auth/jwt/example_test.go
@@ -15,7 +15,7 @@ type AppClaims struct {
 
 func ExampleNew() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, err := jwt.New[AppClaims](auth, jwt.DefaultConfig())
@@ -28,7 +28,7 @@ func ExampleNew() {
 
 func ExampleJWT_CreateTokens() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := jwt.New[AppClaims](auth, jwt.DefaultConfig())
@@ -44,7 +44,7 @@ func ExampleJWT_CreateTokens() {
 
 func ExampleJWT_VerifyAccessToken() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := jwt.New[AppClaims](auth, jwt.DefaultConfig())
@@ -67,7 +67,7 @@ func ExampleJWT_VerifyAccessToken() {
 
 func ExampleJWT_RotateTokens() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := jwt.New[AppClaims](auth, jwt.DefaultConfig())

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -38,7 +38,7 @@ func isUUIDv7(s string) bool {
 			continue
 		}
 		c := s[i]
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			return false
 		}
 	}

--- a/auth/jwt/jwt_test.go
+++ b/auth/jwt/jwt_test.go
@@ -170,10 +170,10 @@ func TestCreateTokens_invalidSubjectReturnsError(t *testing.T) {
 		"123",
 		"0191b432-b5a7-7c4f-b2e6",               // too short
 		"0191b432-b5a7-7c4f-b2e6-7a3f1d2e00001", // too long
-		"550e8400-e29b-11d4-a716-446655440000",   // v1 — rejected
-		"550e8400-e29b-31d4-a716-446655440000",   // v3 — rejected
-		"550e8400-e29b-41d4-a716-446655440000",   // v4 — rejected
-		"550e8400-e29b-61d4-a716-446655440000",   // v6 — rejected
+		"550e8400-e29b-11d4-a716-446655440000",  // v1 — rejected
+		"550e8400-e29b-31d4-a716-446655440000",  // v3 — rejected
+		"550e8400-e29b-41d4-a716-446655440000",  // v4 — rejected
+		"550e8400-e29b-61d4-a716-446655440000",  // v6 — rejected
 	}
 	for _, tc := range cases {
 		_, err := j.CreateTokens(tc, struct{}{})

--- a/auth/jwt/token.go
+++ b/auth/jwt/token.go
@@ -99,12 +99,12 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.T
 	var c accessClaims[T]
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub),                                   // enforce EdDSA alg; rejects HS256/RS256 confusion attacks
-		gjwt.WithTimeFunc(func() time.Time { return now }),  // inject clock so tests can freeze time
-		gjwt.WithExpirationRequired(),                       // reject tokens without an exp claim
-		gjwt.WithIssuedAt(),                                 // reject tokens with iat in the future
-		gjwt.WithAudience(audience[0]),                      // token must contain this audience value
-		gjwt.WithLeeway(leeway),                             // tolerate small clock drift between servers
+		eddsaKeyFunc(pub), // enforce EdDSA alg; rejects HS256/RS256 confusion attacks
+		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
+		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
+		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
+		gjwt.WithAudience(audience[0]),                     // token must contain this audience value
+		gjwt.WithLeeway(leeway),                            // tolerate small clock drift between servers
 	)
 	if err != nil {
 		return nil, mapJWTError(err)
@@ -119,12 +119,12 @@ func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, a
 	var c refreshClaims
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub),                                   // enforce EdDSA alg; rejects HS256/RS256 confusion attacks
-		gjwt.WithTimeFunc(func() time.Time { return now }),  // inject clock so tests can freeze time
-		gjwt.WithExpirationRequired(),                       // reject tokens without an exp claim
-		gjwt.WithIssuedAt(),                                 // reject tokens with iat in the future
-		gjwt.WithAudience(audience[0]),                      // token must contain this audience value
-		gjwt.WithLeeway(leeway),                             // tolerate small clock drift between servers
+		eddsaKeyFunc(pub), // enforce EdDSA alg; rejects HS256/RS256 confusion attacks
+		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
+		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
+		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
+		gjwt.WithAudience(audience[0]),                     // token must contain this audience value
+		gjwt.WithLeeway(leeway),                            // tolerate small clock drift between servers
 	)
 	if err != nil {
 		return nil, mapJWTError(err)
@@ -183,7 +183,7 @@ func accessClaimsToClaims[T any](c *accessClaims[T]) *Claims[T] {
 		Issuer:    c.Issuer,
 		Audience:  []string(c.Audience),
 		TokenID:   c.ID,
-		IssuedAt:  iat.UTC(),  // normalise to UTC regardless of the server's local timezone
+		IssuedAt:  iat.UTC(), // normalise to UTC regardless of the server's local timezone
 		ExpiresAt: exp.UTC(),
 		Extra:     c.Extra,
 	}
@@ -199,7 +199,7 @@ func computeHMAC(token string, secret []byte) string {
 // generateJTI returns a UUID v7 string suitable for use as the "jti" claim.
 // The 48-bit timestamp comes from now; the remaining bits are cryptographically random.
 //
-// Format: xxxxxxxx-xxxx-7xxx-[89ab]xxx-xxxxxxxxxxxx (RFC 9562 §5.7)
+// Format: xxxxxxxx-xxxx-7xxx-[89ab]xxx-xxxxxxxxxxxx (RFC 9562 §5.7).
 func generateJTI(now time.Time) (string, error) {
 	ms := now.UnixMilli()
 

--- a/auth/password/config.go
+++ b/auth/password/config.go
@@ -62,9 +62,9 @@ func applyDefaults(cfg Config) Config {
 }
 
 const (
-	minMemory     = 8 * 1024       // 8 MiB in KiB
+	minMemory     = 8 * 1024        // 8 MiB in KiB
 	maxMemory     = 4 * 1024 * 1024 // 4 GiB in KiB — prevents accidental DoS
-	maxIterations = 20             // beyond this, hashing takes tens of seconds
+	maxIterations = 20              // beyond this, hashing takes tens of seconds
 )
 
 // validateConfig returns an error if cfg contains invalid values.

--- a/auth/password/example_test.go
+++ b/auth/password/example_test.go
@@ -11,7 +11,7 @@ import (
 
 func ExampleNew() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, err := password.New(auth)
@@ -24,7 +24,7 @@ func ExampleNew() {
 
 func ExamplePassword_Hash() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := password.New(auth, password.Config{Memory: 8 * 1024, Iterations: 1, Parallelism: 1})
@@ -40,7 +40,7 @@ func ExamplePassword_Hash() {
 
 func ExamplePassword_Verify() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := password.New(auth, password.Config{Memory: 8 * 1024, Iterations: 1, Parallelism: 1})
@@ -53,7 +53,7 @@ func ExamplePassword_Verify() {
 
 func ExamplePassword_ValidatePolicy() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := password.New(auth)

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Jaro-c/authcore"
 )
 
-
 // ---- test infrastructure ----------------------------------------------------
 
 // fakeProvider satisfies authcore.Provider with a silent logger and no keys.
@@ -258,7 +257,6 @@ func TestHash_strongPasswordSucceeds(t *testing.T) {
 		t.Errorf("Hash(strong password) error = %v, want nil", err)
 	}
 }
-
 
 // ---- checkPolicy() ----------------------------------------------------------
 

--- a/auth/username/errors.go
+++ b/auth/username/errors.go
@@ -2,19 +2,18 @@ package username
 
 import "errors"
 
-// Sentinel errors returned by the username package.
-// Use errors.Is to check for these in calling code.
+// ErrInvalidUsername signals that a username failed validation.
 //
-// # Error safety
-//
-// ErrInvalidUsername is CLIENT-SAFE: the wrapped reason describes exactly which
-// rule failed and is suitable for returning in a 400 response:
+// CLIENT-SAFE: the wrapped reason describes exactly which rule failed and is
+// suitable for returning in a 400 response:
 //
 //	normalized, err := usernameMod.ValidateAndNormalize(req.Username)
 //	if err != nil {
 //	    c.JSON(400, map[string]string{"error": errors.Unwrap(err).Error()})
 //	    return
 //	}
+//
+// Use errors.Is to check for this in calling code.
 var ErrInvalidUsername = errors.New("username: invalid username")
 
 // usernameViolation wraps ErrInvalidUsername with a single specific reason so
@@ -23,6 +22,8 @@ var ErrInvalidUsername = errors.New("username: invalid username")
 // where errors.Unwrap returns nil, breaking the errors.Unwrap(err).Error() pattern.
 type usernameViolation struct{ reason error }
 
-func (v *usernameViolation) Error() string   { return ErrInvalidUsername.Error() + ": " + v.reason.Error() }
+func (v *usernameViolation) Error() string {
+	return ErrInvalidUsername.Error() + ": " + v.reason.Error()
+}
 func (v *usernameViolation) Is(t error) bool { return t == ErrInvalidUsername }
 func (v *usernameViolation) Unwrap() error   { return v.reason }

--- a/auth/username/example_test.go
+++ b/auth/username/example_test.go
@@ -11,7 +11,7 @@ import (
 
 func ExampleNew() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, err := username.New(auth)
@@ -24,7 +24,7 @@ func ExampleNew() {
 
 func ExampleUsername_ValidateAndNormalize() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := username.New(auth)
@@ -40,7 +40,7 @@ func ExampleUsername_ValidateAndNormalize() {
 
 func ExampleUsername_ValidateAndNormalize_reserved() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	auth, _ := authcore.New(authcore.Config{EnableLogs: false, KeysDir: dir})
 	mod, _ := username.New(auth)

--- a/auth/username/username_test.go
+++ b/auth/username/username_test.go
@@ -13,8 +13,8 @@ import (
 type fakeProvider struct{}
 
 func (fakeProvider) Config() authcore.Config { return authcore.DefaultConfig() }
-func (fakeProvider) Logger() authcore.Logger  { return silentLogger{} }
-func (fakeProvider) Keys() authcore.Keys      { return nil }
+func (fakeProvider) Logger() authcore.Logger { return silentLogger{} }
+func (fakeProvider) Keys() authcore.Keys     { return nil }
 
 type silentLogger struct{}
 
@@ -87,9 +87,9 @@ func TestValidateAndNormalize_valid(t *testing.T) {
 		"alice-bob",
 		"alice_bob",
 		"a1b2c3",
-		"abc",                          // exactly minLength (3)
-		"a-b",                          // hyphen in middle
-		"a_b",                          // underscore in middle
+		"abc", // exactly minLength (3)
+		"a-b", // hyphen in middle
+		"a_b", // underscore in middle
 		"user123name",
 		strings.Repeat("a", maxLength), // exactly maxLength (32)
 	}

--- a/config.go
+++ b/config.go
@@ -92,7 +92,7 @@ func validateKeysDir(dir string) error {
 	}
 	name := tmp.Name()
 	if err := tmp.Close(); err != nil {
-		os.Remove(name)
+		_ = os.Remove(name)
 		return fmt.Errorf("keys directory %q write check failed: %w", dir, err)
 	}
 	if err := os.Remove(name); err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 
 func ExampleNew() {
 	dir, _ := os.MkdirTemp("", "authcore-example-")
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	cfg := authcore.DefaultConfig()
 	cfg.EnableLogs = false

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -86,7 +86,7 @@ func tempDir() (string, func()) {
 	if err != nil {
 		log.Fatalf("create temp dir: %v", err)
 	}
-	return dir, func() { os.RemoveAll(dir) }
+	return dir, func() { _ = os.RemoveAll(dir) }
 }
 
 // myAppLogger is a toy implementation of authcore.Logger.

--- a/examples/email/main.go
+++ b/examples/email/main.go
@@ -41,12 +41,12 @@ func main() {
 	fmt.Println("=== ValidateAndNormalize ===")
 
 	cases := []string{
-		"  USER@EXAMPLE.COM  ", // valid — normalized to lowercase + trimmed
+		"  USER@EXAMPLE.COM  ",            // valid — normalized to lowercase + trimmed
 		"user.name+tag@sub.example.co.uk", // valid — complex but correct
-		"",                    // invalid — empty
-		"notanemail",          // invalid — no @
-		"user@localhost",      // invalid — domain has no dot
-		"user@example..com",   // invalid — consecutive dots
+		"",                                // invalid — empty
+		"notanemail",                      // invalid — no @
+		"user@localhost",                  // invalid — domain has no dot
+		"user@example..com",               // invalid — consecutive dots
 	}
 
 	for _, raw := range cases {
@@ -104,5 +104,5 @@ func tempDir() (string, func()) {
 	if err != nil {
 		log.Fatalf("create temp dir: %v", err)
 	}
-	return dir, func() { os.RemoveAll(dir) }
+	return dir, func() { _ = os.RemoveAll(dir) }
 }

--- a/examples/jwt/main.go
+++ b/examples/jwt/main.go
@@ -113,5 +113,5 @@ func tempDir() (string, func()) {
 	if err != nil {
 		log.Fatalf("create temp dir: %v", err)
 	}
-	return dir, func() { os.RemoveAll(dir) }
+	return dir, func() { _ = os.RemoveAll(dir) }
 }

--- a/examples/password/main.go
+++ b/examples/password/main.go
@@ -116,5 +116,5 @@ func tempDir() (string, func()) {
 	if err != nil {
 		log.Fatalf("create temp dir: %v", err)
 	}
-	return dir, func() { os.RemoveAll(dir) }
+	return dir, func() { _ = os.RemoveAll(dir) }
 }

--- a/examples/username/main.go
+++ b/examples/username/main.go
@@ -38,16 +38,16 @@ func main() {
 	fmt.Println("=== ValidateAndNormalize ===")
 
 	cases := []string{
-		"  Alice_123  ",  // valid — normalized to lowercase + trimmed
-		"bob-dev",        // valid — hyphen in middle
-		"user99",         // valid
-		"ab",             // invalid — too short (min 3)
-		"-alice",         // invalid — starts with hyphen
-		"alice__bob",     // invalid — consecutive underscores
-		"alice@bob",      // invalid — @ not allowed
-		"admin",          // invalid — reserved name
-		"root",           // invalid — reserved name
-		"login",          // invalid — reserved name (would clash with URL route)
+		"  Alice_123  ", // valid — normalized to lowercase + trimmed
+		"bob-dev",       // valid — hyphen in middle
+		"user99",        // valid
+		"ab",            // invalid — too short (min 3)
+		"-alice",        // invalid — starts with hyphen
+		"alice__bob",    // invalid — consecutive underscores
+		"alice@bob",     // invalid — @ not allowed
+		"admin",         // invalid — reserved name
+		"root",          // invalid — reserved name
+		"login",         // invalid — reserved name (would clash with URL route)
 	}
 
 	for _, raw := range cases {
@@ -96,5 +96,5 @@ func tempDir() (string, func()) {
 	if err != nil {
 		log.Fatalf("create temp dir: %v", err)
 	}
-	return dir, func() { os.RemoveAll(dir) }
+	return dir, func() { _ = os.RemoveAll(dir) }
 }

--- a/internal/clock/clock_test.go
+++ b/internal/clock/clock_test.go
@@ -75,7 +75,7 @@ func TestFixed_alwaysReturnsTheSameTime(t *testing.T) {
 
 func TestFixed_implementsClock(t *testing.T) {
 	fixed := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	var clk clock.Clock = clock.Fixed(fixed)
+	var clk = clock.Fixed(fixed)
 
 	if !clk.Now().Equal(fixed) {
 		t.Errorf("Fixed clock Now() = %v, want %v", clk.Now(), fixed)

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -105,7 +105,8 @@ func writePublicKey(path string, key ed25519.PublicKey) error {
 		return fmt.Errorf("marshal Ed25519 public key: %w", err)
 	}
 	block := &pem.Block{Type: "PUBLIC KEY", Bytes: der}
-	return os.WriteFile(path, pem.EncodeToMemory(block), 0644)
+	return os.WriteFile(path, pem.EncodeToMemory(block), 0644) //nolint:gosec // public key intended to be world-readable
+
 }
 
 // readPrivateKey parses a PKCS#8 PEM file and returns the Ed25519 private key.

--- a/internal/keymanager/keymanager_test.go
+++ b/internal/keymanager/keymanager_test.go
@@ -232,7 +232,7 @@ func TestKeyID_is16HexCharacters(t *testing.T) {
 		t.Fatalf("KeyID() length = %d, want 16", len(id))
 	}
 	for _, c := range id {
-		if !('0' <= c && c <= '9' || 'a' <= c && c <= 'f') {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("KeyID() contains non-hex character %q", c)
 		}
 	}

--- a/logger.go
+++ b/logger.go
@@ -49,10 +49,10 @@ func newStdLogger(w io.Writer) *stdLogger {
 	}
 }
 
-func (l *stdLogger) Debug(msg string, args ...any) { l.debug.Output(2, fmt.Sprintf(msg, args...)) } //nolint:errcheck
-func (l *stdLogger) Info(msg string, args ...any)  { l.info.Output(2, fmt.Sprintf(msg, args...)) }  //nolint:errcheck
-func (l *stdLogger) Warn(msg string, args ...any)  { l.warn.Output(2, fmt.Sprintf(msg, args...)) }  //nolint:errcheck
-func (l *stdLogger) Error(msg string, args ...any) { l.err.Output(2, fmt.Sprintf(msg, args...)) }   //nolint:errcheck
+func (l *stdLogger) Debug(msg string, args ...any) { l.debug.Output(2, fmt.Sprintf(msg, args...)) } //nolint:errcheck,gosec
+func (l *stdLogger) Info(msg string, args ...any)  { l.info.Output(2, fmt.Sprintf(msg, args...)) }  //nolint:errcheck,gosec
+func (l *stdLogger) Warn(msg string, args ...any)  { l.warn.Output(2, fmt.Sprintf(msg, args...)) }  //nolint:errcheck,gosec
+func (l *stdLogger) Error(msg string, args ...any) { l.err.Output(2, fmt.Sprintf(msg, args...)) }   //nolint:errcheck,gosec
 
 // newLogger selects the right Logger implementation based on the config.
 // If cfg.Logger is set, it is used as-is (bring-your-own-logger).

--- a/module.go
+++ b/module.go
@@ -40,7 +40,7 @@ type Keys interface {
 //  2. Stability — if AuthCore gains new methods in a future release, existing
 //     module code is unaffected because it only depends on the methods below.
 //
-// Guaranteed implementation: *AuthCore
+// Guaranteed implementation: *AuthCore.
 type Provider interface {
 	// Config returns a copy of the active library configuration.
 	Config() Config


### PR DESCRIPTION
## Summary

First develop → main sync. Brings main up to the current develop state so the public-facing branch reflects the latest stable code and workflows.

## What changes

- **CI/security**: govulncheck, codeql, gosec, scorecard, release, stale, pr-title workflows added; CI matrix expanded; codecov-action upgraded to v5; all third-party actions pinned to commit SHA
- **Quality**: golangci-lint config migrated to v2 and 31 findings resolved
- **Tests**: fuzz tests + benchmarks + godoc Examples for every public module
- **Docs**: README badges, API stability section, SECURITY.md scope updated, CONTRIBUTING describes the develop → main workflow
- **Repo**: CODEOWNERS for security-sensitive paths
- **Branch model**: develop is now the working branch, main only ever holds released code

## Test plan

- [x] develop CI green (build, test race, lint, govulncheck, gosec, codeql)
- [x] golangci-lint v2 passes locally with zero findings
- [x] All Example tests verified