### PR TITLE
feat(jwt): zero-downtime key rotation via multiple verification keys

### DIFF
--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"crypto/ed25519"
 	"fmt"
 	"strings"
 	"time"
@@ -53,6 +54,17 @@ type Config struct {
 	// lookup). Set it to consult your own revocation store on each
 	// VerifyAccessToken, keyed by the session jti. See the Denylist type.
 	Denylist Denylist
+
+	// PreviousPublicKeys holds Ed25519 public keys that should still be accepted
+	// for verification in addition to the current signing key. This is the
+	// verification side of zero-downtime key rotation: deploy the new key as the
+	// active one and list the old public key here, so tokens already signed by
+	// it keep verifying through their lifetime; remove it once they have all
+	// expired. New tokens are always signed with the current key only.
+	//
+	// Empty by default. Each key is indexed by its derived "kid", so a token
+	// selects the right key automatically.
+	PreviousPublicKeys []ed25519.PublicKey
 }
 
 // DefaultConfig returns a Config with safe, production-ready defaults.
@@ -131,6 +143,11 @@ func validateConfig(cfg Config) error {
 	}
 	if cfg.ClockSkewLeeway < 0 {
 		return fmt.Errorf("clock skew leeway must not be negative, got %s", cfg.ClockSkewLeeway)
+	}
+	for i, pk := range cfg.PreviousPublicKeys {
+		if len(pk) != ed25519.PublicKeySize {
+			return fmt.Errorf("previous public key %d has wrong length: got %d, want %d", i, len(pk), ed25519.PublicKeySize)
+		}
 	}
 	return nil
 }

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Glyndor/authcore"
 	"github.com/Glyndor/authcore/internal/clock"
+	"github.com/Glyndor/authcore/internal/keymanager"
 )
 
 // isUUIDv7 reports whether s is a valid UUID v7 string (RFC 9562 §5.7).
@@ -66,6 +67,12 @@ type JWT[T any] struct {
 	clock           clock.Clock // injected; replaced by clock.Fixed in tests
 	primaryAudience string      // cfg.Audience[0] snapshotted at construction; immune to post-init mutation
 	denylist        Denylist    // optional; nil means access tokens are never checked for revocation
+
+	// verifyKeys maps each accepted "kid" to its public key. It always holds
+	// the current signing key and additionally any Config.PreviousPublicKeys,
+	// so a verifier accepts tokens minted under a key being rotated out while
+	// new tokens are signed only with the current key.
+	verifyKeys map[string]ed25519.PublicKey
 }
 
 // New creates and returns a JWT module.
@@ -105,8 +112,15 @@ func New[T any](p authcore.Provider, cfg ...Config) (*JWT[T], error) {
 		denylist:        resolved.Denylist,
 	}
 
-	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s)",
-		resolved.Issuer, resolved.AccessTokenTTL, resolved.RefreshTokenTTL)
+	// Build the verification key set: the current key plus any previous public
+	// keys still in their rotation overlap. Signing always uses the current key.
+	j.verifyKeys = map[string]ed25519.PublicKey{j.kid: j.pub}
+	for _, prev := range resolved.PreviousPublicKeys {
+		j.verifyKeys[keymanager.KeyID(prev)] = prev
+	}
+
+	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s, verify_keys=%d)",
+		resolved.Issuer, resolved.AccessTokenTTL, resolved.RefreshTokenTTL, len(j.verifyKeys))
 
 	return j, nil
 }
