### PR TITLE
test: edge-case coverage for v1.2.0 hardenings

### DIFF
--- a/auth/email/email_test.go
+++ b/auth/email/email_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,6 +177,30 @@ func TestValidateAndNormalize_normalizes(t *testing.T) {
 	}
 	if got != "user@example.com" {
 		t.Errorf("got %q, want %q", got, "user@example.com")
+	}
+}
+
+func TestValidateAndNormalize_idnSubdomainEachLabelConverted(t *testing.T) {
+	// When a multi-label IDN domain is supplied, every Unicode label must
+	// be converted to its punycode form, not just the rightmost one.
+	got, err := newMod(t).ValidateAndNormalize("user@süd.münchen.de")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "user@xn--sd-xka.xn--mnchen-3ya.de"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestValidateAndNormalize_idnWithOverlongLabelRejected(t *testing.T) {
+	// idna.Lookup caps a single label at 63 characters. When ToASCII cannot
+	// produce a valid ASCII form, normalize falls back to the raw input and
+	// the downstream validator rejects it with ErrInvalidEmail.
+	overlongLabel := strings.Repeat("ä", 60) // ~120 bytes UTF-8, punycode expands further → >63
+	_, err := newMod(t).ValidateAndNormalize("user@" + overlongLabel + ".com")
+	if !errors.Is(err, ErrInvalidEmail) {
+		t.Errorf("expected ErrInvalidEmail for overlong IDN label, got %v", err)
 	}
 }
 

--- a/auth/jwt/jwt_test.go
+++ b/auth/jwt/jwt_test.go
@@ -119,6 +119,28 @@ func TestNew_negativeTTLReturnsError(t *testing.T) {
 	}
 }
 
+func TestNew_accessTTLExactlyAtCeilingAccepted(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AccessTokenTTL = 24 * time.Hour        // exactly at the cap
+	cfg.RefreshTokenTTL = 365*24*time.Hour - 1 // any value above access works; keep below its own cap
+
+	_, err := New[struct{}](newFakeProvider(t), cfg)
+	if err != nil {
+		t.Errorf("TTL exactly at ceiling must be accepted, got %v", err)
+	}
+}
+
+func TestNew_refreshTTLExactlyAtCeilingAccepted(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AccessTokenTTL = 15 * time.Minute
+	cfg.RefreshTokenTTL = 365 * 24 * time.Hour // exactly at the cap
+
+	_, err := New[struct{}](newFakeProvider(t), cfg)
+	if err != nil {
+		t.Errorf("refresh TTL exactly at ceiling must be accepted, got %v", err)
+	}
+}
+
 func TestNew_accessTTLAboveCeilingReturnsError(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.AccessTokenTTL = 48 * time.Hour // above 24 h ceiling
@@ -405,6 +427,49 @@ func TestVerifyAccessToken_wrongIssuerRejectsToken(t *testing.T) {
 	_, err := j2.VerifyAccessToken(pair.AccessToken)
 	if !errors.Is(err, ErrTokenInvalid) {
 		t.Errorf("expected ErrTokenInvalid when issuer does not match, got %v", err)
+	}
+}
+
+func TestVerifyAccessToken_missingKidRejectsToken(t *testing.T) {
+	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+
+	// An attacker may try to strip the kid header entirely, betting that
+	// the verifier trusts the (single) configured public key regardless.
+	// The verifier must reject tokens whose kid does not match, which
+	// includes tokens where kid is absent.
+	claims := newAccessClaims(j.cfg.Issuer, testSubject, "019600ab-0000-7000-8000-000000000002", j.cfg.Audience, struct{}{}, epoch, j.cfg.AccessTokenTTL)
+	claims.Type = tokenTypeAccess
+	token := gjwt.NewWithClaims(gjwt.SigningMethodEdDSA, claims)
+	// Deliberately do not set token.Header["kid"].
+	stripped, err := token.SignedString(j.priv)
+	if err != nil {
+		t.Fatalf("sign kid-less token: %v", err)
+	}
+
+	_, err = j.VerifyAccessToken(stripped)
+	if !errors.Is(err, ErrTokenInvalid) {
+		t.Errorf("expected ErrTokenInvalid for missing kid, got %v", err)
+	}
+}
+
+func TestRotateTokens_unknownKidRejectsRefreshToken(t *testing.T) {
+	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+
+	// Mirror of the access-token kid check but on the rotation path. A
+	// refresh token with a kid the module does not recognise must be
+	// rejected before it is exchanged for a fresh pair.
+	claims := newRefreshClaims(j.cfg.Issuer, testSubject, "019600ab-0000-7000-8000-000000000003", j.cfg.Audience, epoch, j.cfg.RefreshTokenTTL)
+	claims.Type = tokenTypeRefresh
+	token := gjwt.NewWithClaims(gjwt.SigningMethodEdDSA, claims)
+	token.Header["kid"] = "attacker-controlled-kid"
+	tampered, err := token.SignedString(j.priv)
+	if err != nil {
+		t.Fatalf("sign tampered refresh token: %v", err)
+	}
+
+	_, err = j.RotateTokens(tampered, struct{}{})
+	if !errors.Is(err, ErrTokenInvalid) {
+		t.Errorf("expected ErrTokenInvalid for unknown kid on refresh, got %v", err)
 	}
 }
 

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -329,6 +329,28 @@ func TestValidatePolicy_weakPassword(t *testing.T) {
 	}
 }
 
