### PR TITLE
fix: harden password verification, email Close and JWT docs

### DIFF
--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -96,13 +96,14 @@ type cacheEntry struct {
 // Call [Email.Close] when the module is no longer needed to stop the
 // background cache eviction goroutine.
 type Email struct {
-	log      authcore.Logger
-	resolver *net.Resolver
-	cacheTTL time.Duration
-	mu       sync.RWMutex
-	cache    map[string]cacheEntry
-	group    singleflight.Group
-	done     chan struct{}
+	log       authcore.Logger
+	resolver  *net.Resolver
+	cacheTTL  time.Duration
+	mu        sync.RWMutex
+	cache     map[string]cacheEntry
+	group     singleflight.Group
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // New creates an Email module using the provider's logger and starts a
@@ -129,15 +130,12 @@ func New(p authcore.Provider) (*Email, error) {
 }
 
 // Close stops the background cache eviction goroutine.
-// It is safe to call Close multiple times; subsequent calls are no-ops.
+// It is safe to call Close multiple times and from multiple goroutines
+// concurrently; the channel is closed exactly once via sync.Once.
 // After Close, VerifyDomain continues to work but expired entries are no
 // longer evicted automatically.
 func (e *Email) Close() {
-	select {
-	case <-e.done: // already closed
-	default:
-		close(e.done)
-	}
+	e.closeOnce.Do(func() { close(e.done) })
 }
 
 // evictLoop runs in a background goroutine and periodically removes expired

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -123,7 +123,10 @@ func (j *JWT[T]) Name() string { return "jwt" }
 //	pair.RefreshTokenHash      — store in your database; never store the raw token
 //	pair.SessionID             — UUID v7 jti shared by both tokens; primary key for session store
 //
-// The access token's individual jti is available as claims.TokenID after VerifyAccessToken.
+// The same jti is carried by the access token, the refresh token, and every
+// rotation of the session, so claims.TokenID after VerifyAccessToken equals
+// pair.SessionID. It identifies the session, not an individual access token —
+// access tokens within one session are not distinguishable by jti.
 //
 // The library does not persist any of these values.
 func (j *JWT[T]) CreateTokens(subject string, extra T) (*TokenPair, error) {

--- a/auth/jwt/types.go
+++ b/auth/jwt/types.go
@@ -33,9 +33,13 @@ type TokenPair struct {
 	RefreshTokenHash string
 
 	// SessionID is the UUID v7 shared by both the access and refresh tokens as their "jti" claim.
-	// It uniquely identifies the session. Use it as the primary key for your session store
-	// to associate metadata such as device, IP address, or last-seen time, and as
-	// the lookup key for access token revocation.
+	// It uniquely identifies the session and is stable across rotations. Use it as the
+	// primary key for your session store to associate metadata such as device, IP address,
+	// or last-seen time, and as the lookup/revocation key for the session as a whole.
+	//
+	// Note: the jti identifies the session, not an individual access token. All access
+	// tokens issued within one session (including across rotations) share this jti, so
+	// you cannot single out one access token by it — revocation is per-session.
 	SessionID string
 }
 
@@ -57,7 +61,9 @@ type Claims[T any] struct {
 	// as configured in jwt.Config.Audience.
 	Audience []string
 
-	// TokenID is the "jti" claim — the unique identifier of this access token.
+	// TokenID is the "jti" claim — the session identifier. It equals the
+	// TokenPair.SessionID returned at creation and is shared by the refresh
+	// token and every rotation, so it names the session, not this single token.
 	TokenID string
 
 	// IssuedAt is when the token was created (the "iat" claim).

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -56,6 +56,7 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/Glyndor/authcore"
 	"golang.org/x/crypto/argon2"
@@ -142,6 +143,10 @@ func (p *Password) ValidatePolicy(plaintext string) error {
 // checkPolicy validates plaintext against the built-in password policy.
 // It runs in O(n) with a single pass and no memory allocations.
 //
+// Length is measured in Unicode characters (runes), not bytes, so a
+// multibyte passphrase is counted the way a user perceives it: a 4-character
+// CJK password is 4 characters, not 12 bytes.
+//
 // Rules:
 //   - Length between 12 and 64 characters.
 //   - At least one uppercase letter (Unicode-aware).
@@ -149,10 +154,11 @@ func (p *Password) ValidatePolicy(plaintext string) error {
 //   - At least one digit.
 //   - At least one special character (anything that is not a letter or digit).
 func checkPolicy(plaintext string) error {
-	if len(plaintext) < 12 {
+	count := utf8.RuneCountInString(plaintext)
+	if count < 12 {
 		return fmt.Errorf("must be at least 12 characters")
 	}
-	if len(plaintext) > 64 {
+	if count > 64 {
 		return fmt.Errorf("must be at most 64 characters")
 	}
 
@@ -254,11 +260,15 @@ func (p *Password) Hash(plaintext string) (string, error) {
 //   - Memory:      8 MiB – 4 GiB (8192 – 4194304 KiB)
 //   - Iterations:  1 – 20
 //   - Parallelism: ≥ 1
+//   - Salt:        exactly 16 bytes
+//   - Key:         exactly 32 bytes
 //
 // The comparison is performed in constant time to prevent timing attacks.
 //
 // Returns ErrInvalidHash when phcHash is malformed, uses a non-Argon2id
-// algorithm, or carries parameters outside the ranges above.
+// algorithm, or carries parameters or salt/key lengths outside the ranges
+// above. A truncated hash never reaches the KDF, so it can neither verify
+// true nor crash the process.
 //
 //	ok, err := pwdMod.Verify(submittedPassword, storedHash)
 //	if errors.Is(err, password.ErrInvalidHash) { ... } // hash is malformed or out of range
@@ -333,6 +343,18 @@ func parsePHC(phcHash string) (Config, []byte, []byte, error) {
 	key, err := base64.RawStdEncoding.DecodeString(parts[5])
 	if err != nil {
 		return Config{}, nil, nil, fmt.Errorf("decode key: %w", err)
+	}
+
+	// Reject hashes whose salt or key are not the fixed sizes Hash produces.
+	// A truncated hash with an empty key segment would otherwise reach
+	// argon2.IDKey with keyLen=0, which panics (nil dereference) and crashes
+	// the process. Enforcing the exact lengths fails closed on any corrupted
+	// or attacker-supplied PHC string before it can reach the KDF.
+	if len(salt) != saltLen {
+		return Config{}, nil, nil, fmt.Errorf("salt has wrong length: got %d bytes, want %d", len(salt), saltLen)
+	}
+	if len(key) != keyLen {
+		return Config{}, nil, nil, fmt.Errorf("derived key has wrong length: got %d bytes, want %d", len(key), keyLen)
 	}
 
 	return cfg, salt, key, nil

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -445,6 +445,30 @@ func TestVerify_malformedStoredHashIsRejectedBeforeKeyDerivation(t *testing.T) {
 	}
 }
 
+func TestVerify_emptyKeySegmentRejectedNotPanic(t *testing.T) {
+	p := newMod(t)
+
+	// A truncated hash with an empty key segment reaches argon2.IDKey with
+	// keyLen=0, which panics (nil dereference) and crashes the process.
+	// parsePHC must reject it as ErrInvalidHash, never derive a key.
+	cases := map[string]string{
+		"empty key":  "$argon2id$v=19$m=65536,t=3,p=2$AAAAAAAAAAAAAAAAAAAAAA$",
+		"empty salt": "$argon2id$v=19$m=65536,t=3,p=2$$" + strings.Repeat("A", 43),
+		"short key":  "$argon2id$v=19$m=65536,t=3,p=2$AAAAAAAAAAAAAAAAAAAAAA$a2V5",
+	}
+	for name, h := range cases {
+		t.Run(name, func(t *testing.T) {
+			ok, err := p.Verify("any-password-we-do-not-care", h)
+			if ok {
+				t.Fatalf("%s: malformed hash must never verify true", name)
+			}
+			if !errors.Is(err, ErrInvalidHash) {
+				t.Errorf("%s: expected ErrInvalidHash, got %v", name, err)
+			}
+		})
+	}
+}
+
 // ---- DefaultConfig() --------------------------------------------------------
 
 func TestDefaultConfig_values(t *testing.T) {


### PR DESCRIPTION
While reviewing the modules I found three issues and fixed them here.

- **password.Verify panic (#115).** A stored hash with an empty key segment reached `argon2.IDKey` with `keyLen=0` and crashed the process with a nil-pointer panic. `parsePHC` now enforces the fixed 16-byte salt and 32-byte key before the KDF and fails closed with `ErrInvalidHash`. Added a regression test for the empty-key, empty-salt and short-key cases.
- **email.Close race (#116).** The close pattern only protected serial calls; concurrent callers could close an already closed channel. Now guarded with `sync.Once`.
- **password length in runes (#117).** The 12–64 bound counted bytes, so a short multibyte password passed the minimum. Now measured with `utf8.RuneCountInString`.

I also clarified the JWT doc comments so the `jti` is described as the session identifier (shared by access, refresh and every rotation), not a per-access-token id.

`go build`, `go vet` and the full test suite pass, including `-race`.

Closes #115
Closes #116
Closes #117