@@ -213,7 +227,7 @@ func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
 // is passed to the configured Denylist (if any). The context bounds only the
 // revocation lookup; signature and expiry checks are local and never block.
 func (j *JWT[T]) VerifyAccessTokenContext(ctx context.Context, token string) (*Claims[T], error) {
-	c, err := verifyAccessToken[T](token, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyAccessToken[T](token, j.verifyKeys, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +298,7 @@ func (j *JWT[T]) VerifyRefreshTokenHash(token, storedHash string) bool {
 //
 // Returns the same errors as VerifyAccessToken.
 func (j *JWT[T]) RotateTokens(refreshToken string, extra T) (*TokenPair, error) {
-	c, err := verifyRefreshToken(refreshToken, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyRefreshToken(refreshToken, j.verifyKeys, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/jwt/jwt_test.go
+++ b/auth/jwt/jwt_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Glyndor/authcore"
 	"github.com/Glyndor/authcore/internal/clock"
+	"github.com/Glyndor/authcore/internal/keymanager"
 )
 
 // ---- test infrastructure ----------------------------------------------------
@@ -30,7 +31,7 @@ type fakeKeys struct {
 func (k *fakeKeys) PrivateKey() ed25519.PrivateKey { return k.priv }
 func (k *fakeKeys) PublicKey() ed25519.PublicKey   { return k.pub }
 func (k *fakeKeys) RefreshSecret() []byte          { return k.secret }
-func (k *fakeKeys) KeyID() string                  { return "test0000test0000" }
+func (k *fakeKeys) KeyID() string                  { return keymanager.KeyID(k.pub) }
 
 // fakeProvider satisfies authcore.Provider using in-memory state.
 type fakeProvider struct{ keys *fakeKeys }

--- a/auth/jwt/jwt_tokens_test.go
+++ b/auth/jwt/jwt_tokens_test.go
@@ -194,7 +194,8 @@ func TestCreateTokens_refreshTokenHasIat(t *testing.T) {
 // ---- kid header -------------------------------------------------------------
 
 func TestCreateTokens_accessTokenHeaderContainsKid(t *testing.T) {
-	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+	prov := newFakeProvider(t)
+	j := newTestJWT[struct{}](t, prov, DefaultConfig())
 	pair, _ := j.CreateTokens(testSubject, struct{}{})
 
 	h := tokenHeader(t, pair.AccessToken)
@@ -202,13 +203,14 @@ func TestCreateTokens_accessTokenHeaderContainsKid(t *testing.T) {
 	if !ok || kid == "" {
 		t.Errorf("access token header missing or empty kid: %v", h)
 	}
-	if kid != "test0000test0000" {
-		t.Errorf("kid = %q, want %q", kid, "test0000test0000")
+	if want := prov.Keys().KeyID(); kid != want {
+		t.Errorf("kid = %q, want %q", kid, want)
 	}
 }
 
 func TestCreateTokens_refreshTokenHeaderContainsKid(t *testing.T) {
-	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+	prov := newFakeProvider(t)
+	j := newTestJWT[struct{}](t, prov, DefaultConfig())
 	pair, _ := j.CreateTokens(testSubject, struct{}{})
 
 	h := tokenHeader(t, pair.RefreshToken)
@@ -216,8 +218,8 @@ func TestCreateTokens_refreshTokenHeaderContainsKid(t *testing.T) {
 	if !ok || kid == "" {
 		t.Errorf("refresh token header missing or empty kid: %v", h)
 	}
-	if kid != "test0000test0000" {
-		t.Errorf("kid = %q, want %q", kid, "test0000test0000")
+	if want := prov.Keys().KeyID(); kid != want {
+		t.Errorf("kid = %q, want %q", kid, want)
 	}
 }
 

--- a/auth/jwt/rotation_test.go
+++ b/auth/jwt/rotation_test.go
@@ -1,0 +1,67 @@
+package jwt
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+)
+
+// TestRotation_previousKeyStillVerifies models the overlap window: a new module
+// signs with a fresh key but lists the old public key, so tokens minted by the
+// old key keep verifying.
+func TestRotation_previousKeyStillVerifies(t *testing.T) {
+	provOld := newFakeProvider(t)
+	jOld := newTestJWT[struct{}](t, provOld, DefaultConfig())
+	pair, err := jOld.CreateTokens(testSubject, struct{}{})
+	if err != nil {
+		t.Fatalf("CreateTokens: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.PreviousPublicKeys = []ed25519.PublicKey{provOld.Keys().PublicKey()}
+	jNew := newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+
+	if _, err := jNew.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Errorf("access token from the rotated-out key should still verify, got %v", err)
+	}
+	// Rotation off the old refresh token must also work during the overlap.
+	if _, err := jNew.RotateTokens(pair.RefreshToken, struct{}{}); err != nil {
+		t.Errorf("refresh token from the rotated-out key should still rotate, got %v", err)
+	}
+}
+
+// TestRotation_currentKeyStillVerifies confirms the new module's own tokens
+// verify alongside the accepted previous key.
+func TestRotation_currentKeyStillVerifies(t *testing.T) {
+	provOld := newFakeProvider(t)
+	cfg := DefaultConfig()
+	cfg.PreviousPublicKeys = []ed25519.PublicKey{provOld.Keys().PublicKey()}
+	jNew := newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+
+	pair, _ := jNew.CreateTokens(testSubject, struct{}{})
+	if _, err := jNew.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Errorf("current-key token must verify, got %v", err)
+	}
+}
+
+// TestRotation_unlistedKeyRejected confirms a token signed by a key that is
+// neither current nor listed is refused.
+func TestRotation_unlistedKeyRejected(t *testing.T) {
+	provOld := newFakeProvider(t)
+	jOld := newTestJWT[struct{}](t, provOld, DefaultConfig())
+	pair, _ := jOld.CreateTokens(testSubject, struct{}{})
+
+	jNew := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig()) // no previous keys
+	_, err := jNew.VerifyAccessToken(pair.AccessToken)
+	if !errors.Is(err, ErrTokenInvalid) {
+		t.Errorf("expected ErrTokenInvalid for an unlisted key, got %v", err)
+	}
+}
+
+func TestRotation_badPreviousKeyRejectedAtNew(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.PreviousPublicKeys = []ed25519.PublicKey{[]byte("too-short")}
+	if _, err := New[struct{}](newFakeProvider(t), cfg); !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected ErrInvalidConfig for a wrong-length previous key, got %v", err)
+	}
+}

--- a/auth/jwt/token.go
+++ b/auth/jwt/token.go
@@ -98,11 +98,11 @@ func signToken(claims gjwt.Claims, key ed25519.PrivateKey, kid string) (string, 
 // signed by the same key but issued for a different service would otherwise be
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, kid string, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
+func verifyAccessToken[T any](tokenStr string, keys map[string]ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
 	var c accessClaims[T]
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub, kid),                             // enforce EdDSA alg + kid match; rejects HS256/RS256 confusion attacks and unknown key IDs
+		eddsaKeyFunc(keys), // enforce EdDSA alg + select pub by kid; rejects HS256/RS256 confusion attacks and unknown key IDs
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
@@ -122,11 +122,11 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, kid string
 // signed by the same key but issued for a different service would otherwise be
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, kid string, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
+func verifyRefreshToken(tokenStr string, keys map[string]ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
 	var c refreshClaims
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub, kid),                             // enforce EdDSA alg + kid match; rejects HS256/RS256 confusion attacks and unknown key IDs
+		eddsaKeyFunc(keys), // enforce EdDSA alg + select pub by kid; rejects HS256/RS256 confusion attacks and unknown key IDs
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
@@ -140,12 +140,14 @@ func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, kid string, now 
 	return &c, nil
 }
 
-// eddsaKeyFunc returns a gjwt.Keyfunc that enforces EdDSA, validates the
-// token's "kid" header against the expected value, and returns pub.
-// Rejecting unknown kids narrows the verifier to keys the operator has
-// actually authorised, which matters once key rotation is in play (the
-// verifier would otherwise happily try pub against every incoming kid).
-func eddsaKeyFunc(pub ed25519.PublicKey, expectedKID string) gjwt.Keyfunc {
+// eddsaKeyFunc returns a gjwt.Keyfunc that enforces EdDSA and selects the
+// verification key by the token's "kid" header from keys.
+//
+// Holding more than one key lets a verifier accept tokens signed by a previous
+// key while issuing under the current one — the overlap that makes key rotation
+// zero-downtime. A token whose kid is not in the set is rejected, so the
+// verifier only ever trusts keys the operator has authorised.
+func eddsaKeyFunc(keys map[string]ed25519.PublicKey) gjwt.Keyfunc {
 	return func(t *gjwt.Token) (any, error) {
 		// Explicitly reject any algorithm that is not EdDSA.
 		// Without this check an attacker could craft a token with alg=HS256
@@ -154,14 +156,12 @@ func eddsaKeyFunc(pub ed25519.PublicKey, expectedKID string) gjwt.Keyfunc {
 		if _, ok := t.Method.(*gjwt.SigningMethodEd25519); !ok {
 			return nil, fmt.Errorf("%w: unexpected alg %q", ErrTokenInvalid, t.Header["alg"])
 		}
-		// Reject tokens that did not declare a kid or declared one we do not
-		// recognise. Empty expectedKID disables the check (defence in depth
-		// for callers that legitimately sign without a kid header).
-		if expectedKID != "" {
-			kid, _ := t.Header["kid"].(string)
-			if kid != expectedKID {
-				return nil, fmt.Errorf("%w: unexpected kid %q", ErrTokenInvalid, kid)
-			}
+		// Select the public key by the token's kid. An unknown (or missing) kid
+		// is refused — the verifier never falls back to "try every key".
+		kid, _ := t.Header["kid"].(string)
+		pub, ok := keys[kid]
+		if !ok {
+			return nil, fmt.Errorf("%w: unrecognised kid %q", ErrTokenInvalid, kid)
 		}
 		return pub, nil
 	}

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -85,10 +85,32 @@ key would need more than this), satisfy the one-method `KeyStore` interface
 yourself: `Load() (authcore.Keys, error)`.
 
 The `KeyID()` accessor returns a 16-character hex digest derived from the public
-key. It is embedded in every token's `kid` JOSE header, enabling zero-downtime
-key rotation. Verification rejects tokens whose `kid` does not match the module's
-current key id, so a future multi-key deployment only ever accepts tokens minted
-under an authorised key.
+key. It is embedded in every token's `kid` JOSE header. Verification selects the
+key by `kid` and rejects any token whose `kid` is not one the module accepts.
+
+## Rotating the signing key (zero downtime)
+
+Rotating the Ed25519 key without logging everyone out is a two-phase move that
+relies on `kid`: tokens already in the wild were signed by the old key, so the
+verifier must keep accepting it until they expire.
+
+1. **Overlap.** Make the new key the active one (new `KeysDir` / `KeyStore`
+   material) and list the **old public key** in `jwt.Config.PreviousPublicKeys`.
+   New tokens are signed only with the new key; tokens still bearing the old
+   `kid` keep verifying.
+
+   ```go
+   cfg := jwt.DefaultConfig()
+   cfg.PreviousPublicKeys = []ed25519.PublicKey{oldPublicKey}
+   jwtMod, _ := jwt.New[MyClaims](auth, cfg)
+   ```
+
+2. **Retire.** Once every token signed by the old key has expired (at most one
+   `RefreshTokenTTL`), deploy again without it. The old key is gone.
+
+Each listed key is indexed by its derived `kid`, so a token picks the right key
+automatically. A `kid` that is neither the current key nor a listed previous key
+is rejected as `ErrTokenInvalid`.
 
 > [!NOTE]
 > Key-file loaders enforce a **4 KiB size cap**. A healthy Ed25519 PEM is ~200

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -116,6 +116,12 @@ func New(dir string, log logger) (*KeyManager, error) {
 	}, nil
 }
 
+// KeyID derives the stable key identifier for pub — the same value a
+// KeyManager reports for its own key. It is exported so the JWT module can
+// index additional verification keys (during rotation) by the same id without
+// duplicating the derivation.
+func KeyID(pub ed25519.PublicKey) string { return computeKeyID(pub) }
+
 // computeKeyID derives a stable identifier from a public key.
 // It returns the first 8 bytes of the SHA-256 digest of the raw public key
 // bytes, hex-encoded (16 lowercase characters). The value changes automatically


### PR DESCRIPTION
Roadmap #128. Verification held a single key, so rotating the signing key would have invalidated every token signed by the old one. This makes rotation zero-downtime.

- Verification now selects the public key by the token's `kid` from a set, instead of matching one expected `kid`. Issuance still uses only the current key.
- `Config.PreviousPublicKeys` lists public keys that stay accepted during their rotation overlap. Each is indexed by its derived `kid`, so a token picks the right key automatically; an unrecognised `kid` is rejected as `ErrTokenInvalid` (no fall-back to trying every key).
- `keymanager.KeyID` is exported so additional keys are indexed with the same derivation.
- The JWT test fake previously returned a constant `KeyID`; it now derives it from the public key, so `kid` faithfully tracks the key (this also makes the existing kid-header tests assert the real value).

Two-phase rotation, documented in `docs/key-management.md`: deploy the new key as active with the old public key listed; once tokens signed by the old key have expired (at most one `RefreshTokenTTL`), deploy again without it.

Additive only — no existing signature changes, nothing breaking. Tests cover previous-key-verifies, current-key-verifies, unlisted-key-rejected, and bad-previous-key-rejected-at-New. `go build`, `go vet`, `golangci-lint` (0 issues) and the full suite with `-race` pass. Aggregate coverage 92.5%.

Closes #128