+func TestValidatePolicy_nfcAndNfdFormsAgree(t *testing.T) {
+	p, _ := New(fakeProvider{})
+
+	// Same logical password in NFC (precomposed "é") and NFD (base "e" +
+	// combining acute). Both byte sequences represent the same visual
+	// password, so ValidatePolicy must treat them identically — accepting
+	// or rejecting both the same way. Before NFC normalisation was added,
+	// byte-level length counts and codepoint-level iteration could diverge
+	// on these two forms.
+	nfc := "Contraseña-Seguro9!"       // "ñ" as single codepoint U+00F1
+	nfd := "Contrasen\u0303a-Seguro9!" // "ñ" as "n" + combining tilde U+0303
+
+	if nfc == nfd {
+		t.Fatal("test setup error: NFC and NFD forms are identical")
+	}
+	errNFC := p.ValidatePolicy(nfc)
+	errNFD := p.ValidatePolicy(nfd)
+	if (errNFC == nil) != (errNFD == nil) {
+		t.Errorf("ValidatePolicy disagrees between NFC and NFD forms: NFC=%v, NFD=%v", errNFC, errNFD)
+	}
+}
+
 // ---- parsePHC() -------------------------------------------------------------
 
 func TestParsePHC_wrongSegmentCount(t *testing.T) {

--- a/internal/keymanager/keymanager_test.go
+++ b/internal/keymanager/keymanager_test.go
@@ -51,6 +51,41 @@ func TestNew_oversizedKeyFileRejected(t *testing.T) {
 	}
 }
 
+func TestNew_oversizedPublicKeyFileRejected(t *testing.T) {
+	// Regression guard for the public-key read path. Both key files must
+	// be size-capped; if only the private side is checked an attacker who
+	// can swap the public file still breaks startup.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ed25519_private.pem"), []byte("fake-but-small"), 0600); err != nil {
+		t.Fatalf("seed private key: %v", err)
+	}
+	oversized := make([]byte, 100*1024)
+	if err := os.WriteFile(filepath.Join(dir, "ed25519_public.pem"), oversized, 0644); err != nil {
+		t.Fatalf("seed oversized public key: %v", err)
+	}
+
+	_, err := keymanager.New(dir, testLogger{t})
+	if err == nil {
+		t.Fatal("expected error when public key file exceeds size cap, got nil")
+	}
+}
+
+func TestNew_oversizedRefreshSecretRejected(t *testing.T) {
+	// The refresh secret loader shares the same capped reader. A ~100 KiB
+	// secret file must be refused before it is hex-decoded.
+	dir := t.TempDir()
+	// Let the key-pair step succeed by letting New() generate fresh keys.
+	oversized := make([]byte, 100*1024)
+	if err := os.WriteFile(filepath.Join(dir, "refresh_secret.key"), oversized, 0600); err != nil {
+		t.Fatalf("seed oversized refresh secret: %v", err)
+	}
+
+	_, err := keymanager.New(dir, testLogger{t})
+	if err == nil {
+		t.Fatal("expected error when refresh secret file exceeds size cap, got nil")
+	}
+}
+
 func TestNew_generatesAllFiles(t *testing.T) {
 	dir := t.TempDir()
 	_, err := keymanager.New(dir, testLogger{t})


### PR DESCRIPTION
## Summary

8 tests covering the boundary / negative paths left uncovered by #29. Tests only; no production code change.

### JWT (4 tests)

- `TestNew_accessTTLExactlyAtCeilingAccepted` / `TestNew_refreshTTLExactlyAtCeilingAccepted` — inclusive ceiling boundary
- `TestVerifyAccessToken_missingKidRejectsToken` — attacker strips kid header
- `TestRotateTokens_unknownKidRejectsRefreshToken` — kid check on rotation path

### Password (1 test)

- `TestValidatePolicy_nfcAndNfdFormsAgree` — NFC and NFD forms of same password produce identical verdict

### Email (2 tests)

- `TestValidateAndNormalize_idnSubdomainEachLabelConverted` — every Unicode label converted, not just the rightmost
- `TestValidateAndNormalize_idnWithOverlongLabelRejected` — `idna.ToASCII` failure path surfaces `ErrInvalidEmail`

### Key manager (2 tests)

- `TestNew_oversizedPublicKeyFileRejected` — 4 KiB cap applies to public key, not just private
- `TestNew_oversizedRefreshSecretRejected` — same cap applies to refresh secret

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean