### PR TITLE
chore(release): sync develop content into main

### DIFF
--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -186,7 +186,7 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 //	claims, err := jwtMod.VerifyAccessToken(token)
 //	if errors.Is(err, jwt.ErrTokenExpired) { ... }
 func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
-	c, err := verifyAccessToken[T](token, j.pub, j.clock.Now(), j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyAccessToken[T](token, j.pub, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (j *JWT[T]) VerifyRefreshTokenHash(token, storedHash string) bool {
 //
 // Returns the same errors as VerifyAccessToken.
 func (j *JWT[T]) RotateTokens(refreshToken string, extra T) (*TokenPair, error) {
-	c, err := verifyRefreshToken(refreshToken, j.pub, j.clock.Now(), j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyRefreshToken(refreshToken, j.pub, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/jwt/jwt_test.go
+++ b/auth/jwt/jwt_test.go
@@ -364,6 +364,45 @@ func TestCreateTokens_wrongAudienceRejectsToken(t *testing.T) {
 	}
 }
 
+func TestVerifyAccessToken_wrongIssuerRejectsToken(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Issuer = "https://auth.service-a.example.com"
+	j := newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	// Another service that happens to share the signing key (e.g. accidental
+	// key reuse across microservices) must not accept a token issued by the
+	// first service. The iss claim must be checked on verification.
+	cfg2 := DefaultConfig()
+	cfg2.Issuer = "https://auth.service-b.example.com"
+	j2 := newTestJWT[struct{}](t, newFakeProvider(t), cfg2)
+	j2.priv = j.priv
+	j2.pub = j.pub
+
+	_, err := j2.VerifyAccessToken(pair.AccessToken)
+	if !errors.Is(err, ErrTokenInvalid) {
+		t.Errorf("expected ErrTokenInvalid when issuer does not match, got %v", err)
+	}
+}
+
+func TestRotateTokens_wrongIssuerRejectsRefreshToken(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Issuer = "https://auth.service-a.example.com"
+	j := newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	cfg2 := DefaultConfig()
+	cfg2.Issuer = "https://auth.service-b.example.com"
+	j2 := newTestJWT[struct{}](t, newFakeProvider(t), cfg2)
+	j2.priv = j.priv
+	j2.pub = j.pub
+
+	_, err := j2.RotateTokens(pair.RefreshToken, struct{}{})
+	if !errors.Is(err, ErrTokenInvalid) {
+		t.Errorf("expected ErrTokenInvalid when issuer does not match, got %v", err)
+	}
+}
+
 func TestRotateTokens_audienceEmbeddedInRefreshToken(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Audience = []string{"https://api.example.com"}

--- a/auth/jwt/token.go
+++ b/auth/jwt/token.go
@@ -93,11 +93,12 @@ func signToken(claims gjwt.Claims, key ed25519.PrivateKey, kid string) (string, 
 
 // verifyAccessToken validates the compact JWT string and returns the decoded access claims.
 // now is injected to allow deterministic testing via clock.Fixed.
-// audience is the expected "aud" value the token must contain; captured at
-// construction time so post-construction mutation of the config slice cannot
-// panic this path.
+// issuer and audience are the expected "iss" and "aud" values the token must
+// carry. Enforcing both defends against cross-service key reuse, where a token
+// signed by the same key but issued for a different service would otherwise be
+// accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.Time, audience string, leeway time.Duration) (*accessClaims[T], error) {
+func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
 	var c accessClaims[T]
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
@@ -105,6 +106,7 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.T
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
+		gjwt.WithIssuer(issuer),                            // token must be issued by this service
 		gjwt.WithAudience(audience),                        // token must contain this audience value
 		gjwt.WithLeeway(leeway),                            // tolerate small clock drift between servers
 	)
@@ -115,11 +117,12 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.T
 }
 
 // verifyRefreshToken validates the compact JWT string and returns the decoded refresh claims.
-// audience is the expected "aud" value the token must contain; captured at
-// construction time so post-construction mutation of the config slice cannot
-// panic this path.
+// issuer and audience are the expected "iss" and "aud" values the token must
+// carry. Enforcing both defends against cross-service key reuse, where a token
+// signed by the same key but issued for a different service would otherwise be
+// accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, audience string, leeway time.Duration) (*refreshClaims, error) {
+func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
 	var c refreshClaims
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
@@ -127,6 +130,7 @@ func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, a
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
+		gjwt.WithIssuer(issuer),                            // token must be issued by this service
 		gjwt.WithAudience(audience),                        // token must contain this audience value
 		gjwt.WithLeeway(leeway),                            // tolerate small clock drift between servers
 	)

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -283,6 +283,20 @@ func parsePHC(phcHash string) (Config, []byte, []byte, error) {
 		return Config{}, nil, nil, fmt.Errorf("parse parameters: %w", err)
 	}
 
+	// Bound the parsed parameters before handing them to argon2.IDKey. A
+	// corrupted or attacker-supplied hash with m=4_000_000_000 would otherwise
+	// cause the verifier to attempt a multi-TiB allocation and crash the
+	// process. Reuse the same ceilings validateConfig enforces at construction.
+	if cfg.Memory < minMemory || cfg.Memory > maxMemory {
+		return Config{}, nil, nil, fmt.Errorf("memory parameter out of range: got %d, want [%d, %d]", cfg.Memory, minMemory, maxMemory)
+	}
+	if cfg.Iterations < 1 || cfg.Iterations > maxIterations {
+		return Config{}, nil, nil, fmt.Errorf("iterations parameter out of range: got %d, want [1, %d]", cfg.Iterations, maxIterations)
+	}
+	if cfg.Parallelism < 1 {
+		return Config{}, nil, nil, fmt.Errorf("parallelism parameter out of range: got %d, want >= 1", cfg.Parallelism)
+	}
+
 	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
 	if err != nil {
 		return Config{}, nil, nil, fmt.Errorf("decode salt: %w", err)

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -344,6 +344,56 @@ func TestParsePHC_invalidBase64Key(t *testing.T) {
 	}
 }
 
+func TestParsePHC_memoryAboveCeilingRejected(t *testing.T) {
+	// A corrupted or attacker-supplied hash with m=4_000_000_000 would cause
+	// argon2.IDKey to attempt a multi-TiB allocation and crash the process.
+	// The parser must reject it before the key derivation runs.
+	_, _, _, err := parsePHC("$argon2id$v=19$m=4000000000,t=3,p=2$c2FsdA$a2V5")
+	if err == nil {
+		t.Error("expected error for memory above ceiling, got nil")
+	}
+}
+
+func TestParsePHC_memoryBelowFloorRejected(t *testing.T) {
+	_, _, _, err := parsePHC("$argon2id$v=19$m=1,t=3,p=2$c2FsdA$a2V5")
+	if err == nil {
+		t.Error("expected error for memory below floor, got nil")
+	}
+}
+
+func TestParsePHC_iterationsAboveCeilingRejected(t *testing.T) {
+	_, _, _, err := parsePHC("$argon2id$v=19$m=65536,t=1000,p=2$c2FsdA$a2V5")
+	if err == nil {
+		t.Error("expected error for iterations above ceiling, got nil")
+	}
+}
+
+func TestParsePHC_iterationsZeroRejected(t *testing.T) {
+	_, _, _, err := parsePHC("$argon2id$v=19$m=65536,t=0,p=2$c2FsdA$a2V5")
+	if err == nil {
+		t.Error("expected error for zero iterations, got nil")
+	}
+}
+
+func TestParsePHC_parallelismZeroRejected(t *testing.T) {
+	_, _, _, err := parsePHC("$argon2id$v=19$m=65536,t=3,p=0$c2FsdA$a2V5")
+	if err == nil {
+		t.Error("expected error for zero parallelism, got nil")
+	}
+}
+
+func TestVerify_malformedStoredHashIsRejectedBeforeKeyDerivation(t *testing.T) {
+	p := newMod(t)
+
+	// If Verify accepted this hash, argon2.IDKey would try to allocate 4 TiB.
+	// parsePHC must surface ErrInvalidHash instead.
+	malicious := "$argon2id$v=19$m=4000000000,t=3,p=2$c2FsdA$a2V5"
+	_, err := p.Verify("any-password-we-do-not-care", malicious)
+	if !errors.Is(err, ErrInvalidHash) {
+		t.Errorf("expected ErrInvalidHash for malicious stored hash, got %v", err)
+	}
+}
+
 // ---- DefaultConfig() --------------------------------------------------------
 
 func TestDefaultConfig_values(t *testing.T) {


### PR DESCRIPTION
## Summary

Promotes PR #20 from develop to main.

Single commit branched off main with the develop tree overlaid, to sidestep the history-level conflicts that past squash-merged release PRs leave between develop and main.

## Contents

- **fix(security):** issuer enforced on JWT verify + refresh rotation — defends against shared-key-across-services token confusion
- **fix(security):** argon2id PHC params bounded on Verify — prevents DoS-via-huge-memory from corrupted or malicious stored hashes

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — all packages pass, including 8 new tests
- [x] `gofmt -l .` clean
- [x] Tree-equal to `origin/develop`