### PR TITLE
feat: pluggable KeyStore (disk default, in-memory/PEM for containers)

### DIFF
--- a/authcore.go
+++ b/authcore.go
@@ -89,7 +89,12 @@ func New(cfg Config) (*AuthCore, error) {
 
 	log := newLogger(cfg)
 
-	km, err := keymanager.New(cfg.KeysDir, log)
+	store := cfg.KeyStore
+	if store == nil {
+		// Default: the zero-config secure-disk store under KeysDir.
+		store = diskKeyStore{dir: cfg.KeysDir, log: log}
+	}
+	keys, err := store.Load()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrKeyManager, err)
 	}
@@ -97,7 +102,7 @@ func New(cfg Config) (*AuthCore, error) {
 	ac := &AuthCore{
 		config: cfg,
 		log:    log,
-		keys:   km,
+		keys:   keys,
 	}
 
 	ac.log.Info("authcore initialised (timezone=%s, logs=%v, keys=%s)",

--- a/config.go
+++ b/config.go
@@ -30,7 +30,15 @@ type Config struct {
 	//
 	// The directory is created automatically on first use. A .gitignore is
 	// written inside it to prevent accidental commits of key material.
+	//
+	// Ignored when KeyStore is set.
 	KeysDir string
+
+	// KeyStore optionally overrides where cryptographic keys come from. When
+	// nil (the default), authcore uses the disk store under KeysDir. Set it to
+	// source keys from a secret manager, environment, or KMS instead — see
+	// NewKeyStoreFromKeys and NewKeyStoreFromPEM. When set, KeysDir is ignored.
+	KeyStore KeyStore
 }
 
 // DefaultConfig returns a Config populated with safe, production-ready defaults.
@@ -73,8 +81,12 @@ func validateConfig(cfg Config) error {
 	if cfg.Timezone == nil {
 		return ErrInvalidTimezone
 	}
-	if err := validateKeysDir(cfg.KeysDir); err != nil {
-		return err
+	// KeysDir only matters for the default disk store; a custom KeyStore does
+	// not use it, so skip the directory check entirely.
+	if cfg.KeyStore == nil {
+		if err := validateKeysDir(cfg.KeysDir); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -53,8 +53,36 @@ auth, err := authcore.New(cfg)
 > loads and validates them — it never writes. It writes only when generating a
 > missing file on first run, which a pre-generated mount avoids entirely.
 
-A pluggable key source (env / secret manager / KMS instead of files) is on the
-roadmap for deployments that prefer not to use a mounted volume.
+## Sourcing keys without a volume (KeyStore)
+
+If mounting a volume is awkward — serverless, or keys that live only in a secret
+manager — set `Config.KeyStore` to source the material directly instead of from
+disk. `KeysDir` is then ignored.
+
+```go
+cfg := authcore.DefaultConfig()
+
+// Keys arrive as PEM strings from env / a secret manager.
+ks, err := authcore.NewKeyStoreFromPEM(
+    []byte(os.Getenv("AUTHCORE_PRIVATE_PEM")),
+    []byte(os.Getenv("AUTHCORE_PUBLIC_PEM")),
+    refreshSecretBytes, // raw 32 bytes
+)
+if err != nil { log.Fatal(err) }
+cfg.KeyStore = ks
+
+auth, err := authcore.New(cfg)
+```
+
+`NewKeyStoreFromKeys(priv, pub, secret)` takes already-parsed Ed25519 values for
+the same purpose. Both validate that the public key matches the private key and
+that the refresh secret is 32 bytes, so a misconfigured secret fails loudly at
+startup rather than producing tokens no replica can verify. Inject the **same**
+material into every replica, exactly as with a shared volume.
+
+To implement a fully custom source (KMS that signs without exposing the private
+key would need more than this), satisfy the one-method `KeyStore` interface
+yourself: `Load() (authcore.Keys, error)`.
 
 The `KeyID()` accessor returns a 16-character hex digest derived from the public
 key. It is embedded in every token's `kid` JOSE header, enabling zero-downtime

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -177,19 +177,7 @@ func readPrivateKey(path string) (ed25519.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, fmt.Errorf("no PEM block found in %q", path)
-	}
-	raw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("parse PKCS#8 private key from %q: %w", path, err)
-	}
-	key, ok := raw.(ed25519.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("key in %q is not an Ed25519 private key (got %T)", path, raw)
-	}
-	return key, nil
+	return decodeEd25519PrivatePEM(data, path)
 }
 
 // readPublicKey parses a PKIX PEM file and returns the Ed25519 public key.
@@ -198,17 +186,41 @@ func readPublicKey(path string) (ed25519.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	return decodeEd25519PublicPEM(data, path)
+}
+
+// decodeEd25519PrivatePEM parses a PKCS#8 PEM block into an Ed25519 private key.
+// src names the origin (a path or "input") for error messages.
+func decodeEd25519PrivatePEM(data []byte, src string) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode(data)
 	if block == nil {
-		return nil, fmt.Errorf("no PEM block found in %q", path)
+		return nil, fmt.Errorf("no PEM block found in %q", src)
+	}
+	raw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKCS#8 private key from %q: %w", src, err)
+	}
+	key, ok := raw.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("key in %q is not an Ed25519 private key (got %T)", src, raw)
+	}
+	return key, nil
+}
+
+// decodeEd25519PublicPEM parses a PKIX PEM block into an Ed25519 public key.
+// src names the origin (a path or "input") for error messages.
+func decodeEd25519PublicPEM(data []byte, src string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %q", src)
 	}
 	raw, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("parse PKIX public key from %q: %w", path, err)
