### PR TITLE
chore(codecov): add coverage config and ignore example paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+# Codecov configuration for authcore.
+# See https://docs.codecov.com/docs/codecov-yaml for the full schema.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto        # never regress overall coverage
+        threshold: 1%       # tolerate small fluctuations
+    patch:
+      default:
+        target: 80%         # PRs must keep new code at 80%+ coverage
+        threshold: 5%       # allow small dips under target
+        only_pulls: true
+
+# Files and paths excluded from coverage analysis.
+# Documentation and example programs are not test targets.
+ignore:
+  - "examples/**"
+  - "**/example_test.go"
+  - "**/*_bench_test.go"
+  - "**/*_fuzz_test.go"
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

Add codecov.yml with sensible defaults: 80% patch target (5% threshold), auto project tracking (1% tolerance), and ignores for examples, godoc Example tests, fuzz tests, and benchmarks.

## Why

PR #11 hit 22% patch coverage because Codecov counts examples and one-line cleanup paths as missing. Those files are documentation and unreachable error paths, not unit-test targets. This config aligns Codecov reporting with what we actually intend to test.

## Test plan

- [x] YAML schema validates
- [x] Reduces false positives without hiding real coverage drops