### PR TITLE
release: promote develop to main — example-module CI coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,19 @@ updates:
       - "type:deps"
     open-pull-requests-limit: 10
 
+  # The examples are standalone Go modules (own go.mod + local replace), so the
+  # root entry above does not see them. Track them too — otherwise an example
+  # dependency drifts and accumulates advisories unmonitored.
+  - package-ecosystem: "gomod"
+    directories:
+      - "/examples/*"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"
+    labels:
+      - "type:deps"
+    open-pull-requests-limit: 10
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,37 @@
+name: Examples
+
+# The examples are standalone Go modules (own go.mod + a local `replace`), so the
+# go-ci reusable — which builds the root module — never compiles them. Build and
+# vet each one here so a broken or stale example is caught on the PR, not by a
+# user running `go run ./examples/...`.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build & vet
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [basic, email, fiber, gin, jwt, password, username]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: examples/${{ matrix.example }}/go.mod
+          cache: true
+
+      - name: Build & vet ${{ matrix.example }}
+        working-directory: examples/${{ matrix.example }}
+        run: |
+          go build ./...
+          go vet ./...


### PR DESCRIPTION
## Summary

Promote `develop` to `main`. One change since the last promotion:

- **#102** — cover the seven standalone example modules in Dependabot (`/examples/*`) and in CI (a new `examples.yml` matrix that builds + vets each), so they no longer drift unmonitored.

## Test plan

- Source PR merged green (go-ci, dco, line-limit, and the new Examples matrix across all 7).