### PR TITLE
docs(readme): add codecov sunburst coverage graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,14 @@ pwd, _ := password.New(auth, password.Config{
 
 ---
 
+## Coverage
+
+[![Sunburst](https://codecov.io/github/Jaro-c/AuthCore/graphs/sunburst.svg?token=YXE6LDJFCQ)](https://app.codecov.io/gh/Jaro-c/AuthCore)
+
+Each ring is a directory; each slice is a file. Greener wedges are better covered. Click through for the full per-line report on Codecov.
+
+---
+
 ## Roadmap
 
 - [x] Core library — key management, logger, clock, Provider interface


### PR DESCRIPTION
## Summary

Embed the Codecov sunburst graph in the README under a new Coverage section. Visual map of test coverage by package and file — complements the existing badge.

## Test plan

- [x] Markdown only — no code changes