### PR TITLE
ci(release): make the release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Idempotent: if the maintainer already published the release
+          # manually (with curated notes from CHANGELOG.md), skip the
+          # auto-generated fallback. Otherwise create it so tags pushed
+          # directly never lack a published release.
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "Release ${GITHUB_REF_NAME} already exists — leaving the maintainer-curated notes in place."
+            exit 0
+          fi
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \


### PR DESCRIPTION
## Summary

Root cause of the red Release workflow runs on commits `0c43a92` (v1.1.2), `11a1293` (v1.2.0), `c8393b6` (v1.2.1):

> HTTP 422: Validation Failed (https://api.github.com/repos/Jaro-c/AuthCore/releases)

The workflow fires on tag push and runs \`gh release create\`. The maintainer's flow creates the GitHub Release manually first (with curated notes from \`CHANGELOG.md\`), so the workflow hits an already-existing release and errors out. The tag + release still publish correctly, but the commit shows a red cross that scares future contributors.

## Fix

Check whether the release exists before creating it. If yes, skip. If no, fall back to `--generate-notes` so tags pushed without a manual release still get a published release.

## Test plan

- [x] Workflow YAML still valid
- [ ] Next tag push exits cleanly whether or not a manual release exists