### PR TITLE
feat(jwt): optional access-token denylist for instant revocation

### DIFF
--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -47,6 +47,12 @@ type Config struct {
 	// Defaults to 0 (no leeway). A value of 30 seconds is typical for production deployments.
 	// Must not be negative.
 	ClockSkewLeeway time.Duration
+
+	// Denylist optionally makes access tokens revocable before they expire.
+	// It is nil by default, keeping the stateless fast path (no per-request
+	// lookup). Set it to consult your own revocation store on each
+	// VerifyAccessToken, keyed by the session jti. See the Denylist type.
+	Denylist Denylist
 }
 
 // DefaultConfig returns a Config with safe, production-ready defaults.

--- a/auth/jwt/denylist.go
+++ b/auth/jwt/denylist.go
@@ -1,0 +1,33 @@
+package jwt
+
+import "context"
+
+// Denylist is the optional, opt-in hook that makes a stateless access token
+// revocable before it expires.
+//
+// Access tokens are stateless JWTs: by default the only thing bounding an issued
+// token is its expiry (AccessTokenTTL). That is enough for most applications.
+// When you need instant revocation — logout-everywhere, a compromised account,
+// an admin force-logout — set Config.Denylist to an implementation backed by
+// your own store (in-memory, Redis, a database table) and VerifyAccessToken
+// will reject any token whose session has been revoked.
+//
+// The denylist is keyed by the token's "jti", which equals the TokenPair
+// SessionID and is stable across rotations — so revoking one entry kills the
+// whole session, every access token in it, immediately.
+//
+// Leaving Config.Denylist nil keeps the stateless fast path: no lookup, no
+// store, no per-request cost.
+type Denylist interface {
+	// IsRevoked reports whether the session identified by jti has been revoked.
+	//
+	// It is called only for an access token that has already passed signature,
+	// expiry, audience and type checks, so it runs at most once per valid
+	// request. Return (false, nil) when the session is active. A non-nil error
+	// is surfaced to the caller wrapped, and must fail closed — the token is
+	// not accepted — so a store outage cannot silently bypass revocation.
+	//
+	// Implementations must be safe for concurrent use and should be fast; honour
+	// ctx for cancellation and deadlines.
+	IsRevoked(ctx context.Context, jti string) (bool, error)
+}

