### PR TITLE
refactor: API ergonomics & consistency (no goroutine, uniform constructors, docs)

### DIFF
--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -18,7 +18,6 @@
 // Always store and query emails using this canonical form:
 //
 //	emailMod, _ := email.New(auth)
-//	defer emailMod.Close()
 //
 //	// Registration
 //	normalized, err := emailMod.ValidateAndNormalize(req.Email)
@@ -91,78 +90,51 @@ type cacheEntry struct {
 
 // Email is the email validation and normalization module.
 // Create one instance at startup via New and reuse it — it is safe for
-// concurrent use after construction.
-//
-// Call [Email.Close] when the module is no longer needed to stop the
-// background cache eviction goroutine.
+// concurrent use after construction. It owns no background goroutine and
+// needs no cleanup; like the other modules, you construct it and use it.
 type Email struct {
-	log       authcore.Logger
-	resolver  *net.Resolver
-	cacheTTL  time.Duration
-	mu        sync.RWMutex
-	cache     map[string]cacheEntry
-	group     singleflight.Group
-	done      chan struct{}
-	closeOnce sync.Once
+	log      authcore.Logger
+	resolver *net.Resolver
+	cacheTTL time.Duration
+	mu       sync.RWMutex
+	cache    map[string]cacheEntry
+	group    singleflight.Group
 }
 
-// New creates an Email module using the provider's logger and starts a
-// background goroutine that evicts expired cache entries.
-//
-// Always call [Email.Close] when the module is no longer needed — typically
-// via defer at the call site — to stop the background goroutine and prevent
-// a goroutine leak:
+// New creates an Email module using the provider's logger.
 //
 //	emailMod, err := email.New(auth)
 //	if err != nil { ... }
-//	defer emailMod.Close()
 func New(p authcore.Provider) (*Email, error) {
 	e := &Email{
 		log:      p.Logger(),
 		resolver: net.DefaultResolver,
 		cacheTTL: DefaultCacheTTL,
 		cache:    make(map[string]cacheEntry),
-		done:     make(chan struct{}),
 	}
-	go e.evictLoop()
 	e.log.Info("email: module initialised")
 	return e, nil
 }
 
-// Close stops the background cache eviction goroutine.
-// It is safe to call Close multiple times and from multiple goroutines
-// concurrently; the channel is closed exactly once via sync.Once.
-// After Close, VerifyDomain continues to work but expired entries are no
-// longer evicted automatically.
-func (e *Email) Close() {
-	e.closeOnce.Do(func() { close(e.done) })
-}
+// Close is a no-op retained for backward compatibility.
+//
+// The module no longer runs a background goroutine: the MX cache evicts
+// expired entries lazily when it fills (see store), and reads always ignore
+// expired entries. Nothing needs to be released, so calling Close is optional
+// and always safe — including multiple times and from multiple goroutines.
+func (e *Email) Close() {}
 
-// evictLoop runs in a background goroutine and periodically removes expired
-// cache entries. This keeps memory bounded without touching the hot path.
-func (e *Email) evictLoop() {
-	ticker := time.NewTicker(e.cacheTTL / 2)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			e.evictExpired()
-		case <-e.done:
-			return
-		}
-	}
-}
-
-// evictExpired deletes all expired entries from the cache.
+// evictExpired deletes all expired entries from the cache, taking the write
+// lock itself.
 func (e *Email) evictExpired() {
-	now := time.Now()
 	e.mu.Lock()
+	defer e.mu.Unlock()
+	now := time.Now()
 	for k, v := range e.cache {
 		if now.After(v.expiresAt) {
 			delete(e.cache, k)
 		}
 	}
-	e.mu.Unlock()
 }
 
 // Name implements authcore.Module.
@@ -350,15 +322,24 @@ func (e *Email) cached(domain string) (cacheEntry, bool) {
 	return entry, ok && time.Now().Before(entry.expiresAt)
 }
 
