### PR TITLE
feat(hardening): 5 defence-in-depth validations

### DIFF
--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -54,10 +54,17 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/idna"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/Jaro-c/authcore"
 )
+
+// idnaProfile is configured once and reused because the profile value is
+// immutable and its internal tables are allocated only once.
+// Lookup is the strictest profile that still tolerates TR46 transitional
+// processing, matching what a browser's URL bar does when resolving a host.
+var idnaProfile = idna.Lookup
 
 // DefaultCacheTTL is the maximum duration a domain MX lookup result is cached.
 // Tune this value if your workload has strict freshness requirements.
@@ -182,10 +189,28 @@ func (e *Email) ValidateAndNormalize(address string) (string, error) {
 	return normalized, nil
 }
 
-// normalize lowercases and trims surrounding whitespace. Internal only —
-// callers outside this package must use ValidateAndNormalize.
+// normalize lowercases the address, trims surrounding whitespace, and
+// converts a Unicode (IDN) domain to its ASCII (punycode) form. Internal
+// only — callers outside this package must use ValidateAndNormalize.
+//
+// If the domain cannot be converted (for example it contains a disallowed
+// codepoint), the original lowercased + trimmed string is returned. The
+// downstream validator will then reject it with a clear "invalid format"
+// error.
 func normalize(address string) string {
-	return strings.ToLower(strings.TrimSpace(address))
+	lower := strings.ToLower(strings.TrimSpace(address))
+	atIdx := strings.LastIndexByte(lower, '@')
+	if atIdx < 0 {
+		// Addresses without an "@" fail validation regardless of IDN, so
+		// leaving the input untouched here produces a clearer error path.
+		return lower
+	}
+	local, domain := lower[:atIdx], lower[atIdx+1:]
+	ascii, err := idnaProfile.ToASCII(domain)
+	if err != nil {
+		return lower
+	}
+	return local + "@" + ascii
 }
 
 // validate checks address against RFC 5321 / RFC 5322 rules.

--- a/auth/email/email_test.go
+++ b/auth/email/email_test.go
@@ -179,6 +179,21 @@ func TestValidateAndNormalize_normalizes(t *testing.T) {
 	}
 }
 