--- a/auth/jwt/denylist_test.go
+++ b/auth/jwt/denylist_test.go
@@ -1,0 +1,105 @@
+package jwt
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// stubDenylist is a programmable Denylist for tests.
+type stubDenylist struct {
+	revoked bool
+	err     error
+	gotJTI  string
+	calls   int
+}
+
+func (s *stubDenylist) IsRevoked(_ context.Context, jti string) (bool, error) {
+	s.calls++
+	s.gotJTI = jti
+	return s.revoked, s.err
+}
+
+func jwtWithDenylist(t *testing.T, d Denylist) *JWT[struct{}] {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Denylist = d
+	return newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+}
+
+func TestVerifyAccessToken_denylistRevoked(t *testing.T) {
+	stub := &stubDenylist{revoked: true}
+	j := jwtWithDenylist(t, stub)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	_, err := j.VerifyAccessToken(pair.AccessToken)
+	if !errors.Is(err, ErrTokenRevoked) {
+		t.Fatalf("expected ErrTokenRevoked, got %v", err)
+	}
+	if stub.gotJTI != pair.SessionID {
+		t.Errorf("denylist queried jti %q, want SessionID %q", stub.gotJTI, pair.SessionID)
+	}
+}
+
+func TestVerifyAccessToken_denylistActive(t *testing.T) {
+	stub := &stubDenylist{revoked: false}
+	j := jwtWithDenylist(t, stub)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	if _, err := j.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Fatalf("a non-revoked token must verify, got %v", err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("denylist calls = %d, want 1", stub.calls)
+	}
+}
+
+func TestVerifyAccessToken_denylistErrorFailsClosed(t *testing.T) {
+	sentinel := errors.New("redis down")
+	j := jwtWithDenylist(t, &stubDenylist{err: sentinel})
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	_, err := j.VerifyAccessToken(pair.AccessToken)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected the wrapped store error, got %v", err)
+	}
+	if errors.Is(err, ErrTokenRevoked) {
+		t.Error("a store error must not be reported as a clean revocation")
+	}
+}
+
+func TestVerifyAccessToken_denylistNotCalledForInvalidToken(t *testing.T) {
+	stub := &stubDenylist{}
+	j := jwtWithDenylist(t, stub)
+
+	// A garbage token fails signature/format before any denylist lookup.
+	if _, err := j.VerifyAccessToken("not.a.jwt"); err == nil {
+		t.Fatal("expected an error for a malformed token")
+	}
+	if stub.calls != 0 {
+		t.Errorf("denylist must not be consulted for an invalid token; calls = %d", stub.calls)
+	}
+}
+
+func TestVerifyAccessToken_noDenylistSkipsLookup(t *testing.T) {
+	// Default config has no denylist; verification must not require one.
+	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+	if _, err := j.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Fatalf("verify without a denylist must succeed, got %v", err)
+	}
+}
+
+func TestVerifyAccessTokenContext_passesContext(t *testing.T) {
+	stub := &stubDenylist{}
+	j := jwtWithDenylist(t, stub)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	ctx := context.Background()
+	if _, err := j.VerifyAccessTokenContext(ctx, pair.AccessToken); err != nil {
+		t.Fatalf("VerifyAccessTokenContext error = %v", err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("denylist calls = %d, want 1", stub.calls)
+	}
+}

--- a/auth/jwt/errors.go
+++ b/auth/jwt/errors.go
@@ -58,4 +58,12 @@ var (
 	//
 	// Safety: INTERNAL — programming error in the caller. Treat as a 500.
 	ErrInvalidSubject = errors.New("jwt: subject must be a valid UUID v7")
+
+	// ErrTokenRevoked is returned by VerifyAccessToken when a configured
+	// Denylist reports the token's session as revoked. The token's signature
+	// and expiry were valid; it was explicitly killed.
+	//
+	// Safety: INTERNAL — return a generic "unauthorized" to the client, which
+	// should re-authenticate.
+	ErrTokenRevoked = errors.New("jwt: token has been revoked")
 )

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/subtle"
 	"fmt"
@@ -64,6 +65,7 @@ type JWT[T any] struct {
 	kid             string      // JOSE "kid" header value, derived from the public key
 	clock           clock.Clock // injected; replaced by clock.Fixed in tests
 	primaryAudience string      // cfg.Audience[0] snapshotted at construction; immune to post-init mutation
+	denylist        Denylist    // optional; nil means access tokens are never checked for revocation
 }
 
 // New creates and returns a JWT module.
@@ -100,6 +102,7 @@ func New[T any](p authcore.Provider, cfg ...Config) (*JWT[T], error) {
 		kid:             p.Keys().KeyID(),
 		clock:           clock.New(p.Config().Timezone),
 		primaryAudience: resolved.Audience[0], // validateConfig guarantees len >= 1
+		denylist:        resolved.Denylist,
 	}
 
 	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s)",
@@ -192,18 +195,41 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 //	                        or iss/aud claim does not match Config
 //	jwt.ErrTokenMalformed — not a valid three-part JWT string
 //	jwt.ErrWrongTokenType — token is a refresh token, not an access token
+//	jwt.ErrTokenRevoked   — a configured Denylist reports the token's session revoked
 //
 // Use errors.Is for error inspection:
 //
 //	claims, err := jwtMod.VerifyAccessToken(token)
 //	if errors.Is(err, jwt.ErrTokenExpired) { ... }
+//
+// When a Denylist is configured (Config.Denylist), this uses a background
+// context for the revocation lookup. Use VerifyAccessTokenContext to pass your
+// own context (recommended for a network-backed denylist).
 func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
+	return j.VerifyAccessTokenContext(context.Background(), token)
+}
+
+// VerifyAccessTokenContext is VerifyAccessToken with an explicit context that
+// is passed to the configured Denylist (if any). The context bounds only the
+// revocation lookup; signature and expiry checks are local and never block.
+func (j *JWT[T]) VerifyAccessTokenContext(ctx context.Context, token string) (*Claims[T], error) {
 	c, err := verifyAccessToken[T](token, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}
 	if c.Type != tokenTypeAccess {
 		return nil, ErrWrongTokenType
+	}
+	// Revocation is checked last — only an otherwise-valid access token is worth
+	// a denylist lookup, so a garbage or expired token never reaches the store.
+	if j.denylist != nil {
+		revoked, err := j.denylist.IsRevoked(ctx, c.ID)
+		if err != nil {
+			return nil, fmt.Errorf("jwt: denylist lookup: %w", err)
+		}
+		if revoked {
+			return nil, ErrTokenRevoked
+		}
 	}
 	return accessClaimsToClaims(c), nil
 }

