### PR TITLE
chore(release): clear open code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# Least-privilege GITHUB_TOKEN. Jobs only read the code and upload coverage.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,9 @@ jobs:
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pin to a specific tag instead of @latest so scorecard's
+        # PinnedDependenciesID check passes and the workflow is reproducible.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# Least-privilege GITHUB_TOKEN. golangci-lint-action only needs to read code.
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,17 @@ on:
     tags:
       - 'v*.*.*'
 
+# Workflow default is read-only. Only the release job needs write access to
+# create the GitHub Release, and that is granted per-job below.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # required by `gh release create` to publish the release
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/examples/fiber/main.go
+++ b/examples/fiber/main.go
@@ -129,7 +129,9 @@ func main() {
 		ok, err := pwdMod.Verify(req.Password, u.passwordHash)
 		if err != nil {
 			// ErrInvalidHash is INTERNAL — log it, return generic 401.
-			log.Printf("verify error for %s: %v", req.Email, err)
+			// %q quotes and escapes control characters so a hostile email
+			// containing newlines cannot forge extra log entries.
+			log.Printf("verify error for %q: %v", req.Email, err)
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid credentials"})
 		}
 		if !ok {
@@ -197,11 +199,6 @@ func main() {
 		if err := c.Bind().JSON(&req); err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid body"})
 		}
-
-		// Verify the token is well-formed to extract the subject (user ID).
-		claims, err := jwtMod.VerifyAccessToken(req.RefreshToken)
-		_ = claims
-		// Note: for refresh tokens use VerifyRefreshTokenHash first, then RotateTokens.
 
 		mu.RLock()
 		// In production: look up user by session ID from the refresh token claims.

--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -133,7 +133,9 @@ func main() {
 		ok, err := pwdMod.Verify(req.Password, u.passwordHash)
 		if err != nil {
 			// ErrInvalidHash is INTERNAL — log it, return generic 401.
-			log.Printf("verify error for %s: %v", req.Email, err)
+			// %q quotes and escapes control characters so a hostile email
+			// containing newlines cannot forge extra log entries.
+			log.Printf("verify error for %q: %v", req.Email, err)
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 			return
 		}

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -111,7 +111,9 @@ func writePublicKey(path string, key ed25519.PublicKey) error {
 
 // readPrivateKey parses a PKCS#8 PEM file and returns the Ed25519 private key.
 func readPrivateKey(path string) (ed25519.PrivateKey, error) {
-	data, err := os.ReadFile(path)
+	// path is built from Config.KeysDir and a fixed filename, both under the
+	// operator's control. Not reachable from user input.
+	data, err := os.ReadFile(path) // #nosec G304 -- path derived from trusted config.KeysDir and fixed filename, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +134,9 @@ func readPrivateKey(path string) (ed25519.PrivateKey, error) {
 
 // readPublicKey parses a PKIX PEM file and returns the Ed25519 public key.
 func readPublicKey(path string) (ed25519.PublicKey, error) {
-	data, err := os.ReadFile(path)
+	// path is built from Config.KeysDir and a fixed filename, both under the
+	// operator's control. Not reachable from user input.
+	data, err := os.ReadFile(path) // #nosec G304 -- path derived from trusted config.KeysDir and fixed filename, not user input
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +188,9 @@ func generateAndSaveRefreshSecret(path string) ([]byte, error) {
 
 // loadRefreshSecret reads, validates, and hex-decodes the secret file.
 func loadRefreshSecret(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	// path is built from Config.KeysDir and a fixed filename, both under the
+	// operator's control. Not reachable from user input.
+	data, err := os.ReadFile(path) // #nosec G304 -- path derived from trusted config.KeysDir and fixed filename, not user input
 	if err != nil {
 		return nil, fmt.Errorf("read refresh secret from %q: %w", path, err)
 	}


### PR DESCRIPTION
## Summary

Promotes PR #26 from develop to main. No code-behaviour change, only CI hygiene:

- Scorecard: least-privilege `GITHUB_TOKEN` permissions on `ci.yml`, `lint.yml`, `release.yml`.
- Scorecard: pin `govulncheck` install to `v1.1.4` (no more `@latest`).
- CodeQL: `%q` instead of `%s` on user-email log lines in `examples/gin` + `examples/fiber`; removed dead refresh-handler code in `examples/fiber`.
- gosec: three G304 findings in `internal/keymanager/generate.go` suppressed with the gosec-native `// #nosec G304 -- reason` directive (path derived from trusted operator config, not user input).

Six structural Scorecard alerts (#18, #23, #24, #25, #26, #27) already dismissed out-of-band on develop.

## Merge method

Merge commit to preserve ancestry, per the convention established in #23 / #25.

## Test plan

- [x] PR #26 CI green (10/10 checks)
- [ ] Confirm CI green on this promotion
- [ ] After merge, next Scorecard cron should close #19, #20, #21, #22 automatically