### PR TITLE
docs(changelog): correct release header to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [1.0.1] - 2026-04-19
+## [1.1.2] - 2026-04-19
 
 Security-hardening release. No public API changes; existing callers upgrade
 without modification. Two verification paths are now stricter, which can


### PR DESCRIPTION
## Summary

The CHANGELOG entry merged in #22 used header `[1.0.1]`, but the repository's last released tag is `v1.1.1`. Semver requires a forward patch bump, so the security-hardening release ships as `v1.1.2`. The entry body is unchanged; only the version header is corrected.

## Test plan

- [x] No code change
- [ ] Merge then release to main via merge commit
- [ ] Tag `v1.1.2` on the resulting main HEAD