### PR TITLE
test(keymanager): fuzz the FromPEM key decoder

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,5 +20,6 @@ jobs:
           {"package":"./auth/jwt","func":"FuzzVerifyAccessToken"},
           {"package":"./auth/jwt","func":"FuzzIsUUIDv7"},
           {"package":"./auth/password","func":"FuzzValidatePolicy"},
-          {"package":"./auth/password","func":"FuzzParsePHC"}
+          {"package":"./auth/password","func":"FuzzParsePHC"},
+          {"package":"./internal/keymanager","func":"FuzzFromPEM"}
         ]

--- a/internal/keymanager/material_fuzz_test.go
+++ b/internal/keymanager/material_fuzz_test.go
@@ -1,0 +1,42 @@
+package keymanager_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+// FuzzFromPEM drives the PEM key-material decoder with arbitrary bytes. FromPEM
+// turns untrusted-looking input (PEM blocks sourced from env/secret stores)
+// into key structures, so it must never panic — only return a manager or an
+// error.
+func FuzzFromPEM(f *testing.F) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		f.Fatalf("seed key: %v", err)
+	}
+	privDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	pubDER, _ := x509.MarshalPKIXPublicKey(pub)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	secret := make([]byte, 32)
+
+	f.Add(privPEM, pubPEM, secret)                          // valid set
+	f.Add([]byte("not a pem"), []byte("not a pem"), secret) // garbage
+	f.Add(privPEM, pubPEM, []byte("short"))                 // bad secret length
+	f.Add([]byte{}, []byte{}, []byte{})                     // empty
+
+	f.Fuzz(func(t *testing.T, privBytes, pubBytes, secretBytes []byte) {
+		km, err := keymanager.FromPEM(privBytes, pubBytes, secretBytes)
+		if err == nil && km == nil {
+			t.Fatal("FromPEM returned a nil manager with a nil error")
+		}
+		if err != nil && km != nil {
+			t.Fatal("FromPEM returned a manager alongside an error")
+		}
+	})
+}


### PR DESCRIPTION
The pluggable KeyStore (#127) added `keymanager.FromPEM`, a new bytes->structure decoder. The testing standard requires a fuzz target for every input parser, and `fuzz.yml` lists targets by hand, so a new parser is not swept until it is registered.

- `FuzzFromPEM` in `internal/keymanager/material_fuzz_test.go`: drives the decoder with arbitrary private/public PEM and secret bytes, asserting it never panics and never returns a manager together with an error. Seeded with a valid set plus garbage/short/empty inputs.
- Registered it in `.github/workflows/fuzz.yml` — **the authcore caller only**; the org reusable `Glyndor/.github/go-fuzz.yml` (SHA-pinned) is not touched, so there is no blast radius on other repos.

Ran locally for 15s: ~2.6M executions, no crash. `go build`, `go vet`, `golangci-lint` (0 issues) pass.

Closes #145