-// store writes entry into the cache under write lock.
-// If the cache is at maxCacheSize the entry is silently dropped —
-// background eviction will free space and the next lookup retries DNS.
+// store writes entry into the cache under write lock. When the cache is full,
+// it first drops expired entries to make room (lazy eviction — this is what
+// replaces the old background goroutine); if it is still full afterwards the
+// entry is dropped and the next lookup retries DNS.
 func (e *Email) store(domain string, entry cacheEntry) {
 	e.mu.Lock()
+	defer e.mu.Unlock()
+	if len(e.cache) >= maxCacheSize {
+		now := time.Now()
+		for k, v := range e.cache {
+			if now.After(v.expiresAt) {
+				delete(e.cache, k)
+			}
+		}
+	}
 	if len(e.cache) < maxCacheSize {
 		e.cache[domain] = entry
 	}
-	e.mu.Unlock()
 }
 
 // entryErr converts a cache entry into the appropriate sentinel error.

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -69,33 +69,41 @@ type JWT[T any] struct {
 // New creates and returns a JWT module.
 //
 // T is the application-specific claims type embedded in access tokens.
-// Use struct{} if no custom claims are needed:
+// Use struct{} if no custom claims are needed.
 //
-//	jwtMod, err := jwt.New[struct{}](auth, jwt.DefaultConfig())
+// cfg is optional — omit it to use safe defaults (15-minute access tokens,
+// 24-hour refresh tokens, EdDSA), matching the zero-config shape of the other
+// modules. Pass a Config only to override lifetimes, issuer, or audience:
+//
+//	jwtMod, err := jwt.New[struct{}](auth)                    // defaults
+//	jwtMod, err := jwt.New[MyClaims](auth, jwt.DefaultConfig()) // explicit/custom
 //
 // p provides the Ed25519 signing keys, the HMAC secret, the logger, and the
 // timezone — all sourced from the parent AuthCore instance.
-// cfg controls token lifetimes and the issuer claim.
-func New[T any](p authcore.Provider, cfg Config) (*JWT[T], error) {
-	cfg = applyDefaults(cfg)
+func New[T any](p authcore.Provider, cfg ...Config) (*JWT[T], error) {
+	var resolved Config
+	if len(cfg) > 0 {
+		resolved = cfg[0]
+	}
+	resolved = applyDefaults(resolved)
 
-	if err := validateConfig(cfg); err != nil {
+	if err := validateConfig(resolved); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
 	}
 
 	j := &JWT[T]{
-		cfg:             cfg,
+		cfg:             resolved,
 		log:             p.Logger(),
 		priv:            p.Keys().PrivateKey(),
 		pub:             p.Keys().PublicKey(),
 		secret:          p.Keys().RefreshSecret(),
 		kid:             p.Keys().KeyID(),
 		clock:           clock.New(p.Config().Timezone),
-		primaryAudience: cfg.Audience[0], // validateConfig guarantees len >= 1
+		primaryAudience: resolved.Audience[0], // validateConfig guarantees len >= 1
 	}
 
 	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s)",
-		cfg.Issuer, cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
+		resolved.Issuer, resolved.AccessTokenTTL, resolved.RefreshTokenTTL)
 
 	return j, nil
 }