--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -133,10 +133,36 @@ What to do about it:
 
 - **Good enough for most apps:** keep `AccessTokenTTL` short (the 15-minute
   default) so a logged-out token dies quickly on its own.
-- **Need instant kill** (logout-everywhere, compromised account): maintain your
-  own denylist keyed by the `SessionID`/`jti` (it is stable across rotations)
-  and check it in your middleware after `VerifyAccessToken`, or shorten
-  `AccessTokenTTL` further.
+- **Need instant kill** (logout-everywhere, compromised account): set a
+  `Denylist` on the config. `VerifyAccessToken` then checks it on every
+  otherwise-valid access token, keyed by the `jti`/`SessionID` (stable across
+  rotations), and returns `ErrTokenRevoked` for a killed session.
+
+```go
+// Your store — in-memory, Redis, a DB table. Must fail closed.
+type myDenylist struct{ /* ... */ }
+func (d *myDenylist) IsRevoked(ctx context.Context, jti string) (bool, error) {
+    return d.store.Exists(ctx, "revoked:"+jti)
+}
+
+cfg := jwt.DefaultConfig()
+cfg.Denylist = &myDenylist{ /* ... */ }
+jwtMod, _ := jwt.New[MyClaims](auth, cfg)
+
+// On logout / force-logout: add the session id to the store.
+d.store.Add(ctx, "revoked:"+pair.SessionID, pair.RefreshTokenExpiresAt)
+
+// Verification rejects it from then on:
+claims, err := jwtMod.VerifyAccessTokenContext(ctx, token)
+if errors.Is(err, jwt.ErrTokenRevoked) { /* 401, re-authenticate */ }
+```
+
+The denylist is opt-in: leave `Denylist` nil and verification stays fully
+stateless (no per-request lookup). The lookup runs only for tokens that already
+passed signature and expiry, so a garbage token never touches your store. Use
+`VerifyAccessTokenContext` to pass a request context to the lookup; a store
+error fails closed (the token is rejected). Size the store entries to expire at
+the access token's `exp` — past that the token is dead anyway.
 
 ## Clock skew tolerance
 

--- a/docs/secure-login.md
+++ b/docs/secure-login.md
@@ -157,9 +157,10 @@ db.DeleteSession(session.ID) // stops renewal
 > default). See [JWT — Revocation & logout](jwt.md#revocation--logout).
 
 - **Most apps:** the short access TTL is enough — the token dies on its own.
-- **Need instant kill** (logout-everywhere, account compromise): keep your own
-  denylist keyed by `SessionID`/`jti` (stable across rotations) and check it in
-  middleware after `VerifyAccessToken`, or shorten `AccessTokenTTL`.
+- **Need instant kill** (logout-everywhere, account compromise): set a
+  `jwt.Denylist` on the config and add the `SessionID` to your store on logout —
+  `VerifyAccessToken` then returns `ErrTokenRevoked`. See
+  [JWT — Revocation & logout](jwt.md#revocation--logout).
 
 ## 7. Brute force & lockout
 


### PR DESCRIPTION
Roadmap #126. Access tokens are stateless and stay valid until `exp`, so logout cannot kill one early. This adds the sanctioned, opt-in path for instant revocation without forcing a store on everyone.

- `Denylist` interface: `IsRevoked(ctx, jti) (bool, error)`.
- `Config.Denylist` — nil by default, so the stateless fast path is unchanged (no per-request lookup).
- `VerifyAccessToken` consults it on every otherwise-valid access token, keyed by the `jti`/`SessionID` (stable across rotations), returning `ErrTokenRevoked` for a killed session.
- `VerifyAccessTokenContext(ctx, token)` threads a request context to the lookup; `VerifyAccessToken` delegates with `context.Background()`.

Design choices:
- The lookup runs **last** — only for a token that already passed signature, expiry, audience and type — so a garbage or expired token never touches your store.
- A store error **fails closed**: the token is rejected, never silently accepted.

Additive only — no existing signature changes, nothing breaking. Docs (`jwt.md`, `secure-login.md`) updated to use the hook. Tests cover revoked, active, store-error fail-closed, not-called-for-invalid-token, no-denylist, and the context variant. Aggregate coverage 92.1%.

`go build`, `go vet`, `golangci-lint` (0 issues) and the full suite with `-race` pass.

Closes #126
