### PR TITLE
release: v1.3.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,7 @@ jobs:
       # G104 (errcheck on logger Output) and G306 (public-key 0644) are justified
       # in code with //nolint:gosec; standalone gosec ignores those pragmas.
       # G115 mirrors the .golangci.yml exclusion for UUID/time math.
-      gosec-exclude: "G104,G115,G306"
+      # G401/G505 (SHA-1) are the HaveIBeenPwned k-anonymity prefix hash in
+      # auth/password/breach.go — required by the HIBP range API, never used for
+      # password storage (that is Argon2id) or any security decision on its own.
+      gosec-exclude: "G104,G115,G306,G401,G505"

--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -249,6 +249,14 @@ func validate(address string) error {
 		return &emailViolation{reason: fmt.Errorf("local part must be at most 64 characters")}
 	}
 
+	// Reject address literals like "user@[192.168.1.1]" or "user@[IPv6:...]".
+	// net/mail accepts them, but they are almost never wanted in an account
+	// system, cannot be MX-verified, and would otherwise slip through the
+	// dot/label checks below (the bracketed octets look like labels).
+	if strings.HasPrefix(domain, "[") {
+		return &emailViolation{reason: fmt.Errorf("domain must not be an address literal")}
+	}
+
 	// Domain: at least one dot, no leading/trailing/consecutive dots,
 	// each label 1–63 characters.
 	hasDot := false

