### PR TITLE
docs: post-v1.2.0 polish — fix stale version claims and clarify feature contracts

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,9 +46,21 @@ officially representing the project in public spaces.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported via
-[GitHub private vulnerability reporting](https://github.com/Jaro-c/authcore/security/advisories/new)
-or by opening a confidential discussion with the maintainers.
+Instances of abusive, harassing, or otherwise unacceptable behavior should be
+reported **confidentially** to the maintainers. Two channels are available:
+
+- **Preferred:** contact the maintainer directly using the address listed on the
+  [maintainer's GitHub profile](https://github.com/Jaro-c). This keeps
+  Code-of-Conduct reports entirely separate from the repository's issue tracker
+  and security-advisory workflow.
+- **Fallback:** if you cannot reach out privately, you may open a
+  [GitHub private advisory](https://github.com/Jaro-c/authcore/security/advisories/new).
+  Despite its "security" framing, this is the repository's only built-in
+  private communication channel; note clearly in the title that the report is
+  a Code-of-Conduct matter rather than a vulnerability.
+
+Do not open a public issue or discussion for Code-of-Conduct reports — that
+exposes the reporter and the accused before the report can be triaged.
 
 All reports will be reviewed and investigated promptly and fairly.
 Community leaders are obligated to respect the privacy and security of the reporter.

--- a/README.md
+++ b/README.md
@@ -1093,12 +1093,12 @@ Have an opinion on priority, or a use case we haven't thought about? Open a [dis
 ## API Stability
 
 <details>
-<summary><b>ℹ️ Versioning policy</b> — v0.x breaking allowed, v1.0 locked · <i>click to expand</i></summary>
+<summary><b>ℹ️ Versioning policy</b> — v1.x public API is frozen · <i>click to expand</i></summary>
 
 authcore follows [Semantic Versioning](https://semver.org).
 
-- **`v0.x` (current)** — the public API may introduce breaking changes between minor releases while the library matures. Pin your dependency with `go.sum` and review release notes before upgrading.
-- **`v1.0.0` (future)** — once published, the public API is covered by compatibility guarantees. Breaking changes will only ship in a new major version.
+- **`v1.x` (current)** — the public API is frozen under semver guarantees. Breaking changes only ship in a new major version (`v2.0.0`). Minor releases add features; patch releases fix bugs or harden existing code paths without changing public shapes.
+- **`v1.2.0`** shipped defence-in-depth hardenings: JWT TTL caps, `kid` header matching, Unicode NFC password normalisation, IDN email support, and a PEM file size cap. See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 Internal packages (`internal/…`) carry no compatibility guarantees at any version and must not be imported from outside the module.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,16 @@
 
 ## Supported Versions
 
-Only the latest published version of authcore receives security fixes.
+Security fixes are backported to the latest minor line of each supported major version. Older lines are expected to upgrade to the current minor.
 
-| Version | Supported |
-|---------|-----------|
-| latest  | ✅        |
-| < latest| ❌        |
+| Major line | Supported | Notes |
+|------------|-----------|-------|
+| `v1.x`     | ✅        | Current. Latest minor receives all security fixes. |
+| `< v1.0`   | ❌        | Pre-release; no longer supported. |
 
-Once the library reaches a stable `v1.0.0`, a formal long-term support window will be defined here.
+Upgrading within `v1.x` is non-breaking by semver guarantee. Patch releases may tighten validation (e.g. `v1.2.0` added TTL caps, `kid` matching, and other defence-in-depth checks) — review the [CHANGELOG](CHANGELOG.md) for behaviour that is now stricter.
+
+A formal long-term support window for specific minor lines will be defined if usage patterns make it necessary; until then, always upgrade to the latest tagged `v1.x` release.
 
 ## Reporting a Vulnerability
 

--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -27,8 +27,16 @@ type Config struct {
 	// Override this with your own service URL or identifier (e.g. "https://auth.example.com").
 	Issuer string
 
-	// Audience is the list of intended recipients embedded in the "aud" claim of every token.
-	// Verifiers use this to confirm that a token was issued for their service.
+	// Audience is the list of intended recipients embedded in the "aud" claim
+	// of every token issued by this module. Verifiers use this to confirm
+	// that a token was issued for their service.
+	//
+	// On verification, only the **first** value (Audience[0]) is enforced.
+	// It is snapshotted into a private field at New() time so that a caller
+	// who later mutates the slice they passed in cannot panic or weaken the
+	// verification path. If you need to accept tokens for multiple audiences
+	// today, run one JWT module per audience rather than widening this slice.
+	//
 	// Defaults to ["github.com/Jaro-c/authcore"].
 	// Override this with your own service identifiers (e.g. ["https://api.example.com"]).
 	Audience []string

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -250,10 +250,15 @@ func (p *Password) Hash(plaintext string) (string, error) {
 // or malicious stored hash cannot force argon2.IDKey into an unbounded
 // memory allocation.
 //
+// Supported parameter ranges (mirroring Config validation):
+//   - Memory:      8 MiB – 4 GiB (8192 – 4194304 KiB)
+//   - Iterations:  1 – 20
+//   - Parallelism: ≥ 1
+//
 // The comparison is performed in constant time to prevent timing attacks.
 //
 // Returns ErrInvalidHash when phcHash is malformed, uses a non-Argon2id
-// algorithm, or carries parameters outside the supported range.
+// algorithm, or carries parameters outside the ranges above.
 //
 //	ok, err := pwdMod.Verify(submittedPassword, storedHash)
 //	if errors.Is(err, password.ErrInvalidHash) { ... } // hash is malformed or out of range

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -12,6 +12,12 @@
 // On subsequent calls the existing files are loaded and validated; no new
 // material is generated unless a file is missing.
 //
+// Key-file loading is size-capped at 4 KiB. A healthy Ed25519 PEM is ~200
+// bytes and a hex-encoded HMAC secret is 65 bytes, so the cap leaves
+// comfortable headroom for PEM comment headers while refusing a corrupted
+// or attacker-replaced key file that would otherwise be loaded whole into
+// memory before PEM decoding rejects it.
+//
 // The KeyManager is read-only after construction and safe for concurrent use.
 package keymanager
 


### PR DESCRIPTION
## Summary

Seven targeted docs fixes from the post-v1.2.0 review. No production code changes; only user-facing text and godoc.

### Stale version claims (critical)

- **README.md** `## API Stability` — said "v0.x (current)" and "v1.0.0 (future)". Replaced with accurate v1.x policy + reference to v1.2.0 hardenings.
- **SECURITY.md** `## Supported Versions` — "stable v1.0.0" framed as future event. Replaced with v1.x support table + non-breaking upgrade guarantee.

### Wrong reporting channel

- **CODE_OF_CONDUCT.md** `## Enforcement` — CoC reports were routed to GitHub's *security* advisory page. Now: preferred channel is the maintainer's GitHub profile; private advisory only as a clearly-flagged fallback.

### v1.2.0 feature contracts in godoc

- **auth/jwt/config.go** `Audience` — explains the `primaryAudience` snapshot: only the first value is enforced on verify, and it is captured at `New()` to defend against post-init mutation.
- **auth/password/password.go** `Verify` — adds explicit ranges for the PHC bounds check (Memory 8 MiB – 4 GiB, Iterations 1 – 20, Parallelism ≥ 1).
- **internal/keymanager/keymanager.go** package doc — documents the 4 KiB key-file size cap (was only visible in `generate.go`).

### Out of scope

Not touching README hero tagline or features bullets in this PR — both were flagged as "could be punchier" but the fixes are subjective.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — all pass (no test changes, no behaviour changes)
- [x] `gofmt -l .` clean