### PR TITLE
release: promote develop to main — fuzz via reusable

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,25 +10,15 @@ permissions:
 
 jobs:
   fuzz:
-    name: go test -fuzz (smoke)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { package: ./auth/email, func: FuzzValidateAndNormalize }
-          - { package: ./auth/username, func: FuzzValidateAndNormalize }
-          - { package: ./auth/jwt, func: FuzzVerifyAccessToken }
-          - { package: ./auth/jwt, func: FuzzIsUUIDv7 }
-          - { package: ./auth/password, func: FuzzValidatePolicy }
-          - { package: ./auth/password, func: FuzzParsePHC }
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Fuzz ${{ matrix.func }} (${{ matrix.package }})
-        run: go test -run='^$' -fuzz='^${{ matrix.func }}$' -fuzztime=60s ${{ matrix.package }}
+    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@c628c9374ada9f83c3b488d08e535e294b8fa5c5 # v1.4.0
+    with:
+      fuzztime: "60s"
+      targets: >-
+        [
+          {"package":"./auth/email","func":"FuzzValidateAndNormalize"},
+          {"package":"./auth/username","func":"FuzzValidateAndNormalize"},
+          {"package":"./auth/jwt","func":"FuzzVerifyAccessToken"},
+          {"package":"./auth/jwt","func":"FuzzIsUUIDv7"},
+          {"package":"./auth/password","func":"FuzzValidatePolicy"},
+          {"package":"./auth/password","func":"FuzzParsePHC"}
+        ]


### PR DESCRIPTION
## Summary

Promote `develop` to `main`. One change since the last promotion:

- **#106** — replace the inline fuzz harness with a thin caller to the new `go-fuzz` reusable in `Glyndor/.github` (v1.4.0). Closes the last inline-CI drift in the repo.

## Test plan

- Source PR merged green.
- After this lands on `main`, the Fuzz workflow can be run via `workflow_dispatch` to confirm the reusable executes all six targets.