--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -96,13 +96,14 @@ type cacheEntry struct {
 // Call [Email.Close] when the module is no longer needed to stop the
 // background cache eviction goroutine.
 type Email struct {
-	log      authcore.Logger
-	resolver *net.Resolver
-	cacheTTL time.Duration
-	mu       sync.RWMutex
-	cache    map[string]cacheEntry
-	group    singleflight.Group
-	done     chan struct{}
+	log       authcore.Logger
+	resolver  *net.Resolver
+	cacheTTL  time.Duration
+	mu        sync.RWMutex
+	cache     map[string]cacheEntry
+	group     singleflight.Group
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // New creates an Email module using the provider's logger and starts a
@@ -129,15 +130,12 @@ func New(p authcore.Provider) (*Email, error) {
 }
 
 // Close stops the background cache eviction goroutine.
-// It is safe to call Close multiple times; subsequent calls are no-ops.
+// It is safe to call Close multiple times and from multiple goroutines
+// concurrently; the channel is closed exactly once via sync.Once.
 // After Close, VerifyDomain continues to work but expired entries are no
 // longer evicted automatically.
 func (e *Email) Close() {
-	select {
-	case <-e.done: // already closed
-	default:
-		close(e.done)
-	}
+	e.closeOnce.Do(func() { close(e.done) })
 }
 
 // evictLoop runs in a background goroutine and periodically removes expired

--- a/auth/email/email_test.go
+++ b/auth/email/email_test.go
@@ -151,6 +151,17 @@ func TestValidate_withDisplayName(t *testing.T) {
 	}
 }
 
+func TestValidate_addressLiteralRejected(t *testing.T) {
+	for _, addr := range []string{
+		"user@[192.168.1.1]",
+		"user@[IPv6:2001:db8::1]",
+	} {
+		if err := validate(addr); !errors.Is(err, ErrInvalidEmail) {
+			t.Errorf("expected ErrInvalidEmail for address literal %q, got %v", addr, err)
+		}
+	}
+}
+
 // ---- ErrInvalidEmail wraps a reason -----------------------------------------
 
 func TestValidate_wrapsReason(t *testing.T) {

--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -112,6 +113,15 @@ func validateConfig(cfg Config) error {
 	}
 	if len(cfg.Audience) == 0 {
 		return fmt.Errorf("audience must contain at least one value")
+	}
+	// Reject empty or whitespace-only audience entries. A []string{""} passes
+	// the length check above but would issue tokens with an empty "aud" and
+	// verify against "", silently removing the cross-service-reuse protection
+	// the audience claim exists to provide.
+	for i, aud := range cfg.Audience {
+		if strings.TrimSpace(aud) == "" {
+			return fmt.Errorf("audience entry %d must not be empty or whitespace", i)
+		}
 	}
 	if cfg.ClockSkewLeeway < 0 {
 		return fmt.Errorf("clock skew leeway must not be negative, got %s", cfg.ClockSkewLeeway)

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -123,7 +123,10 @@ func (j *JWT[T]) Name() string { return "jwt" }
 //	pair.RefreshTokenHash      — store in your database; never store the raw token
 //	pair.SessionID             — UUID v7 jti shared by both tokens; primary key for session store
 //
-// The access token's individual jti is available as claims.TokenID after VerifyAccessToken.
+// The same jti is carried by the access token, the refresh token, and every
+// rotation of the session, so claims.TokenID after VerifyAccessToken equals
+// pair.SessionID. It identifies the session, not an individual access token —
+// access tokens within one session are not distinguishable by jti.
 //
 // The library does not persist any of these values.
 func (j *JWT[T]) CreateTokens(subject string, extra T) (*TokenPair, error) {

--- a/auth/jwt/jwt_refresh_test.go
+++ b/auth/jwt/jwt_refresh_test.go
@@ -223,6 +223,20 @@ func TestNew_negativeLeewayReturnsErrInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestNew_emptyAudienceEntryReturnsErrInvalidConfig(t *testing.T) {
+	for _, aud := range [][]string{
+		{""},
+		{"   "},
+		{"valid", ""},
+	} {
+		cfg := DefaultConfig()
+		cfg.Audience = aud
+		if _, err := New[struct{}](newFakeProvider(t), cfg); !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Audience %q: expected ErrInvalidConfig, got %v", aud, err)
+		}
+	}
+}
+
 func TestVerifyAccessToken_tokenWithinLeewayIsAccepted(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.AccessTokenTTL = 10 * time.Minute

--- a/auth/jwt/types.go
+++ b/auth/jwt/types.go
@@ -33,9 +33,13 @@ type TokenPair struct {
 	RefreshTokenHash string
 
 	// SessionID is the UUID v7 shared by both the access and refresh tokens as their "jti" claim.
-	// It uniquely identifies the session. Use it as the primary key for your session store
-	// to associate metadata such as device, IP address, or last-seen time, and as
-	// the lookup key for access token revocation.
+	// It uniquely identifies the session and is stable across rotations. Use it as the
+	// primary key for your session store to associate metadata such as device, IP address,
+	// or last-seen time, and as the lookup/revocation key for the session as a whole.
+	//
+	// Note: the jti identifies the session, not an individual access token. All access
+	// tokens issued within one session (including across rotations) share this jti, so
+	// you cannot single out one access token by it — revocation is per-session.
 	SessionID string
 }
 
@@ -57,7 +61,9 @@ type Claims[T any] struct {
 	// as configured in jwt.Config.Audience.
 	Audience []string
 
-	// TokenID is the "jti" claim — the unique identifier of this access token.
+	// TokenID is the "jti" claim — the session identifier. It equals the
+	// TokenPair.SessionID returned at creation and is shared by the refresh
+	// token and every rotation, so it names the session, not this single token.
 	TokenID string
 
 	// IssuedAt is when the token was created (the "iat" claim).

--- a/auth/password/breach.go
+++ b/auth/password/breach.go
@@ -1,0 +1,224 @@
+package password
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha1" //nolint:gosec // SHA-1 is mandated by the HaveIBeenPwned range API; it guards a k-anonymity prefix lookup, never password storage (that is Argon2id).
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// BreachChecker reports whether a plaintext password appears in a known data
+// breach corpus. It is the opt-in complement to the built-in policy: length
+// and composition rules keep out structurally weak passwords, while a breach
+// check keeps out passwords that are structurally fine but already public.
+//
+// Implementations must never transmit the full password. A network-backed
+// implementation must use k-anonymity — send only a short hash prefix and
+// compare suffixes locally (see HIBPChecker).
+//
+// The interface takes a context so a network implementation can honour a
+// deadline; an offline implementation may ignore it.
+type BreachChecker interface {
+	// IsBreached reports whether plaintext appears in the breach corpus.
+	// The boolean is only meaningful when the error is nil; on error the
+	// caller must decide whether to fail open or closed for its threat model.
+	IsBreached(ctx context.Context, plaintext string) (bool, error)
+}
+
+// CheckBreached reports whether plaintext appears in a known data breach,
+// using the BreachChecker configured in Config.BreachChecker.
+//
+// It is a no-network-by-default, opt-in step — mirroring the email module's
+// VerifyDomain. Configure a checker to enable it:
+//
+//	cfg := password.DefaultConfig()
+//	cfg.BreachChecker = password.NewHIBPChecker()
+//	pwdMod, _ := password.New(auth, cfg)
+//
+//	// Registration / password change, after ValidatePolicy:
+//	if err := pwdMod.CheckBreached(ctx, req.Password); err != nil {
+//	    if errors.Is(err, password.ErrBreachedPassword) {
+//	        c.JSON(400, gin.H{"error": "this password has appeared in a data breach, choose another"})
+//	        return
+//	    }
+//	    log.Printf("breach check unavailable: %v", err) // network error — decide your policy
+//	}
+//
+// plaintext is normalised to Unicode NFC before the lookup, matching Hash and
+// Verify, so the check is consistent across platforms.
+//
+// Returns:
+//
+//	nil                     — the password was not found in the corpus
+//	ErrBreachedPassword     — the password was found (CLIENT-SAFE; ask for a new one)
+//	ErrNoBreachChecker      — no checker is configured (programming error)
+//	a wrapped checker error — the lookup itself failed (e.g. network/DNS); treat
+//	                          as a soft failure unless your threat model needs fail-closed
+func (p *Password) CheckBreached(ctx context.Context, plaintext string) error {
+	if p.cfg.BreachChecker == nil {
+		return ErrNoBreachChecker
+	}
+	breached, err := p.cfg.BreachChecker.IsBreached(ctx, norm.NFC.String(plaintext))
+	if err != nil {
+		return fmt.Errorf("password: breach check: %w", err)
+	}
+	if breached {
+		return ErrBreachedPassword
+	}
+	return nil
+}
+
+// ----- HaveIBeenPwned (k-anonymity) ------------------------------------------
+
+// hibpDefaultBaseURL is the HaveIBeenPwned Pwned Passwords range endpoint.
+const hibpDefaultBaseURL = "https://api.pwnedpasswords.com"
+
+// hibpDefaultTimeout bounds a single range request so a slow or unreachable
+// service cannot stall a registration handler indefinitely. The per-call
+// context still takes precedence when it has a shorter deadline.
+const hibpDefaultTimeout = 5 * time.Second
+
+// HIBPChecker is a BreachChecker backed by the HaveIBeenPwned Pwned Passwords
+// range API using k-anonymity: it hashes the password with SHA-1, sends only
+// the first five hex characters of the digest, and compares the 35-character
+// suffixes returned by the service locally. The full password and its full
+// hash never leave the process.
+//
+// Construct it with NewHIBPChecker and reuse it; it is safe for concurrent use.
+type HIBPChecker struct {
+	client  *http.Client
+	baseURL string
+}
+
+// HIBPOption customises a HIBPChecker.
+type HIBPOption func(*HIBPChecker)
+
+// WithHTTPClient sets the HTTP client used for range requests.
+// Use this to share a tuned client (proxy, transport, timeouts) across modules.
+func WithHTTPClient(c *http.Client) HIBPOption {
+	return func(h *HIBPChecker) {
+		if c != nil {
+			h.client = c
+		}
+	}
+}
+
+// WithBaseURL overrides the HaveIBeenPwned base URL.
+// Intended for tests and for self-hosted/mirrored range endpoints.
+func WithBaseURL(u string) HIBPOption {
+	return func(h *HIBPChecker) {
+		if u != "" {
+			h.baseURL = strings.TrimRight(u, "/")
+		}
+	}
+}
+
+// NewHIBPChecker returns a HIBPChecker with sensible defaults (a 5-second
+// client timeout and the public HaveIBeenPwned endpoint). Override with options:
+//
+//	checker := password.NewHIBPChecker(
+//	    password.WithHTTPClient(myClient),
+//	)
+func NewHIBPChecker(opts ...HIBPOption) *HIBPChecker {
+	h := &HIBPChecker{
+		client:  &http.Client{Timeout: hibpDefaultTimeout},
+		baseURL: hibpDefaultBaseURL,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// IsBreached implements BreachChecker against the HaveIBeenPwned range API.
+//
+// It never transmits the password or its full hash: only the first five hex
+// characters of the SHA-1 digest are sent, and the matching suffix is searched
+// in the response. The "Add-Padding" header is set so the response size does
+// not leak whether the prefix had many or few matches; padding entries (count
+// 0) are ignored.
+func (h *HIBPChecker) IsBreached(ctx context.Context, plaintext string) (bool, error) {
+	sum := sha1.Sum([]byte(plaintext)) //nolint:gosec // k-anonymity prefix hash for the HIBP API, not password storage.
+	digest := strings.ToUpper(hex.EncodeToString(sum[:]))
+	prefix, suffix := digest[:5], digest[5:]
+
+	url := h.baseURL + "/range/" + prefix
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Errorf("build request: %w", err)
+	}
+	// Ask the service to pad the response so its length does not reveal how
+	// many suffixes share this prefix.
+	req.Header.Set("Add-Padding", "true")
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("range request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain a bounded amount so the connection can be reused, then report.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return false, fmt.Errorf("range request: unexpected status %d", resp.StatusCode)
+	}
+
+	// Each line is "SUFFIX:COUNT". A real match has COUNT > 0; padding lines
+	// carry COUNT 0 and are skipped. Suffix comparison is case-insensitive
+	// because the API returns uppercase hex.
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		sep := strings.IndexByte(line, ':')
+		if sep < 0 {
+			continue
+		}
+		if !strings.EqualFold(line[:sep], suffix) {
+			continue
+		}
+		// Found the suffix; treat any non-"0" count as breached.
+		count := strings.TrimSpace(line[sep+1:])
+		return count != "" && count != "0", nil
+	}
+	if err := scanner.Err(); err != nil {
+		return false, fmt.Errorf("read range response: %w", err)
+	}
+	return false, nil
+}
+
+// ----- Local list ------------------------------------------------------------
+
+// ListChecker is an offline BreachChecker backed by an in-memory set of known
+// breached passwords. Use it to embed a curated list (e.g. the most common
+// passwords) without any network dependency.
+//
+// Lookups are O(1) and constant across inputs. The set is built once and is
+// safe for concurrent use.
+type ListChecker struct {
+	set map[string]struct{}
+}
+
+// NewListChecker builds a ListChecker from the given passwords. Each entry is
+// normalised to Unicode NFC so lookups match CheckBreached's normalisation.
+// Duplicates are collapsed.
+func NewListChecker(passwords []string) *ListChecker {
+	set := make(map[string]struct{}, len(passwords))
+	for _, pw := range passwords {
+		set[norm.NFC.String(pw)] = struct{}{}
+	}
+	return &ListChecker{set: set}
+}
+
+// IsBreached implements BreachChecker. It reports whether plaintext is present
+// in the list. The error is always nil; the lookup is local and cannot fail.
+func (l *ListChecker) IsBreached(_ context.Context, plaintext string) (bool, error) {
+	_, ok := l.set[norm.NFC.String(plaintext)]
+	return ok, nil
+}

--- a/auth/password/breach_test.go
+++ b/auth/password/breach_test.go
@@ -1,0 +1,212 @@
+package password
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // mirrors the production k-anonymity hashing under test.
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// digestParts returns the uppercase SHA-1 prefix (5) and suffix (35) of pw,
+// matching what HIBPChecker sends and compares.
+func digestParts(pw string) (prefix, suffix string) {
+	sum := sha1.Sum([]byte(pw)) //nolint:gosec // test mirror of the k-anonymity hash.
+	d := strings.ToUpper(hex.EncodeToString(sum[:]))
+	return d[:5], d[5:]
+}
+
+// ---- ListChecker ------------------------------------------------------------
+
+func TestListChecker_hitAndMiss(t *testing.T) {
+	c := NewListChecker([]string{"password123", "hunter2"})
+	for _, tc := range []struct {
+		pw   string
+		want bool
+	}{
+		{"password123", true},
+		{"hunter2", true},
+		{"not-in-the-list", false},
+	} {
+		got, err := c.IsBreached(context.Background(), tc.pw)
+		if err != nil {
+			t.Fatalf("IsBreached(%q) error = %v", tc.pw, err)
+		}
+		if got != tc.want {
+			t.Errorf("IsBreached(%q) = %v, want %v", tc.pw, got, tc.want)
+		}
+	}
+}
+
+func TestListChecker_normalisesNFC(t *testing.T) {
+	// Store the decomposed form, query the precomposed form: they must match
+	// because both sides are normalised to NFC.
+	base := "café-Passw0rd!"
+	nfdForm := norm.NFD.String(base)
+	nfcForm := norm.NFC.String(base)
+	if nfdForm == nfcForm {
+		t.Skip("base string has no precomposed/decomposed distinction")
+	}
+	c := NewListChecker([]string{nfdForm})
+	got, err := c.IsBreached(context.Background(), nfcForm)
+	if err != nil {
+		t.Fatalf("IsBreached error = %v", err)
+	}
+	if !got {
+		t.Error("expected NFC-normalised lookup to match the NFD-stored entry")
+	}
+}
+
+// ---- HIBPChecker ------------------------------------------------------------
+
+func TestHIBPChecker_breached(t *testing.T) {
+	const pw = "Sup3rSecret!Pass"
+	prefix, suffix := digestParts(pw)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// k-anonymity: only the prefix may be requested, never the full digest.
+		if r.URL.Path != "/range/"+prefix {
+			t.Errorf("requested path = %q, want /range/%s", r.URL.Path, prefix)
+		}
+		if r.Header.Get("Add-Padding") != "true" {
+			t.Errorf("Add-Padding header = %q, want true", r.Header.Get("Add-Padding"))
+		}
+		// Real match (count > 0) plus an unrelated suffix and a padding line.
+		fmt.Fprint(w, "0000000000000000000000000000000000A:3\r\n")
+		fmt.Fprintf(w, "%s:42\r\n", suffix)
+		fmt.Fprint(w, "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:0\r\n")
+	}))
+	defer srv.Close()
+
+	c := NewHIBPChecker(WithBaseURL(srv.URL))
+	got, err := c.IsBreached(context.Background(), pw)
+	if err != nil {
+		t.Fatalf("IsBreached error = %v", err)
+	}
+	if !got {
+		t.Error("expected password to be reported as breached")
+	}
+}
+
+func TestHIBPChecker_notBreached(t *testing.T) {
+	const pw = "An0ther!Unique@Pw"
+	_, suffix := digestParts(pw)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Same suffix but count 0 (padding) plus an unrelated entry — no real hit.
+		fmt.Fprintf(w, "%s:0\r\n", suffix)
+		fmt.Fprint(w, "1111111111111111111111111111111111B:9\r\n")
+	}))
+	defer srv.Close()
+
+	c := NewHIBPChecker(WithBaseURL(srv.URL))
+	got, err := c.IsBreached(context.Background(), pw)
+	if err != nil {
+		t.Fatalf("IsBreached error = %v", err)
+	}
+	if got {
+		t.Error("expected password not to be reported as breached (padding count 0)")
+	}
+}
+
+func TestHIBPChecker_nonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewHIBPChecker(WithBaseURL(srv.URL))
+	if _, err := c.IsBreached(context.Background(), "whatever-Passw0rd!"); err == nil {
+		t.Error("expected an error on non-200 status")
+	}
+}
+
+func TestHIBPChecker_transportError(t *testing.T) {
+	// Point at a closed server to force a transport error.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	c := NewHIBPChecker(WithBaseURL(url))
+	if _, err := c.IsBreached(context.Background(), "whatever-Passw0rd!"); err == nil {
+		t.Error("expected a transport error against a closed server")
+	}
+}
+
+// ---- CheckBreached ----------------------------------------------------------
+
+// stubChecker is a programmable BreachChecker for CheckBreached tests.
+type stubChecker struct {
+	breached bool
+	err      error
+	gotPw    string
+}
+
+func (s *stubChecker) IsBreached(_ context.Context, plaintext string) (bool, error) {
+	s.gotPw = plaintext
+	return s.breached, s.err
+}
+
+func modWithChecker(t *testing.T, c BreachChecker) *Password {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.BreachChecker = c
+	mod, err := New(fakeProvider{}, cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return mod
+}
+
+func TestCheckBreached_noCheckerConfigured(t *testing.T) {
+	p := newMod(t)
+	err := p.CheckBreached(context.Background(), "anything-Passw0rd!")
+	if !errors.Is(err, ErrNoBreachChecker) {
+		t.Errorf("expected ErrNoBreachChecker, got %v", err)
+	}
+}
+
+func TestCheckBreached_breached(t *testing.T) {
+	p := modWithChecker(t, &stubChecker{breached: true})
+	err := p.CheckBreached(context.Background(), "leaked-Passw0rd!")
+	if !errors.Is(err, ErrBreachedPassword) {
+		t.Errorf("expected ErrBreachedPassword, got %v", err)
+	}
+}
+
+func TestCheckBreached_clean(t *testing.T) {
+	p := modWithChecker(t, &stubChecker{breached: false})
+	if err := p.CheckBreached(context.Background(), "fresh-Passw0rd!"); err != nil {
+		t.Errorf("expected nil for a clean password, got %v", err)
+	}
+}
+
+func TestCheckBreached_checkerErrorIsWrapped(t *testing.T) {
+	sentinel := errors.New("dns boom")
+	p := modWithChecker(t, &stubChecker{err: sentinel})
+	err := p.CheckBreached(context.Background(), "any-Passw0rd!")
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped checker error, got %v", err)
+	}
+	if errors.Is(err, ErrBreachedPassword) {
+		t.Error("a lookup error must not be reported as a breach")
+	}
+}
+
+func TestCheckBreached_normalisesNFC(t *testing.T) {
+	stub := &stubChecker{}
+	p := modWithChecker(t, stub)
+	base := "café-Passw0rd!"
+	if err := p.CheckBreached(context.Background(), norm.NFD.String(base)); err != nil {
+		t.Fatalf("CheckBreached error = %v", err)
+	}
+	if stub.gotPw != norm.NFC.String(base) {
+		t.Errorf("checker received %q, want NFC-normalised form", stub.gotPw)
+	}
+}