--- a/auth/jwt/jwt_refresh_test.go
+++ b/auth/jwt/jwt_refresh_test.go
@@ -223,6 +223,29 @@ func TestNew_negativeLeewayReturnsErrInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestNew_zeroConfigUsesDefaults(t *testing.T) {
+	// jwt.New is variadic: omitting Config must apply safe defaults, matching
+	// the zero-config shape of the other modules.
+	j, err := New[struct{}](newFakeProvider(t))
+	if err != nil {
+		t.Fatalf("New without config error = %v", err)
+	}
+	if j.cfg.AccessTokenTTL != DefaultConfig().AccessTokenTTL {
+		t.Errorf("AccessTokenTTL = %s, want default %s", j.cfg.AccessTokenTTL, DefaultConfig().AccessTokenTTL)
+	}
+	if j.cfg.Issuer != DefaultConfig().Issuer {
+		t.Errorf("Issuer = %q, want default %q", j.cfg.Issuer, DefaultConfig().Issuer)
+	}
+	// And it must actually work end-to-end with no config.
+	pair, err := j.CreateTokens(testSubject, struct{}{})
+	if err != nil {
+		t.Fatalf("CreateTokens error = %v", err)
+	}
+	if _, err := j.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Errorf("VerifyAccessToken error = %v", err)
+	}
+}
+
 func TestNew_emptyAudienceEntryReturnsErrInvalidConfig(t *testing.T) {
 	for _, aud := range [][]string{
 		{""},

--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -112,6 +112,32 @@ db.ReplaceRefreshHash(session.ID, newPair.RefreshTokenHash)
 // 6. Send the new tokens to the client.
 ```
 
+## Revocation & logout
+
+Access tokens are **stateless JWTs**: once issued, an access token stays valid
+until its `exp` (the `AccessTokenTTL`, 15 minutes by default). The library holds
+no session store, so there is no way to invalidate an individual access token
+before it expires.
+
+This matters for logout. Deleting the stored refresh-token hash on logout stops
+the session from being **renewed**, but it does **not** kill the access token
+the client already holds — that token keeps working until it expires.
+
+```go
+// Logout: delete the refresh hash so the session cannot be renewed.
+db.DeleteSessionByHash(jwtMod.HashRefreshToken(clientToken))
+// The current access token still works for up to AccessTokenTTL. Plan for it.
+```
+
+What to do about it:
+
+- **Good enough for most apps:** keep `AccessTokenTTL` short (the 15-minute
+  default) so a logged-out token dies quickly on its own.
+- **Need instant kill** (logout-everywhere, compromised account): maintain your
+  own denylist keyed by the `SessionID`/`jti` (it is stable across rotations)
+  and check it in your middleware after `VerifyAccessToken`, or shorten
+  `AccessTokenTTL` further.
+
 ## Clock skew tolerance
 
 In distributed systems, server clocks may drift by a few seconds. Set

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -75,6 +75,14 @@ func New(dir string, log logger) (*KeyManager, error) {
 		return nil, fmt.Errorf("create key directory %q: %w", dir, err)
 	}
 
+	// MkdirAll does not tighten a directory that already exists, so a pre-created
+	// or volume-mounted KeysDir could sit at a looser mode (e.g. 0755). Tighten
+	// it to owner-only. A failure here is not fatal — the private key and refresh
+	// secret are still written 0600 — so warn rather than abort.
+	if err := os.Chmod(dir, dirMode); err != nil {
+		log.Warn("authcore/keymanager: could not tighten key directory %q to %o: %v", dir, dirMode, err)
+	}
+
 	if err := ensureGitignore(dir); err != nil {
 		return nil, fmt.Errorf("write .gitignore in %q: %w", dir, err)
 	}

--- a/module.go
+++ b/module.go
@@ -62,19 +62,21 @@ type Provider interface {
 // Available implementations and their concrete constructors:
 //
 //	auth/jwt      — JSON Web Token authentication (EdDSA / Ed25519)
-//	                  jwt.New[T any](p authcore.Provider, cfg jwt.Config) (*jwt.JWT[T], error)
+//	                  jwt.New[T any](p authcore.Provider, cfg ...jwt.Config) (*jwt.JWT[T], error)
 //	auth/password — Argon2id password hashing
 //	                  password.New(p authcore.Provider, cfg ...password.Config) (*password.Password, error)
 //	auth/email    — email validation, normalization, DNS MX verification
-//	                  email.New(p authcore.Provider, cfg ...email.Config) (*email.Email, error)
+//	                  email.New(p authcore.Provider) (*email.Email, error)
 //	auth/username — username validation, normalization, reserved name blocklist
 //	                  username.New(p authcore.Provider) (*username.Username, error)
 //
 // Conventions shared by every module:
 //
 //  1. The first argument is always an authcore.Provider (never a concrete *AuthCore).
-//  2. Omitting cfg (where variadic) or passing a zero-value Config applies safe,
-//     production-ready defaults via each module's applyDefaults helper.
+//  2. Where a module takes a Config, it is variadic-optional: omit it, or pass a
+//     zero-value Config, to apply safe production defaults via applyDefaults.
+//     The email and username modules need no Config. Construct any module and
+//     use it — none requires cleanup.
 //  3. Constructors return a pointer receiver; concrete types are safe for
 //     concurrent use across goroutines after construction completes.
 type Module interface {


### PR DESCRIPTION
Ergonomics and consistency pass so a developer learns one pattern and reuses it, with no footgun. No security default changes — the core stays secure-by-default. All additive/compatible, nothing breaking.

- **email: no more background goroutine.** It was the only module that needed `Close()` or it leaked a goroutine. The MX cache now evicts lazily (reads already skip expired entries; `store` drops expired ones when full). `Close()` is kept as a no-op for compatibility, so forgetting it can never leak. Construct and use, like the other three modules.
- **jwt.New is variadic.** `jwt.New[T](auth)` now works with safe defaults, matching `password.New`. Passing a `Config` still compiles — additive, not breaking.
- **keymanager tightens an existing KeysDir to 0700.** `MkdirAll` does not re-chmod an existing dir; a pre-created/volume-mounted dir could stay loose. Failure only warns (secrets are 0600 regardless).
- **Docs fixed.** `module.go` documented a non-existent `email.New(p, cfg ...email.Config)` (real is `email.New(p)`) — corrected, plus the jwt variadic signature and the real per-module Config pattern. `docs/jwt.md` gains a Revocation & logout section: deleting the refresh hash does not kill an already-issued stateless access token (it lives until `AccessTokenTTL`).

`go build`, `go vet`, `golangci-lint` (0 issues) and the full suite with `-race` pass. Aggregate coverage 91.6%.
