### PR TITLE
ci: bump Glyndor/.github reusables to v1.6.0 and checkout to v7.0.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/go-audit.yml@aba530bccc10ed0f1eb93b063824560ec9347ea7 # v1.3.0
+    uses: Glyndor/.github/.github/workflows/go-audit.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
     with:
       # G104 (errcheck on logger Output) and G306 (public-key 0644) are justified
       # in code with //nolint:gosec; standalone gosec ignores those pragmas.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   go:
-    uses: Glyndor/.github/.github/workflows/go-ci.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/go-ci.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
     with:
       coverage-threshold: 90

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         example: [basic, email, fiber, gin, jwt, password, username]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   fuzz:
-    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@c628c9374ada9f83c3b488d08e535e294b8fa5c5 # v1.4.0
+    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0
     with:
       fuzztime: "60s"
       targets: >-

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@80523422631014f591b07bc24c507145faabb271 # v1.2.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@61be27ae252d2133fab5bf17dcf03f7c13a86cb3 # v1.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: write # required by `gh release create` to publish the release
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Consolidates the CI pin bumps into one change. Dependabot had opened five separate PRs (#84–#88) targeting `.github` v1.3.0, but the org repo is now at **v1.6.0**, so those are stale. This bumps every pin to current in one go and closes them.

## Changes

- All `Glyndor/.github` reusables → v1.6.0 (`61be27a`): go-ci, go-audit, dco, line-limit, main-guard, go-fuzz.
- `actions/checkout` → v7.0.0.
- `actions/setup-go` already current at v6.5.0.

Supersedes #84, #85, #86, #87, #88.

## Test plan

- All workflow YAML validated; `actionlint` clean.