### PR TITLE
ci(release): promote release-workflow idempotency fix to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Idempotent: if the maintainer already published the release
+          # manually (with curated notes from CHANGELOG.md), skip the
+          # auto-generated fallback. Otherwise create it so tags pushed
+          # directly never lack a published release.
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "Release ${GITHUB_REF_NAME} already exists — leaving the maintainer-curated notes in place."
+            exit 0
+          fi
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \


### PR DESCRIPTION
## Summary

Promotes PR #37 from develop to main. CI-workflow change only; no consumer-facing behaviour.

### Why

Every tag push since v1.1.2 produced a red Release workflow run because the workflow ran \`gh release create\` against an already-published release (maintainer creates them manually first with curated CHANGELOG notes). PR #37 makes the workflow idempotent: skip creation if the release exists, fall back to auto-generated notes when no manual release is present.

## Merge method

**Create a merge commit** (consistent with other CI-only release PRs).

## No new tag

Workflow-only fix. No code, no docs. v1.2.1 remains the latest tag.

## Test plan

- [x] PR #37 CI green on develop
- [ ] Confirm CI green on this promotion
- [ ] Next tag push produces a green Release workflow run