### PR TITLE
fix(keymanager): support a read-only KeysDir mount

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,24 +79,18 @@ func validateConfig(cfg Config) error {
 	return nil
 }
 
-// validateKeysDir ensures KeysDir can be created and written to.
-// Catching this early gives a clear error before the key manager tries to
-// generate or load key files.
+// validateKeysDir ensures KeysDir exists (creating it if possible).
+//
+// It deliberately does NOT probe for writability. A read-only KeysDir is a
+// valid and recommended deployment: pre-generated keys mounted read-only into
+// a container (see docs/key-management.md). Whether the directory needs to be
+// written to depends on whether the key files already exist — that is the key
+// manager's concern. When generation is actually required, the key manager
+// surfaces a clear write error (wrapped as ErrKeyManager); when the keys are
+// already present, no write happens and a read-only mount loads fine.
 func validateKeysDir(dir string) error {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("cannot create keys directory %q: %w", dir, err)
-	}
-	tmp, err := os.CreateTemp(dir, ".authcore-write-check-*")
-	if err != nil {
-		return fmt.Errorf("keys directory %q is not writable: %w", dir, err)
-	}
-	name := tmp.Name()
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(name)
-		return fmt.Errorf("keys directory %q write check failed: %w", dir, err)
-	}
-	if err := os.Remove(name); err != nil {
-		return fmt.Errorf("keys directory %q write check cleanup failed: %w", dir, err)
 	}
 	return nil
 }

--- a/config_coverage_test.go
+++ b/config_coverage_test.go
@@ -1,37 +1,44 @@
 package authcore_test
 
 import (
-	"errors"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/Glyndor/authcore"
 )
 