+		return nil, fmt.Errorf("parse PKIX public key from %q: %w", src, err)
 	}
 	key, ok := raw.(ed25519.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("key in %q is not an Ed25519 public key (got %T)", path, raw)
+		return nil, fmt.Errorf("key in %q is not an Ed25519 public key (got %T)", src, raw)
 	}
 	return key, nil
 }

--- a/internal/keymanager/material.go
+++ b/internal/keymanager/material.go
@@ -1,0 +1,51 @@
+package keymanager
+
+import (
+	"crypto/ed25519"
+	"fmt"
+)
+
+// FromKeys builds an in-memory KeyManager from already-loaded key material,
+// touching no filesystem. It is the backend for a non-disk KeyStore (keys
+// sourced from a secret manager, environment, or KMS).
+//
+// It validates that pub is the public half of priv and that secret is the
+// expected length, then derives the key id. The returned manager has no
+// directory; Dir returns "".
+func FromKeys(priv ed25519.PrivateKey, pub ed25519.PublicKey, secret []byte) (*KeyManager, error) {
+	if l := len(priv); l != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("private key has wrong length: got %d, want %d", l, ed25519.PrivateKeySize)
+	}
+	if l := len(pub); l != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("public key has wrong length: got %d, want %d", l, ed25519.PublicKeySize)
+	}
+	if !priv.Public().(ed25519.PublicKey).Equal(pub) {
+		return nil, fmt.Errorf("public key does not match private key")
+	}
+	if l := len(secret); l != refreshSecretLen {
+		return nil, fmt.Errorf("refresh secret has wrong length: got %d, want %d", l, refreshSecretLen)
+	}
+
+	return &KeyManager{
+		privateKey:    priv,
+		publicKey:     pub,
+		refreshSecret: secret,
+		keyID:         computeKeyID(pub),
+	}, nil
+}
+
+// FromPEM builds an in-memory KeyManager from PEM-encoded key material — a
+// PKCS#8 private key, a PKIX public key, and the raw 32-byte refresh secret.
+// Use it to source keys from environment variables or a secret store that hands
+// out PEM blocks.
+func FromPEM(privatePEM, publicPEM, refreshSecret []byte) (*KeyManager, error) {
+	priv, err := decodeEd25519PrivatePEM(privatePEM, "private key input")
+	if err != nil {
+		return nil, err
+	}
+	pub, err := decodeEd25519PublicPEM(publicPEM, "public key input")
+	if err != nil {
+		return nil, err
+	}
+	return FromKeys(priv, pub, refreshSecret)
+}