--- a/auth/password/config.go
+++ b/auth/password/config.go
@@ -30,6 +30,13 @@ type Config struct {
 	// Set this to the minimum number of CPU cores guaranteed to your service.
 	// Defaults to 2. Minimum 1.
 	Parallelism uint8
+
+	// BreachChecker enables the opt-in known-breach check exposed by
+	// CheckBreached. It is nil by default, keeping the module fully offline and
+	// zero-config; set it to NewHIBPChecker() (network, k-anonymity) or
+	// NewListChecker(...) (offline list) to reject passwords that have already
+	// appeared in a public breach. It does not affect Hash or Verify.
+	BreachChecker BreachChecker
 }
 
 // DefaultConfig returns a Config with OWASP-recommended Argon2id defaults.

--- a/auth/password/errors.go
+++ b/auth/password/errors.go
@@ -46,6 +46,19 @@ var (
 	// Use errors.Unwrap(err).Error() to obtain just the reason without the
 	// "password: does not meet policy requirements: " prefix.
 	ErrWeakPassword = errors.New("password: does not meet policy requirements")
+
+	// ErrBreachedPassword is returned by CheckBreached when the password was
+	// found in a known data breach corpus.
+	//
+	// Safety: CLIENT-SAFE — prompt the user to choose a different password.
+	ErrBreachedPassword = errors.New("password: found in a known data breach")
+
+	// ErrNoBreachChecker is returned by CheckBreached when no BreachChecker is
+	// configured in Config.BreachChecker.
+	//
+	// Safety: INTERNAL — programming error: the caller invoked CheckBreached
+	// without opting in to a breach backend. Treat as a 500.
+	ErrNoBreachChecker = errors.New("password: no breach checker configured")
 )
 
 // policyViolation wraps ErrWeakPassword with a single specific reason so that

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -56,6 +56,7 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/Glyndor/authcore"
 	"golang.org/x/crypto/argon2"
