### PR TITLE
chore(release): v1.1.2 — correct changelog version header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [1.0.1] - 2026-04-19
+## [1.1.2] - 2026-04-19
 
 Security-hardening release. No public API changes; existing callers upgrade
 without modification. Two verification paths are now stricter, which can


### PR DESCRIPTION
## Summary

Promotes PR #24 (CHANGELOG header correction from `[1.0.1]` to `[1.1.2]`) from develop to main, so the forthcoming `v1.1.2` tag ships with the correct version recorded in the changelog.

This is the companion release PR for the v1.1.2 security-hardening set (#20, #22, #23). The body of the changelog entry itself already landed in main via #23.

## Merge method

Merge with **"Create a merge commit"** to preserve develop's ancestry (same convention as #23).

## Test plan

- [x] CHANGELOG body already in main; only the header changes
- [x] No code changes
- [ ] After merge, tag `v1.1.2` pointing at the resulting main HEAD
- [ ] Publish GitHub Release v1.1.2 with notes derived from the CHANGELOG entry