--- a/internal/keymanager/material_test.go
+++ b/internal/keymanager/material_test.go
@@ -1,0 +1,71 @@
+package keymanager_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+func genPair(t *testing.T) (ed25519.PrivateKey, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	return priv, pub
+}
+
+func TestFromKeys_valid(t *testing.T) {
+	priv, pub := genPair(t)
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+
+	km, err := keymanager.FromKeys(priv, pub, secret)
+	if err != nil {
+		t.Fatalf("FromKeys: %v", err)
+	}
+	if km.KeyID() == "" {
+		t.Error("KeyID not derived")
+	}
+	if km.Dir() != "" {
+		t.Errorf("in-memory manager Dir() = %q, want empty", km.Dir())
+	}
+}
+
+func TestFromKeys_rejectsBadInput(t *testing.T) {
+	priv, pub := genPair(t)
+	_, otherPub := genPair(t)
+	good := make([]byte, 32)
+
+	cases := map[string]func() error{
+		"mismatched pair": func() error { _, e := keymanager.FromKeys(priv, otherPub, good); return e },
+		"short secret":    func() error { _, e := keymanager.FromKeys(priv, pub, []byte("x")); return e },
+		"nil private":     func() error { _, e := keymanager.FromKeys(nil, pub, good); return e },
+	}
+	for name, fn := range cases {
+		if fn() == nil {
+			t.Errorf("%s: expected an error, got nil", name)
+		}
+	}
+}
+
+func TestFromPEM_roundTripAndGarbage(t *testing.T) {
+	priv, pub := genPair(t)
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	pubDER, _ := x509.MarshalPKIXPublicKey(pub)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	if _, err := keymanager.FromPEM(privPEM, pubPEM, secret); err != nil {
+		t.Fatalf("FromPEM round-trip: %v", err)
+	}
+	if _, err := keymanager.FromPEM([]byte("garbage"), pubPEM, secret); err == nil {
+		t.Error("expected an error for a non-PEM private key")
+	}
+}

--- a/keystore.go
+++ b/keystore.go
@@ -1,0 +1,74 @@
+package authcore
+
+import (
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+// KeyStore sources authcore's cryptographic key material (the Ed25519 signing
+// pair and the HMAC refresh secret).
+//
+// The default is disk: New generates and loads PEM files under Config.KeysDir.
+// Set Config.KeyStore to override that — for example to source keys from a
+// secret manager, environment variables, or KMS, which is the right fit for
+// serverless or disk-averse deployments where a mounted volume is awkward.
+//
+// Implementations are consulted once, at New time. The returned Keys must be
+// stable for the lifetime of the AuthCore instance.
+type KeyStore interface {
+	// Load returns the key material, or an error if it cannot be obtained or
+	// fails validation.
+	Load() (Keys, error)
+}
+
+// diskKeyStore is the default KeyStore: it generates the key files on first run
+// and loads them on subsequent runs, under dir. It preserves the zero-config
+// secure-disk behaviour when Config.KeyStore is not set.
+type diskKeyStore struct {
+	dir string
+	log Logger
+}
+
+func (d diskKeyStore) Load() (Keys, error) {
+	return keymanager.New(d.dir, d.log)
+}
+
+// staticKeyStore serves pre-built, in-memory key material. It never touches
+// the filesystem.
+type staticKeyStore struct {
+	keys Keys
+}
+
+func (s staticKeyStore) Load() (Keys, error) {
+	return s.keys, nil
+}
+
+// NewKeyStoreFromKeys returns a KeyStore backed by in-memory Ed25519 material,
+// touching no filesystem. Use it to inject keys obtained from a secret manager
+// or KMS at startup.
+//
+// It validates that pub is the public half of priv and that refreshSecret is
+// 32 bytes. Assign the result to Config.KeyStore.
+func NewKeyStoreFromKeys(priv ed25519.PrivateKey, pub ed25519.PublicKey, refreshSecret []byte) (KeyStore, error) {
+	km, err := keymanager.FromKeys(priv, pub, refreshSecret)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrKeyManager, err)
+	}
+	return staticKeyStore{keys: km}, nil
+}
+
+// NewKeyStoreFromPEM returns a KeyStore from PEM-encoded material: a PKCS#8
+// private key, a PKIX public key, and the raw 32-byte refresh secret. This is
+// the convenient form when keys arrive as PEM strings from environment
+// variables or a secret store.
+//
+// Assign the result to Config.KeyStore.
+func NewKeyStoreFromPEM(privatePEM, publicPEM, refreshSecret []byte) (KeyStore, error) {
+	km, err := keymanager.FromPEM(privatePEM, publicPEM, refreshSecret)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrKeyManager, err)
+	}
+	return staticKeyStore{keys: km}, nil
+}

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -1,0 +1,111 @@
+package authcore_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/Glyndor/authcore"
+)
+
+func genMaterial(t *testing.T) (ed25519.PrivateKey, ed25519.PublicKey, []byte) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		t.Fatalf("generate secret: %v", err)
+	}
+	return priv, pub, secret
+}
+
+func TestNewKeyStoreFromKeys_used(t *testing.T) {
+	priv, pub, secret := genMaterial(t)
+	ks, err := authcore.NewKeyStoreFromKeys(priv, pub, secret)
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromKeys: %v", err)
+	}
+
+	cfg := authcore.DefaultConfig()
+	cfg.EnableLogs = false
+	cfg.KeyStore = ks
+	cfg.KeysDir = "" // must be ignored
+
+	ac, err := authcore.New(cfg)
+	if err != nil {
+		t.Fatalf("New with KeyStore: %v", err)
+	}
+	if !ac.Keys().PrivateKey().Equal(priv) {
+		t.Error("module did not use the injected private key")
+	}
+	if string(ac.Keys().RefreshSecret()) != string(secret) {
+		t.Error("module did not use the injected refresh secret")
+	}
+}
+
+func TestNewKeyStoreFromKeys_mismatchedPairRejected(t *testing.T) {
+	priv, _, secret := genMaterial(t)
+	_, otherPub, _ := genMaterial(t)
+	if _, err := authcore.NewKeyStoreFromKeys(priv, otherPub, secret); err == nil {
+		t.Error("expected an error for a mismatched key pair")
+	}
+}
+
+func TestNewKeyStoreFromKeys_badSecretRejected(t *testing.T) {
+	priv, pub, _ := genMaterial(t)
+	if _, err := authcore.NewKeyStoreFromKeys(priv, pub, []byte("too-short")); err == nil {
+		t.Error("expected an error for a wrong-length refresh secret")
+	}
+}
+
+func TestNewKeyStoreFromPEM_roundTrip(t *testing.T) {
+	priv, pub, secret := genMaterial(t)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	pubDER, _ := x509.MarshalPKIXPublicKey(pub)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	ks, err := authcore.NewKeyStoreFromPEM(privPEM, pubPEM, secret)
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromPEM: %v", err)
+	}
+	cfg := authcore.DefaultConfig()
+	cfg.EnableLogs = false
+	cfg.KeyStore = ks
+	ac, err := authcore.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !ac.Keys().PublicKey().Equal(pub) {
+		t.Error("module did not load the PEM public key")
+	}
+}
+
+func TestNewKeyStoreFromPEM_garbageRejected(t *testing.T) {
+	_, _, secret := genMaterial(t)
+	if _, err := authcore.NewKeyStoreFromPEM([]byte("nope"), []byte("nope"), secret); err == nil {
+		t.Error("expected an error for non-PEM input")
+	}
+}
+
+func TestNew_keyStoreBypassesKeysDirValidation(t *testing.T) {
+	// A KeyStore makes KeysDir irrelevant, so even an invalid KeysDir must not
+	// block startup.
+	priv, pub, secret := genMaterial(t)
+	ks, err := authcore.NewKeyStoreFromKeys(priv, pub, secret)
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromKeys: %v", err)
+	}
+	cfg := authcore.DefaultConfig()
+	cfg.EnableLogs = false
+	cfg.KeyStore = ks
+	cfg.KeysDir = string([]byte{0}) // would fail validateKeysDir if it ran
+
+	if _, err := authcore.New(cfg); err != nil {
+		t.Errorf("KeyStore must bypass KeysDir validation, got %v", err)
+	}
+}


