### PR TITLE
fix: harden email, JWT audience and keymanager against edge inputs

### DIFF
--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -251,6 +251,14 @@ func validate(address string) error {
 		return &emailViolation{reason: fmt.Errorf("local part must be at most 64 characters")}
 	}
 
+	// Reject address literals like "user@[192.168.1.1]" or "user@[IPv6:...]".
+	// net/mail accepts them, but they are almost never wanted in an account
+	// system, cannot be MX-verified, and would otherwise slip through the
+	// dot/label checks below (the bracketed octets look like labels).
+	if strings.HasPrefix(domain, "[") {
+		return &emailViolation{reason: fmt.Errorf("domain must not be an address literal")}
+	}
+
 	// Domain: at least one dot, no leading/trailing/consecutive dots,
 	// each label 1–63 characters.
 	hasDot := false

--- a/auth/email/email_test.go
+++ b/auth/email/email_test.go
@@ -151,6 +151,17 @@ func TestValidate_withDisplayName(t *testing.T) {
 	}
 }
 
+func TestValidate_addressLiteralRejected(t *testing.T) {
+	for _, addr := range []string{
+		"user@[192.168.1.1]",
+		"user@[IPv6:2001:db8::1]",
+	} {
+		if err := validate(addr); !errors.Is(err, ErrInvalidEmail) {
+			t.Errorf("expected ErrInvalidEmail for address literal %q, got %v", addr, err)
+		}
+	}
+}
+
 // ---- ErrInvalidEmail wraps a reason -----------------------------------------
 
 func TestValidate_wrapsReason(t *testing.T) {

--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -112,6 +113,15 @@ func validateConfig(cfg Config) error {
 	}
 	if len(cfg.Audience) == 0 {
 		return fmt.Errorf("audience must contain at least one value")
+	}
+	// Reject empty or whitespace-only audience entries. A []string{""} passes
+	// the length check above but would issue tokens with an empty "aud" and
+	// verify against "", silently removing the cross-service-reuse protection
+	// the audience claim exists to provide.
+	for i, aud := range cfg.Audience {
+		if strings.TrimSpace(aud) == "" {
+			return fmt.Errorf("audience entry %d must not be empty or whitespace", i)
+		}
 	}
 	if cfg.ClockSkewLeeway < 0 {
 		return fmt.Errorf("clock skew leeway must not be negative, got %s", cfg.ClockSkewLeeway)

--- a/auth/jwt/jwt_refresh_test.go
+++ b/auth/jwt/jwt_refresh_test.go
@@ -223,6 +223,20 @@ func TestNew_negativeLeewayReturnsErrInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestNew_emptyAudienceEntryReturnsErrInvalidConfig(t *testing.T) {
+	for _, aud := range [][]string{
+		{""},
+		{"   "},
+		{"valid", ""},
+	} {
+		cfg := DefaultConfig()
+		cfg.Audience = aud
+		if _, err := New[struct{}](newFakeProvider(t), cfg); !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Audience %q: expected ErrInvalidConfig, got %v", aud, err)
+		}
+	}
+}
+
 func TestVerifyAccessToken_tokenWithinLeewayIsAccepted(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.AccessTokenTTL = 10 * time.Minute

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -52,6 +52,32 @@ func readCapped(path string) ([]byte, error) {
 	return data, nil
 }
 
+// checkKeyDirConsistency verifies that the key directory is either empty of all
+// managed key files or holds the full set. A partially-populated directory —
+// for example the Ed25519 pair present but refresh_secret.key deleted — is
+// rejected before anything is generated, so the manager never silently mints a
+// new refresh secret that would invalidate every refresh-token hash already
+// stored by the consumer (forcing all users to log in again).
+func checkKeyDirConsistency(dir string) error {
+	files := []string{filePrivateKey, filePublicKey, fileRefreshSecret}
+	var present, missing []string
+	for _, name := range files {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			present = append(present, name)
+		} else {
+			missing = append(missing, name)
+		}
+	}
+	if len(present) > 0 && len(missing) > 0 {
+		return fmt.Errorf(
+			"key directory %q is in an inconsistent state: present {%s}, missing {%s}; "+
+				"restore the missing file(s), or delete all key files to trigger a clean regeneration",
+			dir, strings.Join(present, ", "), strings.Join(missing, ", "),
+		)
+	}
+	return nil
+}
+
 // ----- Ed25519 key pair -------------------------------------------------------
 
 // loadOrGenerateEd25519 returns an Ed25519 key pair, generating and

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -79,6 +79,13 @@ func New(dir string, log logger) (*KeyManager, error) {
 		return nil, fmt.Errorf("write .gitignore in %q: %w", dir, err)
 	}
 
+	// Fail closed on a partially-populated directory before generating anything,
+	// so a missing refresh secret beside an existing key pair is reported rather
+	// than silently regenerated (which would invalidate stored refresh hashes).
+	if err := checkKeyDirConsistency(dir); err != nil {
+		return nil, err
+	}
+
 	priv, pub, err := loadOrGenerateEd25519(dir, log)
 	if err != nil {
 		return nil, fmt.Errorf("ed25519 key pair: %w", err)

--- a/internal/keymanager/keymanager_test.go
+++ b/internal/keymanager/keymanager_test.go
@@ -106,6 +106,30 @@ func TestNew_generatesAllFiles(t *testing.T) {
 	}
 }
 
+func TestNew_partialKeyDirIsRejected(t *testing.T) {
+	// Removing any single managed file while the others remain must fail closed,
+	// rather than silently regenerating it. A regenerated refresh secret would
+	// invalidate every stored refresh-token hash.
+	for _, remove := range []string{
+		"refresh_secret.key",
+		"ed25519_private.pem",
+		"ed25519_public.pem",
+	} {
+		t.Run("missing_"+remove, func(t *testing.T) {
+			dir := t.TempDir()
+			if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+				t.Fatalf("initial New() error = %v", err)
+			}
+			if err := os.Remove(filepath.Join(dir, remove)); err != nil {
+				t.Fatalf("remove %q: %v", remove, err)
+			}
+			if _, err := keymanager.New(dir, testLogger{t}); err == nil {
+				t.Errorf("expected an error for a key dir missing %q, got nil", remove)
+			}
+		})
+	}
+}
+
 func TestNew_keyMaterialHasCorrectSize(t *testing.T) {
 	km := newKM(t)
 


### PR DESCRIPTION
Three small hardening fixes from the review, each fail-closed.

- **email (#119).** `net/mail` accepts `user@[192.168.1.1]` and IPv6 literals, and the bracketed octets slip through the dot/label checks. I reject any domain that begins with a bracket — such addresses cannot be MX-verified and are not wanted in an account system.
- **jwt (#120).** `Audience: []string{""}` passed the `len >= 1` check but issued tokens with an empty `aud` and verified against `""`, silently dropping the cross-service-reuse protection. I reject empty or whitespace-only audience entries at validation time.
- **keymanager (#121).** Only the Ed25519 pair had a both-or-neither guard; a missing `refresh_secret.key` beside an existing key pair was silently regenerated, invalidating every stored refresh-token hash and forcing all users to log in again. I now check all three key files up front and refuse a directory that holds some but not all of them, before generating anything.

Each fix has a test. `go build`, `go vet`, `golangci-lint` (0 issues) and the full suite with `-race` pass; aggregate coverage 91.2%.

Closes #119
Closes #120
Closes #121