@@ -142,6 +143,10 @@ func (p *Password) ValidatePolicy(plaintext string) error {
 // checkPolicy validates plaintext against the built-in password policy.
 // It runs in O(n) with a single pass and no memory allocations.
 //
+// Length is measured in Unicode characters (runes), not bytes, so a
+// multibyte passphrase is counted the way a user perceives it: a 4-character
+// CJK password is 4 characters, not 12 bytes.
+//
 // Rules:
 //   - Length between 12 and 64 characters.
 //   - At least one uppercase letter (Unicode-aware).
@@ -149,10 +154,11 @@ func (p *Password) ValidatePolicy(plaintext string) error {
 //   - At least one digit.
 //   - At least one special character (anything that is not a letter or digit).
 func checkPolicy(plaintext string) error {
-	if len(plaintext) < 12 {
+	count := utf8.RuneCountInString(plaintext)
+	if count < 12 {
 		return fmt.Errorf("must be at least 12 characters")
 	}
-	if len(plaintext) > 64 {
+	if count > 64 {
 		return fmt.Errorf("must be at most 64 characters")
 	}
 
@@ -254,11 +260,15 @@ func (p *Password) Hash(plaintext string) (string, error) {
 //   - Memory:      8 MiB – 4 GiB (8192 – 4194304 KiB)
 //   - Iterations:  1 – 20
 //   - Parallelism: ≥ 1
+//   - Salt:        exactly 16 bytes
+//   - Key:         exactly 32 bytes
 //
 // The comparison is performed in constant time to prevent timing attacks.
 //
 // Returns ErrInvalidHash when phcHash is malformed, uses a non-Argon2id
-// algorithm, or carries parameters outside the ranges above.
+// algorithm, or carries parameters or salt/key lengths outside the ranges
+// above. A truncated hash never reaches the KDF, so it can neither verify
+// true nor crash the process.
 //
 //	ok, err := pwdMod.Verify(submittedPassword, storedHash)
 //	if errors.Is(err, password.ErrInvalidHash) { ... } // hash is malformed or out of range
@@ -333,6 +343,18 @@ func parsePHC(phcHash string) (Config, []byte, []byte, error) {
 	key, err := base64.RawStdEncoding.DecodeString(parts[5])
 	if err != nil {
 		return Config{}, nil, nil, fmt.Errorf("decode key: %w", err)
+	}
+
+	// Reject hashes whose salt or key are not the fixed sizes Hash produces.
+	// A truncated hash with an empty key segment would otherwise reach
+	// argon2.IDKey with keyLen=0, which panics (nil dereference) and crashes
+	// the process. Enforcing the exact lengths fails closed on any corrupted
+	// or attacker-supplied PHC string before it can reach the KDF.
+	if len(salt) != saltLen {
+		return Config{}, nil, nil, fmt.Errorf("salt has wrong length: got %d bytes, want %d", len(salt), saltLen)
+	}
+	if len(key) != keyLen {
+		return Config{}, nil, nil, fmt.Errorf("derived key has wrong length: got %d bytes, want %d", len(key), keyLen)
 	}
 
 	return cfg, salt, key, nil

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -28,6 +28,20 @@
 // Memory, Iterations, and Parallelism can be increased to match your hardware.
 // The algorithm and output format are never configurable — that's the point.
 //
+// # Rejecting breached passwords (opt-in)
+//
+// Length and composition rules keep out structurally weak passwords; they do
+// not catch a strong-looking password that has already leaked in a public
+// breach. Set Config.BreachChecker to enable an opt-in breach check via
+// CheckBreached — off by default, so the module stays offline and zero-config:
+//
+//	cfg := password.DefaultConfig()
+//	cfg.BreachChecker = password.NewHIBPChecker() // HaveIBeenPwned, k-anonymity
+//	pwdMod, _ := password.New(auth, cfg)
+//	if err := pwdMod.CheckBreached(ctx, userPassword); errors.Is(err, password.ErrBreachedPassword) {
+//	    // ask the user for a different password
+//	}
+//
 // # Full usage
 //
 //	// Startup — one instance, shared across all goroutines.

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -445,6 +445,30 @@ func TestVerify_malformedStoredHashIsRejectedBeforeKeyDerivation(t *testing.T) {
 	}
 }
 
+func TestVerify_emptyKeySegmentRejectedNotPanic(t *testing.T) {
+	p := newMod(t)
+
+	// A truncated hash with an empty key segment reaches argon2.IDKey with
+	// keyLen=0, which panics (nil dereference) and crashes the process.
+	// parsePHC must reject it as ErrInvalidHash, never derive a key.
+	cases := map[string]string{
+		"empty key":  "$argon2id$v=19$m=65536,t=3,p=2$AAAAAAAAAAAAAAAAAAAAAA$",
+		"empty salt": "$argon2id$v=19$m=65536,t=3,p=2$$" + strings.Repeat("A", 43),
+		"short key":  "$argon2id$v=19$m=65536,t=3,p=2$AAAAAAAAAAAAAAAAAAAAAA$a2V5",
+	}
+	for name, h := range cases {
+		t.Run(name, func(t *testing.T) {
+			ok, err := p.Verify("any-password-we-do-not-care", h)
+			if ok {
+				t.Fatalf("%s: malformed hash must never verify true", name)
+			}
+			if !errors.Is(err, ErrInvalidHash) {
+				t.Errorf("%s: expected ErrInvalidHash, got %v", name, err)
+			}
+		})
+	}
+}
+
 // ---- DefaultConfig() --------------------------------------------------------
 
 func TestDefaultConfig_values(t *testing.T) {

--- a/docs/password.md
+++ b/docs/password.md
@@ -76,6 +76,46 @@ hash cannot force `argon2.IDKey` into an unbounded memory allocation.
 > on macOS (precomposed `é`) or Linux (decomposed `e` + combining acute), so
 > cross-platform account access works out of the box.
 
+## Rejecting breached passwords (optional)
+
+A password can satisfy every composition rule and still be terrible because it
+has already leaked in a public breach. That check is opt-in and **off by
+default**, so the module stays fully offline and zero-config until you ask for
+it — exactly like the email module's DNS check.
+
+Enable it by setting a `BreachChecker` on the config, then call `CheckBreached`
+at registration or password change (after `ValidatePolicy`, before `Hash`):
+
+```go
+cfg := password.DefaultConfig()
+cfg.BreachChecker = password.NewHIBPChecker() // HaveIBeenPwned, k-anonymity
+pwdMod, _ := password.New(auth, cfg)
+
+ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+defer cancel()
+switch err := pwdMod.CheckBreached(ctx, req.Password); {
+case errors.Is(err, password.ErrBreachedPassword):
+    // 400 — ask the user to choose a different password
+case err != nil:
+    // network/lookup error — log it and decide your policy (fail open or closed)
+}
+```
+
+`NewHIBPChecker` never transmits the password or its full hash: it sends only
+the first **five** hex characters of the SHA-1 digest to the HaveIBeenPwned
+range API and compares the returned suffixes locally (k-anonymity). The SHA-1
+here guards that prefix lookup — it is **not** password storage, which is always
+Argon2id.
+
+For an air-gapped deployment, use a local list instead — no network at all:
+
+```go
+cfg.BreachChecker = password.NewListChecker(myCommonPasswordList)
+```
+
+You can also supply your own backend by implementing the `BreachChecker`
+interface (`IsBreached(ctx, plaintext) (bool, error)`).
+
 ## Tuning work parameters (optional)
 
 The defaults are sized for 2 vCPUs / 4 GiB RAM. On more powerful hardware, crank

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -52,6 +52,32 @@ func readCapped(path string) ([]byte, error) {
 	return data, nil
 }
 
+// checkKeyDirConsistency verifies that the key directory is either empty of all
+// managed key files or holds the full set. A partially-populated directory —
+// for example the Ed25519 pair present but refresh_secret.key deleted — is
+// rejected before anything is generated, so the manager never silently mints a
+// new refresh secret that would invalidate every refresh-token hash already
+// stored by the consumer (forcing all users to log in again).
+func checkKeyDirConsistency(dir string) error {
+	files := []string{filePrivateKey, filePublicKey, fileRefreshSecret}
+	var present, missing []string
+	for _, name := range files {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			present = append(present, name)
+		} else {
+			missing = append(missing, name)
+		}
+	}
+	if len(present) > 0 && len(missing) > 0 {
+		return fmt.Errorf(
+			"key directory %q is in an inconsistent state: present {%s}, missing {%s}; "+
+				"restore the missing file(s), or delete all key files to trigger a clean regeneration",
+			dir, strings.Join(present, ", "), strings.Join(missing, ", "),
+		)
+	}
+	return nil
+}
+
 // ----- Ed25519 key pair -------------------------------------------------------
 
 // loadOrGenerateEd25519 returns an Ed25519 key pair, generating and

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -79,6 +79,13 @@ func New(dir string, log logger) (*KeyManager, error) {
 		return nil, fmt.Errorf("write .gitignore in %q: %w", dir, err)
 	}
 
+	// Fail closed on a partially-populated directory before generating anything,
+	// so a missing refresh secret beside an existing key pair is reported rather
+	// than silently regenerated (which would invalidate stored refresh hashes).
+	if err := checkKeyDirConsistency(dir); err != nil {
+		return nil, err
+	}
+
 	priv, pub, err := loadOrGenerateEd25519(dir, log)
 	if err != nil {
 		return nil, fmt.Errorf("ed25519 key pair: %w", err)

--- a/internal/keymanager/keymanager_test.go
+++ b/internal/keymanager/keymanager_test.go
@@ -106,6 +106,30 @@ func TestNew_generatesAllFiles(t *testing.T) {
 	}
 }
 
+func TestNew_partialKeyDirIsRejected(t *testing.T) {
+	// Removing any single managed file while the others remain must fail closed,
+	// rather than silently regenerating it. A regenerated refresh secret would
+	// invalidate every stored refresh-token hash.
+	for _, remove := range []string{
+		"refresh_secret.key",
+		"ed25519_private.pem",
+		"ed25519_public.pem",
+	} {
+		t.Run("missing_"+remove, func(t *testing.T) {
+			dir := t.TempDir()
+			if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+				t.Fatalf("initial New() error = %v", err)
+			}
+			if err := os.Remove(filepath.Join(dir, remove)); err != nil {
+				t.Fatalf("remove %q: %v", remove, err)
+			}
+			if _, err := keymanager.New(dir, testLogger{t}); err == nil {
+				t.Errorf("expected an error for a key dir missing %q, got nil", remove)
+			}
+		})
+	}
+}
+
 func TestNew_keyMaterialHasCorrectSize(t *testing.T) {
 	km := newKM(t)
 


### PR DESCRIPTION
Release v1.3.0 — review hardening plus the opt-in breached-password check.

## Highlights

**Feature**
- `auth/password`: opt-in known-breach check — `BreachChecker` interface, `NewHIBPChecker` (HaveIBeenPwned, k-anonymity), `NewListChecker` (offline), and `Password.CheckBreached`. Off by default; `Hash`/`Verify` stay offline. (#118)

**Fixes (security / correctness)**
- `auth/password`: reject malformed PHC hashes before key derivation — a truncated hash with an empty key segment used to panic the verifier; now fails closed with `ErrInvalidHash`. (#115)
- `auth/password`: measure policy length in runes, not bytes. (#117)
- `auth/email`: `Close` is now safe under concurrent calls (`sync.Once`). (#116)
- `auth/email`: reject address-literal domains (`user@[192.168.1.1]`). (#119)
- `auth/jwt`: reject empty or whitespace-only audience entries. (#120)
- `internal/keymanager`: fail closed on a partially-populated key directory instead of silently regenerating the refresh secret. (#121)

**Docs**
- `auth/jwt`: clarified that the `jti` identifies the session, not an individual access token.

No breaking API changes — new symbols are additive; the new input validations only reject input that was already invalid or unsafe.