### PR DESCRIPTION
Roadmap #127, and the real fix for the container/serverless story we hit earlier: keys were disk-only. This abstracts the source behind a small `KeyStore` interface so a consumer can inject material from a secret manager, env, or KMS — no mounted volume required.

- `KeyStore` interface: `Load() (Keys, error)`.
- `Config.KeyStore` — nil by default, so authcore keeps the zero-config disk store under `KeysDir` and existing behaviour is unchanged. When set, `KeysDir` is ignored and its validation skipped.
- `NewKeyStoreFromKeys(priv, pub, secret)` and `NewKeyStoreFromPEM(privPEM, pubPEM, secret)` build an in-memory store. Both validate that the public key matches the private key and that the refresh secret is 32 bytes, so a misconfigured secret fails loudly at startup rather than minting tokens no replica can verify.
- `internal/keymanager` gains `FromKeys`/`FromPEM` (no filesystem); the PEM decode is factored into byte-level helpers shared with the existing file loaders.

Additive only — no existing signature changes, nothing breaking. `docs/key-management.md` gains a "Sourcing keys without a volume" section.

Tests cover the injected-keys and PEM paths, mismatched-pair and bad-secret rejection, garbage PEM, and that a `KeyStore` bypasses `KeysDir` validation. `go build`, `go vet`, `golangci-lint` (0 issues) and the full suite with `-race` pass. Aggregate coverage 92.6%.

Closes #127
