### PR TITLE
chore(release): sync develop content into main

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: Jaro-c
+github: Jaro-c  # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 # patreon: # Replace with a single Patreon username
 # open_collective: # Replace with a single Open Collective username
 # ko_fi: # Replace with a single Ko-fi username
@@ -8,5 +8,6 @@ github: Jaro-c
 # community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 # liberapay: # Replace with a single Liberapay username
 # issuehunt: # Replace with a single IssueHunt username
-# ocrp: # Replace with a single OCRP username
-# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['https://www.paypal.me/jaro']
+# otechie: # Replace with a single Otechie username
+# lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -1,55 +1,123 @@
-# authcore
+<h1 align="center">🛡️ authcore</h1>
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/Jaro-c/authcore.svg)](https://pkg.go.dev/github.com/Jaro-c/authcore)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Jaro-c/authcore)](https://goreportcard.com/report/github.com/Jaro-c/authcore)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![CI](https://github.com/Jaro-c/authcore/actions/workflows/ci.yml/badge.svg)](https://github.com/Jaro-c/authcore/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Jaro-c/authcore/branch/main/graph/badge.svg)](https://codecov.io/gh/Jaro-c/authcore)
-[![CodeQL](https://github.com/Jaro-c/authcore/actions/workflows/codeql.yml/badge.svg)](https://github.com/Jaro-c/authcore/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Jaro-c/authcore/badge)](https://scorecard.dev/viewer/?uri=github.com/Jaro-c/authcore)
+<p align="center">
+  <b>Drop-in authentication for Go. Password hashing, JWT sessions, email + username validation — secure defaults, zero boilerplate.</b>
+</p>
 
-**A modular, production-ready authentication library for Go 1.26+.**
+<p align="center">
+  <a href="https://pkg.go.dev/github.com/Jaro-c/authcore"><img src="https://pkg.go.dev/badge/github.com/Jaro-c/authcore.svg" alt="Go Reference"></a>
+  <a href="https://goreportcard.com/report/github.com/Jaro-c/authcore"><img src="https://goreportcard.com/badge/github.com/Jaro-c/authcore" alt="Go Report Card"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-brightgreen.svg" alt="License: MIT"></a>
+  <a href="https://github.com/Jaro-c/authcore/actions/workflows/ci.yml"><img src="https://github.com/Jaro-c/authcore/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/Jaro-c/authcore"><img src="https://codecov.io/gh/Jaro-c/authcore/branch/main/graph/badge.svg" alt="codecov"></a>
+  <a href="https://github.com/Jaro-c/authcore/actions/workflows/codeql.yml"><img src="https://github.com/Jaro-c/authcore/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/Jaro-c/authcore"><img src="https://api.scorecard.dev/projects/github.com/Jaro-c/authcore/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://github.com/sponsors/Jaro-c"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors" alt="Sponsor"></a>
+</p>
 
-authcore gives you secure token issuance, automatic key management, and a clean plugin architecture — so you can focus on your application instead of cryptographic plumbing.
+<p align="center">
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#why-authcore">Why AuthCore?</a> ·
+  <a href="#modules-at-a-glance">Modules</a> ·
+  <a href="examples/">Examples</a> ·
+  <a href="https://pkg.go.dev/github.com/Jaro-c/authcore">API Docs</a>
+</p>
 
-```
+---
+
+## What is AuthCore?
+
+AuthCore is a Go library that handles the authentication plumbing most apps need — **password hashing, login tokens, refresh/rotation, email + username validation** — without forcing you to become a crypto expert. Import it, call three functions, and you have login that a security auditor would accept.
+
+Written for **Go 1.26+**. No database. No HTTP framework. You plug those in.
+
+```bash
 go get github.com/Jaro-c/authcore
 ```
+
+## How it fits together
+
+```mermaid
+flowchart LR
+    App["Your App"] -->|init once| Core["authcore.AuthCore"]
+    Core -->|manages| Keys[("🔑 Ed25519 keys<br/>HMAC secret<br/>(auto-generated, on disk)")]
+    Core -->|Provider| Mods
+    subgraph Mods["Plug-in modules"]
+        direction TB
+        JWT["auth/jwt<br/>access + refresh tokens"]
+        Pwd["auth/password<br/>Argon2id hashing"]
+        Email["auth/email<br/>validate + DNS MX"]
+        User["auth/username<br/>validate + reserved"]
+    end
+    JWT -->|sign / verify| Client["HTTP client"]
+    Pwd -->|hash / verify| DB[("Your database")]
+    Email -->|normalize| DB
+    User -->|normalize| DB
+```
+
+Pick only the modules you need. Each one is independent, testable, and safe by default.
 
 ---
 
 ## Table of Contents
 
+- [Why AuthCore?](#why-authcore)
+- [Modules at a Glance](#modules-at-a-glance)
 - [Features](#features)
 - [Quick Start](#quick-start)
 - [JWT Authentication](#jwt-authentication)
-  - [Setup](#setup)
-  - [Login — creating a token pair](#login--creating-a-token-pair)
-  - [Authenticating requests](#authenticating-requests)
-  - [Rotating tokens](#rotating-tokens)
-  - [Clock skew tolerance](#clock-skew-tolerance)
 - [Password Hashing](#password-hashing)
-  - [Setup](#setup-1)
-  - [Hashing a password](#hashing-a-password)
-  - [Verifying a password](#verifying-a-password)
-  - [Tuning work parameters](#tuning-work-parameters)
 - [Email Validation](#email-validation)
-  - [Setup](#setup-2)
-  - [Validating and normalizing](#validating-and-normalizing)
-  - [Verifying a domain can receive email](#verifying-a-domain-can-receive-email)
 - [Username Validation](#username-validation)
-  - [Setup](#setup-3)
-  - [Validating and normalizing](#validating-and-normalizing-1)
 - [Key Management](#key-management)
 - [Configuration](#configuration)
 - [Custom Logger](#custom-logger)
+- [Testing Your Auth Layer](#testing-your-auth-layer)
+- [Migrating from bcrypt / other libraries](#migrating-from-bcrypt--other-libraries)
 - [Project Layout](#project-layout)
 - [Writing a Module](#writing-a-module)
 - [Error Handling](#error-handling)
+- [FAQ](#faq)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [Security](#security)
 - [License](#license)
+
+---
+
+## Why AuthCore?
+
+You could roll your own — but password storage, token signing, and timing-safe comparison are the kind of things you only get wrong once. You could also pull in a full identity platform — but that's a lot of surface area for a login form.
+
+AuthCore sits in the middle: **a small, opinionated library that does the dangerous parts for you** and leaves the rest to your app.
+
+| | Roll your own | Full IdP (Ory, Keycloak) | **AuthCore** |
+|---|:---:|:---:|:---:|
+| Time to first login | Hours – days | Hours (with ops) | **5 minutes** |
+| Database included | ❌ (you build it) | ✅ (theirs) | ❌ (**bring your own — any DB works**) |
+| HTTP server included | ❌ | ✅ (theirs) | ❌ (**plug into any router**) |
+| Argon2id password hashing | Manual | ✅ | ✅ |
+| EdDSA access + refresh tokens | Manual | ✅ | ✅ |
+| Timing-safe comparisons | Easy to forget | ✅ | ✅ |
+| Automatic key management | Manual | ✅ | ✅ |
+| OAuth / OIDC provider | ❌ | ✅ | Planned |
+| You own the data model | ✅ | ❌ | ✅ |
+| Runs in-process, no extra service | ✅ | ❌ | ✅ |
+
+Use AuthCore when you want **security defaults without the infrastructure cost** of a dedicated identity platform.
+
+---
+
+## Modules at a Glance
+
+| Module | Does | Import |
+|---|---|---|
+| 🔐 **`auth/jwt`** | Sign + verify access/refresh tokens. EdDSA / Ed25519. Generic custom claims. Rotation. | `github.com/Jaro-c/authcore/auth/jwt` |
+| 🔑 **`auth/password`** | Hash + verify passwords. Argon2id. Policy enforced. PHC format (self-describing). | `github.com/Jaro-c/authcore/auth/password` |
+| 📧 **`auth/email`** | Validate + normalize addresses. RFC 5321/5322. Optional DNS MX check (cached). | `github.com/Jaro-c/authcore/auth/email` |
+| 👤 **`auth/username`** | Validate + normalize usernames. Reserved-name blocklist. Character rules. | `github.com/Jaro-c/authcore/auth/username` |
+
+Each module works on its own — mix and match.
 
 ---
 
@@ -90,44 +158,61 @@ type UserClaims struct {
 
 func main() {
     // 1. One-time setup at startup.
+    //    On first run, Ed25519 keys + HMAC secret are generated in ./.authcore/.
     auth, err := authcore.New(authcore.DefaultConfig())
     if err != nil {
         log.Fatal(err)
     }
 
-    // 2. Password hashing — zero config, secure defaults.
+    // 2. Password hashing — zero config, OWASP-recommended Argon2id defaults.
     pwdMod, err := password.New(auth)
     if err != nil {
         log.Fatal(err)
     }
 
-    // 3. JWT tokens — configure issuer/audience for your service.
+    // 3. JWT tokens — set issuer + audience to your service URL in production.
     jwtMod, err := jwt.New[UserClaims](auth, jwt.DefaultConfig())
     if err != nil {
         log.Fatal(err)
     }
 
-    // Registration: hash and store — never store the plaintext.
-    hash, _ := pwdMod.Hash("user-chosen-password")
-    _ = hash // → db.StorePasswordHash(userID, hash)
+    // Registration: hash the plaintext, store only the hash.
+    hash, err := pwdMod.Hash("Str0ng-P@ssword!")
+    if err != nil {
+        log.Fatal(err) // e.g. password.ErrWeakPassword — surface the reason to the user
+    }
+    // → db.StorePasswordHash(userID, hash)
 
-    // Login: verify password, then issue a token pair.
-    ok, _ := pwdMod.Verify("user-submitted-password", hash)
-    if !ok {
+    // Login: verify the submitted password, then issue a token pair.
+    ok, err := pwdMod.Verify("Str0ng-P@ssword!", hash)
+    if err != nil || !ok {
         log.Fatal("wrong password")
     }
 
-    pair, _ := jwtMod.CreateTokens(userID, UserClaims{Name: "Ana", Role: "admin"})
-    // pair.AccessToken      → Authorization: Bearer header
-    // pair.RefreshToken     → secure httpOnly cookie
-    // pair.RefreshTokenHash → store in your database (never the raw token)
+    // userID must be a UUID v7 — the rest of your app can generate this.
+    userID := "019600ab-1234-7000-8000-000000000001"
+    pair, err := jwtMod.CreateTokens(userID, UserClaims{Name: "Ana", Role: "admin"})
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // pair.AccessToken      → send as `Authorization: Bearer <token>`
+    // pair.RefreshToken     → store client-side in a secure, httpOnly cookie
+    // pair.RefreshTokenHash → store server-side (never the raw refresh token)
+    // pair.SessionID        → UUID v7 shared by both tokens — use as your session row PK
     _ = pair
 }
 ```
 
+> [!TIP]
+> **Want a runnable version?** Every module has a full example under [`examples/`](examples/) — just `go run ./examples/jwt/` to see it work end-to-end.
+
 ---
 
 ## JWT Authentication
+
+<details>
+<summary><b>🔐 Full reference</b> — setup, login, auth, rotation, clock skew · <i>click to expand</i></summary>
 
 ### Setup
 
@@ -245,9 +330,14 @@ cfg.ClockSkewLeeway = 30 * time.Second
 The leeway applies to both access and refresh token verification.
 Keep it small — large values reduce the security margin of short-lived tokens.
 
+</details>
+
 ---
 
 ## Password Hashing
+
+<details>
+<summary><b>🔑 Full reference</b> — hashing, verifying, policy, tuning · <i>click to expand</i></summary>
 
 No boilerplate. No algorithm choices. Just secure password hashing that works.
 
@@ -343,9 +433,14 @@ pwdMod, err := password.New(auth, password.Config{
 > **Old hashes stay valid.** All parameters live inside the hash string itself.
 > Changing the config only affects *new* hashes — existing users keep working.
 
+</details>
+
 ---
 
 ## Email Validation
+
+<details>
+<summary><b>📧 Full reference</b> — validate, normalize, DNS MX · <i>click to expand</i></summary>
 
 ### Setup
 
@@ -423,9 +518,14 @@ case errors.Is(err, email.ErrDomainUnresolvable):
 > unavailable due to network issues unrelated to the user's input. Never
 > block a registration on this error — log it and proceed.
 
+</details>
+
 ---
 
 ## Username Validation
+
+<details>
+<summary><b>👤 Full reference</b> — validate, normalize, reserved names · <i>click to expand</i></summary>
 
 ### Setup
 
@@ -467,9 +567,14 @@ Validation rules:
 > **Always normalize before storing and before querying.** `Alice123` and `alice123`
 > are the same username — store only the canonical (normalized) form.
 
+</details>
+
 ---
 
 ## Key Management
+
+<details>
+<summary><b>🗝️ Full reference</b> — files, persistence, kid header, containers · <i>click to expand</i></summary>
 
 On first run authcore creates `KeysDir` (default `.authcore`) and generates:
 
@@ -494,9 +599,14 @@ auth, err := authcore.New(cfg)
 The `KeyID()` accessor returns a 16-character hex digest derived from the public key.
 It is embedded in every token's `kid` JOSE header, enabling zero-downtime key rotation.
 
+</details>
+
 ---
 
 ## Configuration
+
+<details>
+<summary><b>⚙️ Full reference</b> — EnableLogs, Timezone, Logger, KeysDir · <i>click to expand</i></summary>
 
 ```go
 type Config struct {
@@ -520,9 +630,14 @@ cfg.KeysDir    = "/run/secrets/authcore"  // absolute path in containers
 > `Config{}`. Start from `DefaultConfig()` to get `EnableLogs = true`, then set it to
 > `false` to explicitly opt out.
 
+</details>
+
 ---
 
 ## Custom Logger
+
+<details>
+<summary><b>📝 Full reference</b> — Logger interface, slog / zap / zerolog adapters · <i>click to expand</i></summary>
 
 Implement the `Logger` interface to route authcore output through your existing log pipeline:
 
@@ -544,9 +659,119 @@ cfg.Logger = slog.Default() // or slog.New(yourHandler)
 
 When `Config.Logger` is non-nil it takes precedence over `EnableLogs`.
 
+</details>
+
+---
+
+## Testing Your Auth Layer
+
+<details>
+<summary><b>🧪 Full reference</b> — Provider stub recipe, deterministic time · <i>click to expand</i></summary>
+
+Every AuthCore module accepts a `Provider` interface — not a concrete `*AuthCore` — which means **you never need to generate real keys or touch the disk in tests**. Pass in a stub.
+
+```go
+package mypkg_test
+
+import (
+    "crypto/ed25519"
+    "testing"
+
+    "github.com/Jaro-c/authcore"
+    "github.com/Jaro-c/authcore/auth/jwt"
+)
+
+// stubProvider implements authcore.Provider with fixed, in-memory dependencies.
+type stubProvider struct {
+    cfg    authcore.Config
+    logger authcore.Logger
+    keys   authcore.Keys
+}
+
+func (s *stubProvider) Config() authcore.Config { return s.cfg }
+func (s *stubProvider) Logger() authcore.Logger { return s.logger }
+func (s *stubProvider) Keys() authcore.Keys     { return s.keys }
+
+// stubKeys satisfies authcore.Keys with values you control in the test.
+type stubKeys struct {
+    priv   ed25519.PrivateKey
+    pub    ed25519.PublicKey
+    secret []byte
+    kid    string
+}
+
+func (k *stubKeys) PrivateKey() ed25519.PrivateKey { return k.priv }
+func (k *stubKeys) PublicKey() ed25519.PublicKey   { return k.pub }
+func (k *stubKeys) RefreshSecret() []byte          { return k.secret }
+func (k *stubKeys) KeyID() string                  { return k.kid }
+
+func TestMyHandler(t *testing.T) {
+    pub, priv, _ := ed25519.GenerateKey(nil)
+    p := &stubProvider{
+        cfg:    authcore.DefaultConfig(),
+        logger: &noopLogger{},
+        keys:   &stubKeys{priv: priv, pub: pub, secret: []byte("test-secret-32-bytes-long-xxxxxx"), kid: "test"},
+    }
+
+    jwtMod, err := jwt.New[struct{}](p, jwt.DefaultConfig())
+    if err != nil {
+        t.Fatal(err)
+    }
+    // ... exercise your handler against jwtMod, with no file I/O.
+}
+```
+
+> [!TIP]
+> For deterministic time in tests (e.g. to assert `ExpiresAt`), override `Config.Timezone` and use `time.Now()` equivalents through the same clock your production code reads from.
+
+</details>
+
+---
+
+## Migrating from bcrypt / other libraries
+
+<details>
+<summary><b>🔄 Full reference</b> — re-hash on next login pattern · <i>click to expand</i></summary>
+
+AuthCore can take over password verification from another library **without forcing every user to reset their password**. Use the "re-hash on next login" pattern:
+
+```go
+func Login(email, submitted string) error {
+    user := db.FindUser(email)
+
+    // 1. Try authcore first. New users and already-migrated users land here.
+    if ok, _ := pwdMod.Verify(submitted, user.PasswordHash); ok {
+        return issueSession(user)
+    }
+
+    // 2. Fall back to the legacy hasher (e.g. bcrypt).
+    if !legacyBcrypt.Compare(submitted, user.PasswordHash) {
+        return ErrWrongPassword
+    }
+
+    // 3. Password is correct — upgrade the hash transparently.
+    newHash, err := pwdMod.Hash(submitted)
+    if err != nil {
+        return err
+    }
+    db.UpdatePasswordHash(user.ID, newHash)
+    return issueSession(user)
+}
+```
+
+After a few weeks, most active users are migrated and you can delete the legacy path. Dormant accounts can be forced into password reset the next time they log in.
+
+> [!NOTE]
+> If your existing hashes are already in **PHC Argon2id format** (`$argon2id$v=19$…`), no migration is needed — `pwdMod.Verify` reads all parameters from the stored hash, regardless of which library produced it.
+
+</details>
+
 ---
 
 ## Project Layout
+
+<details>
+<summary><b>📁 Full tree</b> — module organisation + import paths · <i>click to expand</i></summary>
 
 ```
 authcore/
@@ -578,8 +803,6 @@ authcore/
 
 | Import path | Visibility | Purpose |
 |---|---|---|
-| Import path | Visibility | Purpose |
-|---|---|---|
 | `github.com/Jaro-c/authcore` | public | Core types and entry point |
 | `…/auth/jwt` | public | JWT module |
 | `…/auth/password` | public | Argon2id password hashing module |
@@ -588,9 +811,14 @@ authcore/
 | `…/internal/clock` | internal | Shared time abstraction |
 | `…/internal/keymanager` | internal | Key generation and persistence |
 
+</details>
+
 ---
 
 ## Writing a Module
+
+<details>
+<summary><b>🧩 Full guide</b> — Provider contract + minimal module skeleton · <i>click to expand</i></summary>
 
 Modules depend on `authcore.Provider` — not the concrete `*AuthCore` — so they remain
 independently testable without touching the filesystem or generating real keys.
@@ -630,9 +858,14 @@ func (m *MyModule) Name() string { return "mypkg" }
 
 In tests, inject a stub `Provider` that returns fixed keys — no disk I/O required.
 
+</details>
+
 ---
 
 ## Error Handling
+
+<details>
+<summary><b>🚨 Full reference</b> — every sentinel error, per package · <i>click to expand</i></summary>
 
 ### authcore package
 
@@ -685,53 +918,92 @@ if errors.Is(err, jwt.ErrTokenExpired) {
 }
 ```
 
+</details>
+
 ---
 
 ## FAQ
 
-**My access token fails verification in a distributed system — is clock skew the issue?**
+<details>
+<summary><b>Do I need a database to use AuthCore?</b></summary>
 
-Yes. Different servers may have clocks that drift a few seconds apart, causing
-`ErrTokenExpired` on a brand-new token. Set `ClockSkewLeeway` in your JWT config:
+No — AuthCore never touches your database. It hashes passwords, signs tokens, and validates input. *You* store hashes, usernames, and refresh-token hashes wherever your app already keeps data (Postgres, Redis, SQLite, even an in-memory `map` for a toy project).
+
+</details>
+
+<details>
+<summary><b>What is a UUID v7 and why does `CreateTokens` require one?</b></summary>
+
+UUID v7 is a 128-bit identifier whose first 48 bits are a millisecond Unix timestamp (RFC 9562 §5.7). That means UUID v7 values **sort naturally by creation time** — ideal as a database primary key and as a stable session identifier. AuthCore requires v7 for the `sub` claim so your sessions always sort chronologically.
+
+Libraries that generate UUID v7 in Go: `github.com/google/uuid` (≥ v1.6), `github.com/gofrs/uuid`.
+
+</details>
+
+<details>
+<summary><b>Do I really need refresh token rotation?</b></summary>
+
+Short answer: yes, if your refresh token lives longer than a few minutes. Rotation limits the blast radius of a stolen refresh token — once the legitimate client rotates, the stolen copy is rejected. Combined with storing only the **hash** of refresh tokens on the server, an attacker who dumps your database still cannot forge new sessions.
+
+</details>
+
+<details>
+<summary><b>My access token fails verification in a distributed system — is clock skew the issue?</b></summary>
+
+Yes. Different servers may have clocks that drift a few seconds apart, causing `ErrTokenExpired` on a brand-new token. Set `ClockSkewLeeway` in your JWT config:
 
 ```go
 cfg := jwt.DefaultConfig()
 cfg.ClockSkewLeeway = 5 * time.Second
 ```
 
----
+Keep it small (5–30 s). Larger values erode the security margin of short-lived tokens.
 
-**I'm getting `ErrKeyManager` on startup. What went wrong?**
+</details>
 
-authcore could not read or create its key files. Check that:
+<details>
+<summary><b>I'm getting `ErrKeyManager` on startup. What went wrong?</b></summary>
+
+AuthCore could not read or create its key files. Check that:
+
 1. `KeysDir` (default `.authcore`) is writable by the process.
 2. The directory is not a read-only filesystem (common in some container setups).
-3. Existing key files are not corrupted — delete `.authcore` and let authcore regenerate them.
+3. Existing key files are not corrupted — delete `.authcore` and let AuthCore regenerate them. **Warning:** regenerating keys invalidates every token currently in circulation.
 
----
+</details>
 
-**Can I verify tokens issued before I rotated my signing key?**
+<details>
+<summary><b>Can I verify tokens issued before I rotated my signing key?</b></summary>
 
-Yes. authcore embeds the `kid` (key ID) in every token header. When you add a new
-key pair, keep the old public key in the key store under its original `kid`. The
-verifier will select the right key automatically. See the
-[Key Management](#key-management) section for the rotation workflow.
+Yes. AuthCore embeds the `kid` (key ID) in every token header. When you add a new key pair, keep the old public key in the key store under its original `kid`. The verifier will select the right key automatically. See the [Key Management](#key-management) section for the rotation workflow.
 
----
+</details>
 
-**My existing password hashes were created with a different library. Can I migrate?**
+<details>
+<summary><b>My existing password hashes were created with a different library. Can I migrate?</b></summary>
 
-Yes, as long as the hashes are in PHC string format (`$argon2id$v=19$...`).
-`Verify` reads all parameters from the stored hash, so it works regardless of which
-library produced it. For hashes in a legacy format, validate the password at your
-application layer before calling `Hash`, then re-hash on the user's next successful login.
+Yes. See [Migrating from bcrypt / other libraries](#migrating-from-bcrypt--other-libraries) for the re-hash-on-next-login pattern. If your hashes are already in PHC Argon2id format (`$argon2id$v=19$…`), no migration is needed at all — `pwdMod.Verify` reads parameters from the stored hash.
 
----
+</details>
 
-**The `Hash` call is slower than expected in tests. Is that normal?**
+<details>
+<summary><b>Can I run AuthCore in Docker / Kubernetes?</b></summary>
 
-Yes — Argon2id deliberately takes ~100–300 ms and allocates 64 MiB of RAM per call.
-In tests, use a low-cost config to avoid slow suites:
+Yes. Point `KeysDir` at a mounted secrets volume so keys survive container restarts and are shared across replicas:
+
+```go
+cfg := authcore.DefaultConfig()
+cfg.KeysDir = os.Getenv("AUTHCORE_KEYS_DIR") // e.g. /run/secrets/authcore
+```
+
+Pre-generate the key files once (a one-shot job that runs AuthCore against the volume), then mount them read-only into your app.
+
+</details>
+
+<details>
+<summary><b>The `Hash` call is slower than expected in tests. Is that normal?</b></summary>
+
+Yes — Argon2id deliberately takes ~100–300 ms and allocates 64 MiB of RAM per call. In tests, use a low-cost config to avoid slow suites:
 
 ```go
 pwd, _ := password.New(auth, password.Config{
@@ -741,30 +1013,54 @@ pwd, _ := password.New(auth, password.Config{
 })
 ```
 
+</details>
+
+<details>
+<summary><b>Does AuthCore ship an HTTP server, middleware, or CSRF protection?</b></summary>
+
+No — AuthCore gives you the primitives (hash, sign, verify, rotate) and stays framework-agnostic. See [`examples/fiber`](examples/fiber/) and [`examples/gin`](examples/gin/) for wiring into a real HTTP stack, including protected-route middleware.
+
+</details>
+
 ---
 
 ## Coverage
+
+<details>
+<summary><b>📊 Sunburst coverage graph</b> · <i>click to expand</i></summary>
 
 [![Sunburst](https://codecov.io/github/Jaro-c/AuthCore/graphs/sunburst.svg?token=YXE6LDJFCQ)](https://app.codecov.io/gh/Jaro-c/AuthCore)
 
 Each ring is a directory; each slice is a file. Greener wedges are better covered. Click through for the full per-line report on Codecov.
 
+</details>
+
 ---
 
 ## Roadmap
 
-- [x] Core library — key management, logger, clock, Provider interface
-- [x] `auth/jwt` — EdDSA token issuance, verification, rotation, timing-safe hash
-- [x] `auth/password` — Argon2id password hashing with PHC format
-- [x] `auth/email` — RFC 5321/5322 validation, normalization, DNS MX verification with cache
-- [x] `auth/username` — validation, normalization, reserved name blocklist, configurable length limits
-- [ ] `auth/apikey` — opaque key generation with pluggable store interface *(future)*
-- [ ] `auth/oauth` — OAuth 2.0 / OIDC provider integration *(future)*
-- [ ] Key rotation helpers — zero-downtime rotation via `kid` header *(future)*
+Shipped:
+
+- ✅ **Core library** — key management, logger, clock, Provider interface
+- ✅ **`auth/jwt`** — EdDSA token issuance, verification, rotation, timing-safe hash
+- ✅ **`auth/password`** — Argon2id password hashing with PHC format
+- ✅ **`auth/email`** — RFC 5321/5322 validation, normalization, DNS MX verification with cache
+- ✅ **`auth/username`** — validation, normalization, reserved name blocklist
+
+Planned (no hard ETA — subject to community input):
+
+- 🚧 **`auth/apikey`** — opaque key generation with a pluggable store interface
+- 🚧 **Key rotation helpers** — zero-downtime rotation via the `kid` header
+- 🕐 **`auth/oauth`** — OAuth 2.0 / OIDC provider integration *(larger scope, later)*
+
+Have an opinion on priority, or a use case we haven't thought about? Open a [discussion](https://github.com/Jaro-c/authcore/discussions) — the roadmap bends toward real user needs.
 
 ---
 
 ## API Stability
+
+<details>
+<summary><b>ℹ️ Versioning policy</b> — v0.x breaking allowed, v1.0 locked · <i>click to expand</i></summary>
 
 authcore follows [Semantic Versioning](https://semver.org).
 
@@ -773,16 +1069,33 @@ authcore follows [Semantic Versioning](https://semver.org).
 
 Internal packages (`internal/…`) carry no compatibility guarantees at any version and must not be imported from outside the module.
 
+</details>
+
+---
+
+## Get Started Now
+
+Ready to add secure auth to your Go app? Here's the 2-minute path:
+
+1. 📦 **Install** — `go get github.com/Jaro-c/authcore`
+2. ⚡ **Copy** the [Quick Start](#quick-start) above into your `main.go`
+3. 🧪 **Run** a module example end-to-end — [`examples/jwt`](examples/jwt/), [`examples/password`](examples/password/), [`examples/fiber`](examples/fiber/), [`examples/gin`](examples/gin/)
+4. 📖 **Reference** the [full API on pkg.go.dev](https://pkg.go.dev/github.com/Jaro-c/authcore)
+
+⭐ **If AuthCore saved you from writing your own password hasher, please star the repo** — it helps others find it.
+
+❤️ **Keeping it free and maintained takes time.** If you or your company depend on AuthCore, consider [sponsoring on GitHub](https://github.com/sponsors/Jaro-c) — any amount funds continued security audits and new modules.
+
 ---
 
 ## Contributing
 
-Contributions are welcome! Please read the [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) before opening a pull request.
+Contributions are welcome! Please read the [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) before opening a pull request. Bug reports, feature ideas, and docs improvements are all valuable — open an [issue](https://github.com/Jaro-c/authcore/issues) or [discussion](https://github.com/Jaro-c/authcore/discussions) any time.
 
 ## Security
 
 To report a vulnerability, please follow the [Security Policy](SECURITY.md).
-Do not open a public issue for security bugs.
+Do not open a public issue for security bugs — coordinated disclosure keeps users safe while a fix is prepared.
 
 ## License
 

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -56,13 +56,14 @@ var _ authcore.Module = (*JWT[struct{}])(nil)
 // Construct one instance at application startup using New and share it
 // across all goroutines. JWT is safe for concurrent use after construction.
 type JWT[T any] struct {
-	cfg    Config
-	log    authcore.Logger
-	priv   ed25519.PrivateKey
-	pub    ed25519.PublicKey
-	secret []byte      // HMAC-SHA256 key for hashing refresh tokens
-	kid    string      // JOSE "kid" header value, derived from the public key
-	clock  clock.Clock // injected; replaced by clock.Fixed in tests
+	cfg             Config
+	log             authcore.Logger
+	priv            ed25519.PrivateKey
+	pub             ed25519.PublicKey
+	secret          []byte      // HMAC-SHA256 key for hashing refresh tokens
+	kid             string      // JOSE "kid" header value, derived from the public key
+	clock           clock.Clock // injected; replaced by clock.Fixed in tests
+	primaryAudience string      // cfg.Audience[0] snapshotted at construction; immune to post-init mutation
 }
 
 // New creates and returns a JWT module.
@@ -83,13 +84,14 @@ func New[T any](p authcore.Provider, cfg Config) (*JWT[T], error) {
 	}
 
 	j := &JWT[T]{
-		cfg:    cfg,
-		log:    p.Logger(),
-		priv:   p.Keys().PrivateKey(),
-		pub:    p.Keys().PublicKey(),
-		secret: p.Keys().RefreshSecret(),
-		kid:    p.Keys().KeyID(),
-		clock:  clock.New(p.Config().Timezone),
+		cfg:             cfg,
+		log:             p.Logger(),
+		priv:            p.Keys().PrivateKey(),
+		pub:             p.Keys().PublicKey(),
+		secret:          p.Keys().RefreshSecret(),
+		kid:             p.Keys().KeyID(),
+		clock:           clock.New(p.Config().Timezone),
+		primaryAudience: cfg.Audience[0], // validateConfig guarantees len >= 1
 	}
 
 	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s)",
@@ -184,7 +186,7 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 //	claims, err := jwtMod.VerifyAccessToken(token)
 //	if errors.Is(err, jwt.ErrTokenExpired) { ... }
 func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
-	c, err := verifyAccessToken[T](token, j.pub, j.clock.Now(), j.cfg.Audience, j.cfg.ClockSkewLeeway)
+	c, err := verifyAccessToken[T](token, j.pub, j.clock.Now(), j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +246,7 @@ func (j *JWT[T]) VerifyRefreshTokenHash(token, storedHash string) bool {
 //
 // Returns the same errors as VerifyAccessToken.
 func (j *JWT[T]) RotateTokens(refreshToken string, extra T) (*TokenPair, error) {
-	c, err := verifyRefreshToken(refreshToken, j.pub, j.clock.Now(), j.cfg.Audience, j.cfg.ClockSkewLeeway)
+	c, err := verifyRefreshToken(refreshToken, j.pub, j.clock.Now(), j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/jwt/token.go
+++ b/auth/jwt/token.go
@@ -93,9 +93,11 @@ func signToken(claims gjwt.Claims, key ed25519.PrivateKey, kid string) (string, 
 
 // verifyAccessToken validates the compact JWT string and returns the decoded access claims.
 // now is injected to allow deterministic testing via clock.Fixed.
-// audience is validated: the token must contain at least the first configured audience value.
+// audience is the expected "aud" value the token must contain; captured at
+// construction time so post-construction mutation of the config slice cannot
+// panic this path.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.Time, audience []string, leeway time.Duration) (*accessClaims[T], error) {
+func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.Time, audience string, leeway time.Duration) (*accessClaims[T], error) {
 	var c accessClaims[T]
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
@@ -103,7 +105,7 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.T
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
-		gjwt.WithAudience(audience[0]),                     // token must contain this audience value
+		gjwt.WithAudience(audience),                        // token must contain this audience value
 		gjwt.WithLeeway(leeway),                            // tolerate small clock drift between servers
 	)
 	if err != nil {
@@ -113,9 +115,11 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.T
 }
 
 // verifyRefreshToken validates the compact JWT string and returns the decoded refresh claims.
-// audience is validated: the token must contain at least the first configured audience value.
+// audience is the expected "aud" value the token must contain; captured at
+// construction time so post-construction mutation of the config slice cannot
+// panic this path.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, audience []string, leeway time.Duration) (*refreshClaims, error) {
+func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, audience string, leeway time.Duration) (*refreshClaims, error) {
 	var c refreshClaims
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
@@ -123,7 +127,7 @@ func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, a
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
-		gjwt.WithAudience(audience[0]),                     // token must contain this audience value
+		gjwt.WithAudience(audience),                        // token must contain this audience value
 		gjwt.WithLeeway(leeway),                            // tolerate small clock drift between servers
 	)
 	if err != nil {

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,35 @@
+# authcore — basic initialisation example
+
+Two ways to construct the library:
+
+1. **Zero config** — call `authcore.New(authcore.DefaultConfig())`. Keys are generated under `./.authcore/` on first run.
+2. **Custom config** — override `Timezone`, `EnableLogs`, `KeysDir`, or plug in your own `Logger`.
+
+## Run
+
+```bash
+go run ./examples/basic
+```
+
+## What it does
+
+- Constructs one `*authcore.AuthCore` with `DefaultConfig()`.
+- Constructs a second one with a custom timezone, a silent logger, and a temporary `KeysDir`.
+- Prints the resolved configuration + the first 16 hex characters of the public key fingerprint.
+
+## Expected output (abridged)
+
+```
+[WARN]  authcore/keymanager: Ed25519 key pair not found, generating new keys in /tmp/authcore-example-XXXXXXXXX
+[WARN]  authcore/keymanager: refresh secret not found, generating new secret in /tmp/authcore-example-XXXXXXXXX
+[INFO]  authcore initialised (timezone=UTC, logs=true, keys=/tmp/authcore-example-XXXXXXXXX)
+timezone      : UTC
+logs enabled  : true
+keys dir      : /tmp/authcore-example-XXXXXXXXX
+public key    : cd1fe09d32c6024e…
+
+timezone      : America/Bogota
+logs enabled  : false
+```
+
+The temporary `KeysDir` is removed at the end of each run — real apps should point it at persistent storage.

--- a/examples/email/README.md
+++ b/examples/email/README.md
@@ -1,0 +1,43 @@
+# auth/email — validation, normalization, DNS MX
+
+Validate + normalize an address in one call, optionally verify its domain can receive mail.
+
+## Run
+
+```bash
+go run ./examples/email
+```
+
+> The `VerifyDomain` step performs a real DNS lookup. It is skipped automatically if your network has no outbound DNS access.
+
+## What it shows
+
+| Step | API |
+|---|---|
+| Normalize + validate in one call — always store the canonical form | `emailMod.ValidateAndNormalize(input)` |
+| Rejection reasons — RFC 5321/5322 rules, descriptive errors | `errors.Unwrap(err).Error()` |
+| DNS MX verification — cached per domain, `singleflight`-deduplicated | `emailMod.VerifyDomain(ctx, addr)` |
+| Soft-fail handling — `ErrDomainUnresolvable` means "DNS is down", not "email is bad" | `errors.Is(err, email.ErrDomainUnresolvable)` |
+
+## Expected output (abridged)
+
+```
+=== ValidateAndNormalize ===
+accepted  "  USER@EXAMPLE.COM  " → "user@example.com"
+accepted  "user.name+tag@sub.example.co.uk" → "user.name+tag@sub.example.co.uk"
+rejected  "" → must not be empty
+rejected  "notanemail" → invalid format
+rejected  "user@localhost" → domain must contain at least one dot
+rejected  "user@example..com" → invalid format
+
+=== VerifyDomain ===
+domain OK     : user@gmail.com
+
+=== Error handling ===
+ErrInvalidEmail: email: invalid address: invalid format
+reason only   : invalid format
+```
+
+## Golden rule
+
+Always normalize **before storing** and **before querying** the database. `User@EXAMPLE.COM` and `user@example.com` are the same address — store only the canonical form.

--- a/examples/fiber/README.md
+++ b/examples/fiber/README.md
@@ -1,0 +1,55 @@
+# examples/fiber — full auth API with Fiber v3
+
+A runnable HTTP server that wires AuthCore into [Fiber v3](https://gofiber.io). Register, login, access a protected route, rotate tokens.
+
+> This example is its own Go module (separate `go.mod`) so the root library has no runtime dependency on Fiber. Run it from this directory.
+
+## Run
+
+```bash
+cd examples/fiber
+go run .
+```
+
+Server listens on `:3000`.
+
+## Routes
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `POST` | `/register` | — | Hash + store the new user's password |
+| `POST` | `/login` | — | Verify password, issue an access + refresh pair |
+| `GET` | `/me` | `Authorization: Bearer <access>` | Verify the access token, return claims |
+| `POST` | `/refresh` | refresh token in body | Rotate the pair, replace the stored hash |
+
+## Try it
+
+```bash
+# 1. Register
+curl -X POST localhost:3000/register \
+  -H 'content-type: application/json' \
+  -d '{"email":"ana@example.com","password":"Str0ng-P@ssword!"}'
+
+# 2. Login — capture the tokens
+curl -X POST localhost:3000/login \
+  -H 'content-type: application/json' \
+  -d '{"email":"ana@example.com","password":"Str0ng-P@ssword!"}'
+
+# 3. Protected route
+curl localhost:3000/me -H 'authorization: Bearer <access-token>'
+
+# 4. Rotate
+curl -X POST localhost:3000/refresh \
+  -H 'content-type: application/json' \
+  -d '{"refresh_token":"<refresh-token>"}'
+```
+
+## What it shows
+
+- `Provider` passed to multiple modules once at startup.
+- `pwdMod.Hash` / `pwdMod.Verify` for registration + login.
+- `jwtMod.CreateTokens` with typed `UserClaims`.
+- `jwtMod.VerifyAccessToken` in a Fiber middleware for `/me`.
+- `jwtMod.HashRefreshToken` → DB lookup → `jwtMod.VerifyRefreshTokenHash` → `jwtMod.RotateTokens` — the full anti-reuse rotation pattern.
+
+User storage is an in-memory `map` for brevity — swap it for your real database.

--- a/examples/gin/README.md
+++ b/examples/gin/README.md
@@ -1,0 +1,55 @@
+# examples/gin — full auth API with Gin
+
+A runnable HTTP server that wires AuthCore into [Gin](https://gin-gonic.com). Same routes as the Fiber example, different framework.
+
+> This example is its own Go module (separate `go.mod`) so the root library has no runtime dependency on Gin. Run it from this directory.
+
+## Run
+
+```bash
+cd examples/gin
+go run .
+```
+
+Server listens on `:3000`.
+
+## Routes
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `POST` | `/register` | — | Hash + store the new user's password |
+| `POST` | `/login` | — | Verify password, issue an access + refresh pair |
+| `GET` | `/me` | `Authorization: Bearer <access>` | Verify the access token, return claims |
+| `POST` | `/refresh` | refresh token in body | Rotate the pair, replace the stored hash |
+
+## Try it
+
+```bash
+# 1. Register
+curl -X POST localhost:3000/register \
+  -H 'content-type: application/json' \
+  -d '{"email":"ana@example.com","password":"Str0ng-P@ssword!"}'
+
+# 2. Login — capture the tokens
+curl -X POST localhost:3000/login \
+  -H 'content-type: application/json' \
+  -d '{"email":"ana@example.com","password":"Str0ng-P@ssword!"}'
+
+# 3. Protected route
+curl localhost:3000/me -H 'authorization: Bearer <access-token>'
+
+# 4. Rotate
+curl -X POST localhost:3000/refresh \
+  -H 'content-type: application/json' \
+  -d '{"refresh_token":"<refresh-token>"}'
+```
+
+## What it shows
+
+- `Provider` passed to multiple modules once at startup.
+- `pwdMod.Hash` / `pwdMod.Verify` for registration + login.
+- `jwtMod.CreateTokens` with typed `UserClaims`.
+- `jwtMod.VerifyAccessToken` in a Gin middleware for `/me`.
+- `jwtMod.HashRefreshToken` → DB lookup → `jwtMod.VerifyRefreshTokenHash` → `jwtMod.RotateTokens` — the full anti-reuse rotation pattern.
+
+User storage is an in-memory `map` for brevity — swap it for your real database.

--- a/examples/jwt/README.md
+++ b/examples/jwt/README.md
@@ -1,0 +1,48 @@
+# auth/jwt — access + refresh token example
+
+End-to-end JWT flow: create a pair, verify the access token, handle errors, rotate on refresh.
+
+## Run
+
+```bash
+go run ./examples/jwt
+```
+
+## What it shows
+
+| Step | API |
+|---|---|
+| Login — issue a token pair | `jwtMod.CreateTokens(subject, extra)` |
+| Authenticated request — verify the access token | `jwtMod.VerifyAccessToken(token)` |
+| Error handling — `ErrTokenExpired`, `ErrTokenMalformed`, `ErrWrongTokenType` | `errors.Is` |
+| Token rotation — exchange a refresh token for a new pair | `jwtMod.RotateTokens(refreshToken, freshClaims)` |
+
+`SessionID` (a UUID v7 `jti`) stays stable across rotations — use it as the primary key of your session row.
+
+## Expected output (abridged)
+
+```
+=== Login — CreateTokens ===
+access token  : eyJhbGciOiJFZERTQSIsImtpZCI6Ij…
+access exp    : 2026-XX-XX XX:XX:XX +0000 UTC
+refresh exp   : 2026-XX-XX XX:XX:XX +0000 UTC
+session ID    : 019da3ab-cc0b-795f-8cf3-30e87a9acbe8
+refresh hash  : dedfb1afef8ee0f7  ← store this in DB
+
+=== Authenticated request — VerifyAccessToken ===
+subject  : 019600ab-1234-7000-8000-000000000001
+name     : Ana García
+role     : admin
+token id : 019da3ab-cc0b-795f-8cf3-30e87a9acbe8
+
+=== Error handling ===
+ErrTokenMalformed caught correctly
+
+=== Token rotation — RotateTokens ===
+new access token : eyJhbGciOiJFZERTQSIsImtpZCI6Ij…
+new refresh hash : dedfb1afef8ee0f7  ← replace old hash in DB
+```
+
+## Next
+
+For a full HTTP server wiring, see [`examples/fiber`](../fiber/) or [`examples/gin`](../gin/).

--- a/examples/password/README.md
+++ b/examples/password/README.md
@@ -1,0 +1,46 @@
+# auth/password — Argon2id hashing example
+
+Policy check → hash → verify → error handling → custom work parameters.
+
+## Run
+
+```bash
+go run ./examples/password
+```
+
+## What it shows
+
+| Step | API |
+|---|---|
+| Policy validation — weak passwords are rejected *before* any CPU is spent | `pwdMod.Hash(weak)` → `ErrWeakPassword` |
+| Hashing — 64 MiB Argon2id, PHC-encoded output | `pwdMod.Hash(strong)` |
+| Verification — constant-time comparison, parameters read from the stored hash | `pwdMod.Verify(plain, hash)` |
+| Error handling — malformed hashes return `ErrInvalidHash` | `errors.Is(err, password.ErrInvalidHash)` |
+| Tuning — scale `Memory`, `Iterations`, `Parallelism` for your hardware | `password.New(auth, password.Config{…})` |
+
+## Expected output (abridged)
+
+```
+=== Policy validation ===
+rejected  : password: does not meet policy requirements: must be at least 12 characters
+accepted  : Str0ng-P@ssword!
+
+=== Hashing ===
+stored hash: $argon2id$v=19$m=65536,t=3,p=2$OUz5NhK5p0CQauGq2cB0eA$A8OffcIAr5jSM/qWrp0/sYS8t62kGT/BaXNF8kV1oYs
+
+=== Verification ===
+correct password : true
+wrong password   : false
+
+=== Error handling ===
+ErrInvalidHash caught correctly
+
+=== Custom parameters ===
+128 MiB hash: $argon2id$v=19$m=131072,t=4,p=4$…
+```
+
+Each run produces a **different** hash string for the same password — every call generates a fresh random salt.
+
+## Why Argon2id?
+
+Memory-hard: an attacker must allocate ~64 MiB per attempt, which makes GPU and ASIC brute-force attacks prohibitively expensive. bcrypt does not have this property.

--- a/examples/username/README.md
+++ b/examples/username/README.md
@@ -1,0 +1,45 @@
+# auth/username — validation, normalization, reserved names
+
+Validate + normalize a handle in one call, reject reserved names like `admin`, `root`, `login`.
+
+## Run
+
+```bash
+go run ./examples/username
+```
+
+## What it shows
+
+| Step | API |
+|---|---|
+| Normalize + validate in one call | `userMod.ValidateAndNormalize(input)` |
+| Character rules (`[a-z0-9_-]`, no consecutive specials, length 3–32) | `errors.Unwrap(err).Error()` |
+| Reserved-name blocklist (built-in, fixed) | `username.ErrInvalidUsername` |
+| Idempotent normalization — `Alice_Dev99` and `alice_dev99` collapse to the same canonical form |
+
+## Expected output (abridged)
+
+```
+=== ValidateAndNormalize ===
+accepted  "  Alice_123  "      → "alice_123"
+accepted  "bob-dev"            → "bob-dev"
+accepted  "user99"             → "user99"
+rejected  "ab"                 → must be at least 3 characters
+rejected  "-alice"             → must start with a letter or digit
+rejected  "alice__bob"         → must not contain consecutive underscores or hyphens
+rejected  "alice@bob"          → may only contain letters, digits, underscores, and hyphens
+rejected  "admin"              → "admin" is a reserved name
+rejected  "root"               → "root" is a reserved name
+
+=== Registration flow ===
+raw input  : "  Alice_Dev99  "
+stored as  : "alice_dev99"
+
+=== Error handling ===
+ErrInvalidUsername: username: invalid username: "admin" is a reserved name
+reason only       : "admin" is a reserved name
+```
+
+## Golden rule
+
+Always normalize **before storing** and **before querying** — two users should never differ only in casing or whitespace.

--- a/module.go
+++ b/module.go
@@ -59,18 +59,24 @@ type Provider interface {
 // implement. It acts as a marker interface today and will grow as shared
 // lifecycle requirements (e.g. Close, HealthCheck) are identified.
 //
-// Available implementations:
+// Available implementations and their concrete constructors:
 //
 //	auth/jwt      — JSON Web Token authentication (EdDSA / Ed25519)
+//	                  jwt.New[T any](p authcore.Provider, cfg jwt.Config) (*jwt.JWT[T], error)
 //	auth/password — Argon2id password hashing
-//	auth/email    — email validation and normalization
+//	                  password.New(p authcore.Provider, cfg ...password.Config) (*password.Password, error)
+//	auth/email    — email validation, normalization, DNS MX verification
+//	                  email.New(p authcore.Provider, cfg ...email.Config) (*email.Email, error)
+//	auth/username — username validation, normalization, reserved name blocklist
+//	                  username.New(p authcore.Provider) (*username.Username, error)
 //
-// Module constructors follow the convention:
+// Conventions shared by every module:
 //
-//	func New(p authcore.Provider, cfg ...Config) (*T, error)
-//
-// where T is the concrete module type and cfg is the optional module-specific
-// configuration. Omitting cfg applies safe, production-ready defaults.
+//  1. The first argument is always an authcore.Provider (never a concrete *AuthCore).
+//  2. Omitting cfg (where variadic) or passing a zero-value Config applies safe,
+//     production-ready defaults via each module's applyDefaults helper.
+//  3. Constructors return a pointer receiver; concrete types are safe for
+//     concurrent use across goroutines after construction completes.
 type Module interface {
 	// Name returns the unique, lowercase identifier of this module.
 	// It must be stable across releases because callers may use it as a key.


### PR DESCRIPTION
## Summary

Promotes develop content to main as a single commit on top of main.

**Why not develop → main directly?** PR #17 (superseded by this one) got stuck on a GitHub-level merge conflict caused by past release PRs that squash-merged develop onto main: the two branches carry equivalent content under different commit SHAs, and git's 3-way merge flags every file that either side has touched. Squash-merging the reconcile PR #18 did not help, because squash does not record main in develop's history.

This PR sidesteps the history divergence entirely by branching **off main** and overlaying the current develop tree as one release commit. The result is a clean fast-forward on main.

## Contents

- **fix(jwt):** snapshot primary audience at construction to prevent panic on caller-side slice mutation
- **docs(module):** explicit per-module constructor signatures
- **docs(README):** hero, Mermaid diagram, comparison table, Modules at a Glance, Testing + Migration sections, FAQ grown 5 → 10, collapsibles, Sponsor badge, CTA
- **docs(examples):** README per example directory with run command + expected output
- **chore(funding):** widen platform list in `.github/FUNDING.yml`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` (all packages pass)
- [x] `gofmt -l .` clean
- [x] Tree-equal to `origin/develop` (verified via `git diff origin/develop`)

## After merge

- Close PR #17 (superseded)
- Delete `release/sync-develop-r1` branch
- `develop` and `main` will be tree-identical again