### PR TITLE
docs: document v1.0.1 security hardening (jwt iss, argon2id phc bounds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [1.0.1] - 2026-04-19
+
+Security-hardening release. No public API changes; existing callers upgrade
+without modification. Two verification paths are now stricter, which can
+reject previously-accepted tokens and stored hashes that were produced under
+inconsistent configuration.
+
+### Security
+
+#### JWT module (`github.com/Jaro-c/authcore/auth/jwt`)
+- `VerifyAccessToken` and `RotateTokens` now enforce the `iss` claim against
+  `Config.Issuer`, mirroring the existing `aud` check. Previously, a token
+  signed by a trusted key was accepted regardless of which service issued it
+  — a cross-service key-reuse gap. Tokens with a mismatched issuer now return
+  `ErrTokenInvalid`.
+
+#### Password module (`github.com/Jaro-c/authcore/auth/password`)
+- `parsePHC` now bounds the `m=` (memory), `t=` (iterations), and `p=`
+  (parallelism) parameters read from the stored hash to the same ceilings
+  `validateConfig` enforces at construction time. A corrupted or attacker-
+  supplied hash of the form `$argon2id$v=19$m=4000000000,…` previously caused
+  `argon2.IDKey` to attempt a multi-TiB allocation and crash the process on
+  `Verify`; such hashes now return `ErrInvalidHash` before any key derivation.
+
+### Hardening
+
+#### JWT module
+- `verifyAccessToken` / `verifyRefreshToken` internal helpers take
+  `audience string` (previously `[]string`). The module snapshots
+  `Config.Audience[0]` into a private `primaryAudience` field at
+  construction, making the verify path immune to post-init mutation of the
+  caller's audience slice.
+
+### Fixed
+
+- `module.go` constructor convention comment now lists the actual
+  per-module signatures (`jwt.New[T]`, variadic `password.New`, variadic
+  `email.New`, `username.New(p)` only) instead of the outdated
+  one-size-fits-all form.
+
+---
+
 ## [1.0.0] - 2026-03-14
 
 First stable release. The public API is now frozen under the guarantees of

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ switch {
 case errors.Is(err, jwt.ErrTokenExpired):
     // 401 — client should refresh
 case errors.Is(err, jwt.ErrTokenInvalid):
-    // 401 — tampered or wrong key
+    // 401 — tampered, wrong key, or issuer/audience mismatch
 case errors.Is(err, jwt.ErrTokenMalformed):
     // 400 — not a JWT at all
 case err != nil:
@@ -279,6 +279,9 @@ fmt.Println(claims.Subject)    // UUID v7 user ID
 fmt.Println(claims.Extra.Role) // "admin" — your custom claims
 fmt.Println(claims.ExpiresAt)  // time.Time
 ```
+
+> [!NOTE]
+> Verification enforces both **`iss` (issuer)** and **`aud` (audience)** match the values in `jwt.Config`. A token signed by a trusted key but minted for a different service is rejected with `ErrTokenInvalid` — this is the defense against accidental key reuse across services.
 
 ---
 
@@ -407,7 +410,9 @@ case !ok:
 
 Comparison is **constant-time** (`crypto/subtle`) — timing attacks are not
 possible. Parameters are always read from the stored hash, never from the
-current module config.
+current module config, and **bounded to the same safe range** (`Memory` 8 MiB – 4 GiB,
+`Iterations` ≤ 20, `Parallelism` ≥ 1) so a corrupted or malicious stored hash
+cannot force `argon2.IDKey` into an unbounded memory allocation.
 
 ---
 
@@ -881,7 +886,7 @@ In tests, inject a stub `Provider` that returns fixed keys — no disk I/O requi
 |---|---|
 | `jwt.ErrInvalidConfig` | `jwt.Config` validation failed |
 | `jwt.ErrTokenExpired` | `exp` claim is in the past (beyond leeway) |
-| `jwt.ErrTokenInvalid` | signature invalid or unsupported algorithm |
+| `jwt.ErrTokenInvalid` | signature invalid, unsupported algorithm, or `iss` / `aud` claim does not match `Config` |
 | `jwt.ErrTokenMalformed` | not a valid three-part JWT string |
 | `jwt.ErrWrongTokenType` | access token passed where refresh expected, or vice-versa |
 | `jwt.ErrInvalidSubject` | subject passed to `CreateTokens` is not a UUID v7 |

--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -17,7 +17,11 @@ type Config struct {
 	// Defaults to 24 hours.
 	RefreshTokenTTL time.Duration
 
-	// Issuer is the value of the "iss" claim in every token.
+	// Issuer is the value of the "iss" claim in every token issued by this
+	// module, and the value VerifyAccessToken / RotateTokens require the
+	// "iss" claim to match on verification. Tokens whose iss does not equal
+	// this string are rejected with ErrTokenInvalid.
+	//
 	// Defaults to "github.com/Jaro-c/authcore".
 	// Override this with your own service URL or identifier (e.g. "https://auth.example.com").
 	Issuer string

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -177,7 +177,8 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 // On failure it returns one of the following sentinel errors:
 //
 //	jwt.ErrTokenExpired   — exp claim is in the past
-//	jwt.ErrTokenInvalid   — signature invalid or unsupported algorithm
+//	jwt.ErrTokenInvalid   — signature invalid, unsupported algorithm,
+//	                        or iss/aud claim does not match Config
 //	jwt.ErrTokenMalformed — not a valid three-part JWT string
 //	jwt.ErrWrongTokenType — token is a refresh token, not an access token
 //

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -233,12 +233,18 @@ func (p *Password) Hash(plaintext string) (string, error) {
 //
 // The Argon2id parameters (Memory, Iterations, Parallelism) are read from
 // phcHash itself, so stored hashes remain valid even if the module's Config
-// is updated after they were created.
+// is updated after they were created. The parsed parameters are bounded to
+// the same ceilings validateConfig enforces at construction, so a corrupted
+// or malicious stored hash cannot force argon2.IDKey into an unbounded
+// memory allocation.
 //
 // The comparison is performed in constant time to prevent timing attacks.
 //
+// Returns ErrInvalidHash when phcHash is malformed, uses a non-Argon2id
+// algorithm, or carries parameters outside the supported range.
+//
 //	ok, err := pwdMod.Verify(submittedPassword, storedHash)
-//	if errors.Is(err, password.ErrInvalidHash) { ... } // hash is malformed
+//	if errors.Is(err, password.ErrInvalidHash) { ... } // hash is malformed or out of range
 //	if !ok { return http.StatusUnauthorized }
 func (p *Password) Verify(plaintext, phcHash string) (bool, error) {
 	// Extract the Argon2id parameters and salt embedded in the stored hash.


### PR DESCRIPTION
## Summary

Reflects the behaviour changes from PR #20 in user-visible documentation. No code changes.

### Changes

- **`CHANGELOG.md`** — new `[1.0.1] - 2026-04-19` entry covering:
  - Security: `iss` claim enforcement on `VerifyAccessToken` / `RotateTokens`
  - Security: argon2id PHC parameter bounds on `Verify`
  - Hardening: `primaryAudience` snapshot (from PR #16)
  - Fixed: `module.go` constructor signatures (from PR #16)

- **`auth/jwt/config.go`** — `Issuer` field godoc now states it is both issued and enforced on verify, with mismatches returning `ErrTokenInvalid`.

- **`auth/jwt/jwt.go`** — `VerifyAccessToken` godoc updates `ErrTokenInvalid` description to cover iss/aud mismatch.

- **`auth/password/password.go`** — `Verify` godoc notes parameter-bounded guarantee and `ErrInvalidHash` on out-of-range values.

- **`README.md`**:
  - Error Handling table `jwt.ErrTokenInvalid` row updated.
  - New `> [!NOTE]` callout under "Authenticating requests" explaining the `iss` + `aud` check as the cross-service key-reuse defence.
  - Password Hashing verification paragraph gained the bounded-parameters note.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — all pass (no test additions; behaviour already covered by PR #20's 8 new tests)
- [x] `gofmt -l .` clean
- [ ] Review rendered README on GitHub — NOTE callout + updated table row