### PR TITLE
Ignore agent/AI-tool artifacts (zero AI trace)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,12 @@ Thumbs.db
 # authcore managed key directory — never commit cryptographic keys
 .authcore/
 
+
+# Agent / AI-tool artifacts — never commit (zero AI trace).
+.claude/
+.agents/
+.cursor/
+.aider*
+.continue/
+.playwright-mcp/
+**/*-mcp/


### PR DESCRIPTION
The synced `.claude/` agent symlinks and agent-tool scratch like `.playwright-mcp/` were ignored only by a machine-global gitignore, so a clone or CI without it could commit them and leak an AI trace. Ignoring them in-repo makes the protection portable. The private `ai-context` repo is the only place these belong.