+func TestValidateAndNormalize_idnDomainConvertedToPunycode(t *testing.T) {
+	// "münchen.de" is a legitimate German internationalised domain name.
+	// Without IDN support the validator rejects it as non-ASCII; with IDN
+	// support it is converted to its punycode (xn--mnchen-3ya.de) form that
+	// DNS can actually resolve.
+	got, err := newMod(t).ValidateAndNormalize("user@münchen.de")
+	if err != nil {
+		t.Fatalf("unexpected error for IDN email: %v", err)
+	}
+	want := "user@xn--mnchen-3ya.de"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestValidateAndNormalize_invalidReturnsError(t *testing.T) {
 	_, err := newMod(t).ValidateAndNormalize("not-an-email")
 	if !errors.Is(err, ErrInvalidEmail) {

--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -74,16 +74,32 @@ func applyDefaults(cfg Config) Config {
 	return cfg
 }
 
+// maxAccessTokenTTL and maxRefreshTokenTTL cap the configurable token
+// lifetimes. They protect operators from accidentally issuing effectively
+// permanent bearer tokens (for example by typing 10*time.Hour instead of
+// 10*time.Minute). The ceilings match the longest values OWASP's JWT cheat
+// sheet recommends for a typical web application.
+const (
+	maxAccessTokenTTL  = 24 * time.Hour
+	maxRefreshTokenTTL = 365 * 24 * time.Hour
+)
+
 // validateConfig returns an error if cfg contains invalid or inconsistent values.
 func validateConfig(cfg Config) error {
 	if cfg.AccessTokenTTL <= 0 {
 		return fmt.Errorf("access token TTL must be positive, got %s", cfg.AccessTokenTTL)
+	}
+	if cfg.AccessTokenTTL > maxAccessTokenTTL {
+		return fmt.Errorf("access token TTL must be at most %s, got %s", maxAccessTokenTTL, cfg.AccessTokenTTL)
 	}
 	if cfg.RefreshTokenTTL <= cfg.AccessTokenTTL {
 		return fmt.Errorf(
 			"refresh token TTL (%s) must be greater than access token TTL (%s)",
 			cfg.RefreshTokenTTL, cfg.AccessTokenTTL,
 		)
+	}
+	if cfg.RefreshTokenTTL > maxRefreshTokenTTL {
+		return fmt.Errorf("refresh token TTL must be at most %s, got %s", maxRefreshTokenTTL, cfg.RefreshTokenTTL)
 	}
 	if len(cfg.Audience) == 0 {
 		return fmt.Errorf("audience must contain at least one value")

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -187,7 +187,7 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 //	claims, err := jwtMod.VerifyAccessToken(token)
 //	if errors.Is(err, jwt.ErrTokenExpired) { ... }
 func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
-	c, err := verifyAccessToken[T](token, j.pub, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyAccessToken[T](token, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (j *JWT[T]) VerifyRefreshTokenHash(token, storedHash string) bool {
 //
 // Returns the same errors as VerifyAccessToken.
 func (j *JWT[T]) RotateTokens(refreshToken string, extra T) (*TokenPair, error) {
-	c, err := verifyRefreshToken(refreshToken, j.pub, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyRefreshToken(refreshToken, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/jwt/jwt_test.go
+++ b/auth/jwt/jwt_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	gjwt "github.com/golang-jwt/jwt/v5"
+
 	"github.com/Jaro-c/authcore"
 	"github.com/Jaro-c/authcore/internal/clock"
 )
@@ -110,6 +112,27 @@ func TestNew_defaultConfigSucceeds(t *testing.T) {
 func TestNew_negativeTTLReturnsError(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.AccessTokenTTL = -1 * time.Second
+
+	_, err := New[struct{}](newFakeProvider(t), cfg)
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected ErrInvalidConfig, got %v", err)
+	}
+}
+
+func TestNew_accessTTLAboveCeilingReturnsError(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AccessTokenTTL = 48 * time.Hour // above 24 h ceiling
+	cfg.RefreshTokenTTL = 96 * time.Hour
+
+	_, err := New[struct{}](newFakeProvider(t), cfg)
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected ErrInvalidConfig, got %v", err)
+	}
+}
+
+func TestNew_refreshTTLAboveCeilingReturnsError(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RefreshTokenTTL = 2 * 365 * 24 * time.Hour // above 365-day ceiling
 
 	_, err := New[struct{}](newFakeProvider(t), cfg)
 	if !errors.Is(err, ErrInvalidConfig) {
@@ -382,6 +405,29 @@ func TestVerifyAccessToken_wrongIssuerRejectsToken(t *testing.T) {
 	_, err := j2.VerifyAccessToken(pair.AccessToken)
 	if !errors.Is(err, ErrTokenInvalid) {
 		t.Errorf("expected ErrTokenInvalid when issuer does not match, got %v", err)
+	}
+}
+
+func TestVerifyAccessToken_unknownKidRejectsToken(t *testing.T) {
+	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+
+	// Craft a token signed with the module's private key (so the signature
+	// is valid) but with a "kid" header the verifier does not recognise.
+	// This simulates an attacker who has obtained a signing key but whose
+	// "kid" is not on the verifier's trusted list — the kid check must
+	// reject the token before it is accepted.
+	claims := newAccessClaims(j.cfg.Issuer, testSubject, "019600ab-0000-7000-8000-000000000001", j.cfg.Audience, struct{}{}, epoch, j.cfg.AccessTokenTTL)
+	claims.Type = tokenTypeAccess
+	token := gjwt.NewWithClaims(gjwt.SigningMethodEdDSA, claims)
+	token.Header["kid"] = "attacker-controlled-kid"
+	tampered, err := token.SignedString(j.priv)
+	if err != nil {
+		t.Fatalf("sign tampered token: %v", err)
+	}
+
+	_, err = j.VerifyAccessToken(tampered)
+	if !errors.Is(err, ErrTokenInvalid) {
+		t.Errorf("expected ErrTokenInvalid for unknown kid, got %v", err)
 	}
 }
 

--- a/auth/jwt/token.go
+++ b/auth/jwt/token.go
@@ -98,11 +98,11 @@ func signToken(claims gjwt.Claims, key ed25519.PrivateKey, kid string) (string, 
 // signed by the same key but issued for a different service would otherwise be
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
+func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, kid string, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
 	var c accessClaims[T]
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub), // enforce EdDSA alg; rejects HS256/RS256 confusion attacks
+		eddsaKeyFunc(pub, kid),                             // enforce EdDSA alg + kid match; rejects HS256/RS256 confusion attacks and unknown key IDs
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
@@ -122,11 +122,11 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, now time.T
 // signed by the same key but issued for a different service would otherwise be
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
+func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, kid string, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
 	var c refreshClaims
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub), // enforce EdDSA alg; rejects HS256/RS256 confusion attacks
+		eddsaKeyFunc(pub, kid),                             // enforce EdDSA alg + kid match; rejects HS256/RS256 confusion attacks and unknown key IDs
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
@@ -140,8 +140,12 @@ func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, now time.Time, i
 	return &c, nil
 }
 
-// eddsaKeyFunc returns a gjwt.Keyfunc that enforces EdDSA and returns pub.
-func eddsaKeyFunc(pub ed25519.PublicKey) gjwt.Keyfunc {
+// eddsaKeyFunc returns a gjwt.Keyfunc that enforces EdDSA, validates the
+// token's "kid" header against the expected value, and returns pub.
+// Rejecting unknown kids narrows the verifier to keys the operator has
+// actually authorised, which matters once key rotation is in play (the
+// verifier would otherwise happily try pub against every incoming kid).
+func eddsaKeyFunc(pub ed25519.PublicKey, expectedKID string) gjwt.Keyfunc {
 	return func(t *gjwt.Token) (any, error) {
 		// Explicitly reject any algorithm that is not EdDSA.
 		// Without this check an attacker could craft a token with alg=HS256
@@ -149,6 +153,15 @@ func eddsaKeyFunc(pub ed25519.PublicKey) gjwt.Keyfunc {
 		// algorithm confusion attack that allows signature forgery.
 		if _, ok := t.Method.(*gjwt.SigningMethodEd25519); !ok {
 			return nil, fmt.Errorf("%w: unexpected alg %q", ErrTokenInvalid, t.Header["alg"])
+		}
+		// Reject tokens that did not declare a kid or declared one we do not
+		// recognise. Empty expectedKID disables the check (defence in depth
+		// for callers that legitimately sign without a kid header).
+		if expectedKID != "" {
+			kid, _ := t.Header["kid"].(string)
+			if kid != expectedKID {
+				return nil, fmt.Errorf("%w: unexpected kid %q", ErrTokenInvalid, kid)
+			}
 		}
 		return pub, nil
 	}

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -59,6 +59,7 @@ import (
 
 	"github.com/Jaro-c/authcore"
 	"golang.org/x/crypto/argon2"
+	"golang.org/x/text/unicode/norm"
 )
 
 const (
@@ -132,7 +133,7 @@ func (p *Password) Name() string { return "password" }
 //
 // This check is identical to the one Hash performs internally.
 func (p *Password) ValidatePolicy(plaintext string) error {
-	if err := checkPolicy(plaintext); err != nil {
+	if err := checkPolicy(norm.NFC.String(plaintext)); err != nil {
 		return &policyViolation{reason: err}
 	}
 	return nil
@@ -197,6 +198,12 @@ func checkPolicy(plaintext string) error {
 //	if errors.Is(err, password.ErrWeakPassword) { /* tell the user what's wrong */ }
 //	db.StorePasswordHash(userID, hash)
 func (p *Password) Hash(plaintext string) (string, error) {
+	// Normalise to Unicode NFC so the same visual password typed on different
+	// systems (precomposed vs combining accents, e.g. "café" as one codepoint
+	// vs "e" + combining-acute) produces the same hash. Without this, users
+	// who register on one platform and sign in on another can be locked out.
+	plaintext = norm.NFC.String(plaintext)
+
 	// Validate before hashing — fail fast before spending ~64 MiB of RAM on Argon2id.
 	if err := checkPolicy(plaintext); err != nil {
 		return "", &policyViolation{reason: err}
@@ -247,6 +254,11 @@ func (p *Password) Hash(plaintext string) (string, error) {
 //	if errors.Is(err, password.ErrInvalidHash) { ... } // hash is malformed or out of range
 //	if !ok { return http.StatusUnauthorized }
 func (p *Password) Verify(plaintext, phcHash string) (bool, error) {
+	// Normalise to Unicode NFC (matching Hash) so the user can sign in from a
+	// different platform than the one they registered on without losing access
+	// to their account.
+	plaintext = norm.NFC.String(plaintext)
+
 	// Extract the Argon2id parameters and salt embedded in the stored hash.
 	// Using the stored parameters — not the current module config — means old
 	// hashes remain valid even after the work factors are tuned upward.

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -148,6 +148,35 @@ func TestVerify_correctPassword(t *testing.T) {
 	}
 }
 
+func TestVerify_unicodeNFDInputMatchesNFCHash(t *testing.T) {
+	mod := newMod(t)
+
+	// Register with precomposed "é" (U+00E9) — the NFC form typically
+	// produced by macOS and most IMEs.
+	precomposed := "Contraseña-Seguro9!" // "ñ" as single codepoint U+00F1
+	hash, err := mod.Hash(precomposed)
+	if err != nil {
+		t.Fatalf("Hash() error = %v", err)
+	}
+
+	// Log back in with the same password typed on a system that uses the
+	// NFD decomposed form: "n" + combining tilde (U+006E U+0303). Without
+	// NFC normalisation at Verify time the bytes differ → Argon2id hash
+	// differs → user locked out. With normalisation, they match.
+	decomposed := strings.ReplaceAll(precomposed, "ñ", "n\u0303")
+	if decomposed == precomposed {
+		t.Fatalf("test setup error: decomposed form is identical to input")
+	}
+
+	ok, err := mod.Verify(decomposed, hash)
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !ok {
+		t.Error("Verify() = false for NFD form of the same password, want true — NFC normalisation missing")
+	}
+}
+
 func TestVerify_wrongPassword(t *testing.T) {
 	mod := newMod(t)
 	hash, err := mod.Hash("My-Secret-Pass9!")

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.26.1
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	golang.org/x/crypto v0.49.0
+	golang.org/x/net v0.51.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.35.0
 )
 
 require golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,11 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
+golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,41 @@ import (
 // refreshSecretLen is the number of raw bytes in a refresh secret.
 // 32 bytes gives 256 bits of entropy, matching the HMAC-SHA256 key size.
 const refreshSecretLen = 32
+
+// maxKeyFileSize caps the bytes the key loader will read from disk. A healthy
+// Ed25519 PEM file is ~200 bytes and a hex-encoded HMAC secret is 65 bytes,
+// so 4 KiB leaves comfortable headroom for PEM comment headers without ever
+// reading an oversized file. The cap protects startup from a corrupted or
+// attacker-replaced key file that would otherwise be loaded whole into memory.
+const maxKeyFileSize = 4 * 1024
+
+// readCapped reads up to maxKeyFileSize bytes from path and returns an error
+// if the file is larger. It replaces os.ReadFile at every key-loading site.
+func readCapped(path string) ([]byte, error) {
+	// #nosec G304 -- path derived from trusted config.KeysDir and fixed filename, not user input
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Stat first so an obviously oversized file is rejected before any read.
+	if fi, err := f.Stat(); err == nil && fi.Size() > maxKeyFileSize {
+		return nil, fmt.Errorf("file %q is %d bytes, exceeds %d-byte cap", path, fi.Size(), maxKeyFileSize)
+	}
+
+	// Read at most maxKeyFileSize+1 bytes. If the +1 byte actually arrives,
+	// the file streams more than the stat reported (symlink race, pipe-like
+	// path) and the loader refuses it.
+	data, err := io.ReadAll(io.LimitReader(f, maxKeyFileSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxKeyFileSize {
+		return nil, fmt.Errorf("file %q exceeds %d-byte cap", path, maxKeyFileSize)
+	}
+	return data, nil
+}
 
 // ----- Ed25519 key pair -------------------------------------------------------
 
@@ -111,9 +147,7 @@ func writePublicKey(path string, key ed25519.PublicKey) error {
 
 // readPrivateKey parses a PKCS#8 PEM file and returns the Ed25519 private key.
 func readPrivateKey(path string) (ed25519.PrivateKey, error) {
-	// path is built from Config.KeysDir and a fixed filename, both under the
-	// operator's control. Not reachable from user input.
-	data, err := os.ReadFile(path) // #nosec G304 -- path derived from trusted config.KeysDir and fixed filename, not user input
+	data, err := readCapped(path)
 	if err != nil {
 		return nil, err
 	}
@@ -134,9 +168,7 @@ func readPrivateKey(path string) (ed25519.PrivateKey, error) {
 
 // readPublicKey parses a PKIX PEM file and returns the Ed25519 public key.
 func readPublicKey(path string) (ed25519.PublicKey, error) {
-	// path is built from Config.KeysDir and a fixed filename, both under the
-	// operator's control. Not reachable from user input.
-	data, err := os.ReadFile(path) // #nosec G304 -- path derived from trusted config.KeysDir and fixed filename, not user input
+	data, err := readCapped(path)
 	if err != nil {
 		return nil, err
 	}
@@ -188,9 +220,7 @@ func generateAndSaveRefreshSecret(path string) ([]byte, error) {
 
 // loadRefreshSecret reads, validates, and hex-decodes the secret file.
 func loadRefreshSecret(path string) ([]byte, error) {
-	// path is built from Config.KeysDir and a fixed filename, both under the
-	// operator's control. Not reachable from user input.
-	data, err := os.ReadFile(path) // #nosec G304 -- path derived from trusted config.KeysDir and fixed filename, not user input
+	data, err := readCapped(path)
 	if err != nil {
 		return nil, fmt.Errorf("read refresh secret from %q: %w", path, err)
 	}

--- a/internal/keymanager/keymanager_test.go
+++ b/internal/keymanager/keymanager_test.go
@@ -30,6 +30,27 @@ func newKM(t *testing.T) *keymanager.KeyManager {
 
 // ----- generation -------------------------------------------------------------
 
+func TestNew_oversizedKeyFileRejected(t *testing.T) {
+	// A valid Ed25519 PEM is ~200 bytes. An attacker-replaced key file
+	// several megabytes long would previously be loaded whole into
+	// memory before pem.Decode rejected it. The capped reader must
+	// surface a size error before the allocation.
+	dir := t.TempDir()
+	oversized := make([]byte, 100*1024) // 100 KiB, well above the 4 KiB cap
+	// Pair both key files so New() takes the "load existing" branch.
+	if err := os.WriteFile(filepath.Join(dir, "ed25519_private.pem"), oversized, 0600); err != nil {
+		t.Fatalf("seed oversized private key: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ed25519_public.pem"), []byte("fake"), 0644); err != nil {
+		t.Fatalf("seed public key: %v", err)
+	}
+
+	_, err := keymanager.New(dir, testLogger{t})
+	if err == nil {
+		t.Fatal("expected error when private key file exceeds size cap, got nil")
+	}
+}
+
 func TestNew_generatesAllFiles(t *testing.T) {
 	dir := t.TempDir()
 	_, err := keymanager.New(dir, testLogger{t})


### PR DESCRIPTION
## Summary

Closes the 5 nice-to-have gaps identified in the pre-v1 audit. All additive, no API break.

### 1. JWT TTL upper bounds — `auth/jwt/config.go`
- `AccessTokenTTL` capped at 24h, `RefreshTokenTTL` at 365d. OWASP-aligned.

### 2. JWT kid match — `auth/jwt/token.go`
- `eddsaKeyFunc` now asserts incoming `kid` equals module's current `kid`. Unknown kids → `ErrTokenInvalid`. Future-proofs multi-key rotation.

### 3. Password Unicode NFC — `auth/password/password.go`
- `Hash`, `Verify`, `ValidatePolicy` normalise plaintext via `golang.org/x/text/unicode/norm`. Cross-platform account access for passwords with accents / diacritics / emoji.

### 4. Email IDN — `auth/email/email.go`
- `normalize` converts Unicode domain → punycode via `golang.org/x/net/idna`. `münchen.de` now accepted and resolves via DNS.

### 5. PEM file size cap — `internal/keymanager/generate.go`
- Shared `readCapped` helper rejects key files > 4 KiB. Protects startup from corrupted/malicious key files.

### Tests

6 new tests, one per hardening. All ≤1ms.

### New dependencies

- `golang.org/x/net v0.51.0` (idna) — post-GO-2026-4559 safe version
- `golang.org/x/text v0.35.0` (unicode/norm)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — all pass including 6 new
- [x] `gofmt -l .` clean
- [x] `go mod tidy` clean
- [ ] Merge to develop, then release PR to main with merge-commit

## Next

After merge this probably warrants a **v1.2.0** tag (new behavior: new validations, technically backward-compatible but semantic tightening).