-// TestNew_unwritableKeysDirReturnsError covers the write-check error path in
-// validateKeysDir: a directory that exists but cannot be written to must be
-// rejected before the key manager runs. Skipped when running as root, which
-// bypasses filesystem permission bits.
-func TestNew_unwritableKeysDirReturnsError(t *testing.T) {
+// TestNew_keysDirWithExistingKeysIsNotWriteProbed verifies that, once the key
+// files exist, New does not require the directory to be writable — the
+// recommended container deployment mounts pre-generated keys read-only. New
+// must load them instead of refusing to start over a write check.
+func TestNew_keysDirWithExistingKeysIsNotWriteProbed(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root bypasses directory permission bits")
 	}
 
-	dir := filepath.Join(t.TempDir(), "readonly")
-	if err := os.Mkdir(dir, 0500); err != nil { // r-x: present but not writable
-		t.Fatalf("create read-only dir: %v", err)
-	}
+	dir := t.TempDir()
 
 	cfg := authcore.DefaultConfig()
 	cfg.EnableLogs = false
 	cfg.KeysDir = dir
 
-	_, err := authcore.New(cfg)
-	if err == nil {
-		t.Fatal("expected error for unwritable keys directory, got nil")
+	// First run generates the key files.
+	if _, err := authcore.New(cfg); err != nil {
+		t.Fatalf("initial New: %v", err)
 	}
-	if !errors.Is(err, authcore.ErrInvalidConfig) {
-		t.Errorf("error = %v, want ErrInvalidConfig", err)
+
+	// Restrict the directory to read+execute (no write), as a read-only secret
+	// mount would, and reload. With the keys already present this must succeed.
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	ac, err := authcore.New(cfg)
+	if err != nil {
+		t.Fatalf("New with existing keys in a restricted dir must succeed, got %v", err)
+	}
+	if ac.Keys() == nil || len(ac.Keys().PrivateKey()) == 0 {
+		t.Error("keys were not loaded from the existing directory")
 	}
 }

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -13,13 +13,48 @@ On subsequent starts the files are loaded and the key pair is validated for
 consistency. If only one PEM file is present, `New()` returns `ErrKeyManager` —
 delete both to regenerate.
 
-**In containers or CI**, point `KeysDir` at a mounted secrets volume:
+## Containers & multiple replicas
+
+The zero-config default persists keys to `.authcore` in the working directory.
+That is fine on a host with a durable disk, but a container filesystem is
+**ephemeral** and a deployment usually runs **more than one replica**. With the
+default, two things break — silently:
+
+> [!WARNING]
+> - **On restart / redeploy** the `.authcore` directory is gone, so authcore
+>   generates a **new** key pair (it logs a `WARN`). Every access token already
+>   issued fails signature verification and every refresh-token hash stored in
+>   your database stops matching — **every user is logged out**.
+> - **With multiple replicas** each pod generates **its own** key pair, so a
+>   token minted by pod A is rejected by pod B (different `kid` and signature).
+>   Behind a load balancer, login appears to fail at random.
+
+The fix is to give every instance the **same, stable** keys. Generate them once,
+then mount them **read-only** into every replica:
 
 ```go
 cfg := authcore.DefaultConfig()
 cfg.KeysDir = os.Getenv("AUTHCORE_KEYS_DIR") // e.g. /run/secrets/authcore
 auth, err := authcore.New(cfg)
 ```
+
+1. **Pre-generate once** — run authcore in a one-shot job pointed at the volume,
+   or generate the three files (`ed25519_private.pem`, `ed25519_public.pem`,
+   `refresh_secret.key`) with any Ed25519 tool, and store them as a Kubernetes
+   Secret / Docker secret.
+2. **Mount the *same* set read-only** into every replica at `KeysDir`. Do **not**
+   give each pod a writable empty volume — each would generate its own keys and
+   reintroduce the multi-replica break above.
+3. Keep the volume durable across restarts so the keys (and therefore live
+   sessions) survive a redeploy.
+
+> [!NOTE]
+> A read-only `KeysDir` works: when all three files already exist, authcore only
+> loads and validates them — it never writes. It writes only when generating a
+> missing file on first run, which a pre-generated mount avoids entirely.
+
+A pluggable key source (env / secret manager / KMS instead of files) is on the
+roadmap for deployments that prefer not to use a mounted volume.
 
 The `KeyID()` accessor returns a 16-character hex digest derived from the public
 key. It is embedded in every token's `kid` JOSE header, enabling zero-downtime

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -83,8 +83,11 @@ func New(dir string, log logger) (*KeyManager, error) {
 		log.Warn("authcore/keymanager: could not tighten key directory %q to %o: %v", dir, dirMode, err)
 	}
 
+	// The .gitignore is a convenience guard against committing keys; it is not
+	// security-critical. On a read-only KeysDir (a mounted secret) the write
+	// fails harmlessly — warn and carry on rather than refusing to start.
 	if err := ensureGitignore(dir); err != nil {
-		return nil, fmt.Errorf("write .gitignore in %q: %w", dir, err)
+		log.Warn("authcore/keymanager: could not write .gitignore in %q (continuing): %v", dir, err)
 	}
 
 	// Fail closed on a partially-populated directory before generating anything,


### PR DESCRIPTION
The recommended container deployment mounts pre-generated keys read-only at `KeysDir` (a Kubernetes/Docker secret), but it did not actually work: `validateKeysDir` ran an unconditional writability probe (`CreateTemp`) on every `New`, so a read-only mount failed with `ErrInvalidConfig` even when all key files were already present and only needed loading. Confirmed empirically.

Fix:
- Drop the eager write-probe in `validateKeysDir` — keep only `MkdirAll`. Whether a write is needed depends on whether the keys exist, which is the key manager's concern.
- Make the `.gitignore` write best-effort (warn, do not abort) so a read-only mount does not fail on it.

Result: keys already present in a read-only `KeysDir` load fine; when generation is genuinely needed and the directory is unwritable, the key manager still returns a clear `ErrKeyManager`.

Docs: `docs/key-management.md` gains a "Containers & multiple replicas" section that states the failure mode of the default (every user logged out on redeploy because the ephemeral `.authcore` regenerates keys; intermittent login across replicas because each pod signs with its own key) and the fix (pre-generate once, mount the same set read-only into every replica).

Test updated to assert that existing keys in a restricted dir load instead of being rejected.

`go build`, `go vet`, `golangci-lint` (0 issues) and the full suite with `-race` pass.

Closes #139