### PR TITLE
release: v1.6.0

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,5 +20,6 @@ jobs:
           {"package":"./auth/jwt","func":"FuzzVerifyAccessToken"},
           {"package":"./auth/jwt","func":"FuzzIsUUIDv7"},
           {"package":"./auth/password","func":"FuzzValidatePolicy"},
-          {"package":"./auth/password","func":"FuzzParsePHC"}
+          {"package":"./auth/password","func":"FuzzParsePHC"},
+          {"package":"./internal/keymanager","func":"FuzzFromPEM"}
         ]

--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"crypto/ed25519"
 	"fmt"
 	"strings"
 	"time"
@@ -53,6 +54,17 @@ type Config struct {
 	// lookup). Set it to consult your own revocation store on each
 	// VerifyAccessToken, keyed by the session jti. See the Denylist type.
 	Denylist Denylist
+
+	// PreviousPublicKeys holds Ed25519 public keys that should still be accepted
+	// for verification in addition to the current signing key. This is the
+	// verification side of zero-downtime key rotation: deploy the new key as the
+	// active one and list the old public key here, so tokens already signed by
+	// it keep verifying through their lifetime; remove it once they have all
+	// expired. New tokens are always signed with the current key only.
+	//
+	// Empty by default. Each key is indexed by its derived "kid", so a token
+	// selects the right key automatically.
+	PreviousPublicKeys []ed25519.PublicKey
 }
 
 // DefaultConfig returns a Config with safe, production-ready defaults.
@@ -131,6 +143,11 @@ func validateConfig(cfg Config) error {
 	}
 	if cfg.ClockSkewLeeway < 0 {
 		return fmt.Errorf("clock skew leeway must not be negative, got %s", cfg.ClockSkewLeeway)
+	}
+	for i, pk := range cfg.PreviousPublicKeys {
+		if len(pk) != ed25519.PublicKeySize {
+			return fmt.Errorf("previous public key %d has wrong length: got %d, want %d", i, len(pk), ed25519.PublicKeySize)
+		}
 	}
 	return nil
 }

--- a/auth/jwt/config.go
+++ b/auth/jwt/config.go
@@ -47,6 +47,12 @@ type Config struct {
 	// Defaults to 0 (no leeway). A value of 30 seconds is typical for production deployments.
 	// Must not be negative.
 	ClockSkewLeeway time.Duration
+
+	// Denylist optionally makes access tokens revocable before they expire.
+	// It is nil by default, keeping the stateless fast path (no per-request
+	// lookup). Set it to consult your own revocation store on each
+	// VerifyAccessToken, keyed by the session jti. See the Denylist type.
+	Denylist Denylist
 }
 
 // DefaultConfig returns a Config with safe, production-ready defaults.

--- a/auth/jwt/denylist.go
+++ b/auth/jwt/denylist.go
@@ -1,0 +1,33 @@
+package jwt
+
+import "context"
+
+// Denylist is the optional, opt-in hook that makes a stateless access token
+// revocable before it expires.
+//
+// Access tokens are stateless JWTs: by default the only thing bounding an issued
+// token is its expiry (AccessTokenTTL). That is enough for most applications.
+// When you need instant revocation — logout-everywhere, a compromised account,
+// an admin force-logout — set Config.Denylist to an implementation backed by
+// your own store (in-memory, Redis, a database table) and VerifyAccessToken
+// will reject any token whose session has been revoked.
+//
+// The denylist is keyed by the token's "jti", which equals the TokenPair
+// SessionID and is stable across rotations — so revoking one entry kills the
+// whole session, every access token in it, immediately.
+//
+// Leaving Config.Denylist nil keeps the stateless fast path: no lookup, no
+// store, no per-request cost.
+type Denylist interface {
+	// IsRevoked reports whether the session identified by jti has been revoked.
+	//
+	// It is called only for an access token that has already passed signature,
+	// expiry, audience and type checks, so it runs at most once per valid
+	// request. Return (false, nil) when the session is active. A non-nil error
+	// is surfaced to the caller wrapped, and must fail closed — the token is
+	// not accepted — so a store outage cannot silently bypass revocation.
+	//
+	// Implementations must be safe for concurrent use and should be fast; honour
+	// ctx for cancellation and deadlines.
+	IsRevoked(ctx context.Context, jti string) (bool, error)
+}

--- a/auth/jwt/denylist_test.go
+++ b/auth/jwt/denylist_test.go
@@ -1,0 +1,105 @@
+package jwt
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// stubDenylist is a programmable Denylist for tests.
+type stubDenylist struct {
+	revoked bool
+	err     error
+	gotJTI  string
+	calls   int
+}
+
+func (s *stubDenylist) IsRevoked(_ context.Context, jti string) (bool, error) {
+	s.calls++
+	s.gotJTI = jti
+	return s.revoked, s.err
+}
+
+func jwtWithDenylist(t *testing.T, d Denylist) *JWT[struct{}] {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Denylist = d
+	return newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+}
+
+func TestVerifyAccessToken_denylistRevoked(t *testing.T) {
+	stub := &stubDenylist{revoked: true}
+	j := jwtWithDenylist(t, stub)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	_, err := j.VerifyAccessToken(pair.AccessToken)
+	if !errors.Is(err, ErrTokenRevoked) {
+		t.Fatalf("expected ErrTokenRevoked, got %v", err)
+	}
+	if stub.gotJTI != pair.SessionID {
+		t.Errorf("denylist queried jti %q, want SessionID %q", stub.gotJTI, pair.SessionID)
+	}
+}
+
+func TestVerifyAccessToken_denylistActive(t *testing.T) {
+	stub := &stubDenylist{revoked: false}
+	j := jwtWithDenylist(t, stub)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	if _, err := j.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Fatalf("a non-revoked token must verify, got %v", err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("denylist calls = %d, want 1", stub.calls)
+	}
+}
+
+func TestVerifyAccessToken_denylistErrorFailsClosed(t *testing.T) {
+	sentinel := errors.New("redis down")
+	j := jwtWithDenylist(t, &stubDenylist{err: sentinel})
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	_, err := j.VerifyAccessToken(pair.AccessToken)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected the wrapped store error, got %v", err)
+	}
+	if errors.Is(err, ErrTokenRevoked) {
+		t.Error("a store error must not be reported as a clean revocation")
+	}
+}
+
+func TestVerifyAccessToken_denylistNotCalledForInvalidToken(t *testing.T) {
+	stub := &stubDenylist{}
+	j := jwtWithDenylist(t, stub)
+
+	// A garbage token fails signature/format before any denylist lookup.
+	if _, err := j.VerifyAccessToken("not.a.jwt"); err == nil {
+		t.Fatal("expected an error for a malformed token")
+	}
+	if stub.calls != 0 {
+		t.Errorf("denylist must not be consulted for an invalid token; calls = %d", stub.calls)
+	}
+}
+
+func TestVerifyAccessToken_noDenylistSkipsLookup(t *testing.T) {
+	// Default config has no denylist; verification must not require one.
+	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+	if _, err := j.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Fatalf("verify without a denylist must succeed, got %v", err)
+	}
+}
+
+func TestVerifyAccessTokenContext_passesContext(t *testing.T) {
+	stub := &stubDenylist{}
+	j := jwtWithDenylist(t, stub)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	ctx := context.Background()
+	if _, err := j.VerifyAccessTokenContext(ctx, pair.AccessToken); err != nil {
+		t.Fatalf("VerifyAccessTokenContext error = %v", err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("denylist calls = %d, want 1", stub.calls)
+	}
+}

--- a/auth/jwt/errors.go
+++ b/auth/jwt/errors.go
@@ -58,4 +58,12 @@ var (
 	//
 	// Safety: INTERNAL — programming error in the caller. Treat as a 500.
 	ErrInvalidSubject = errors.New("jwt: subject must be a valid UUID v7")
+
+	// ErrTokenRevoked is returned by VerifyAccessToken when a configured
+	// Denylist reports the token's session as revoked. The token's signature
+	// and expiry were valid; it was explicitly killed.
+	//
+	// Safety: INTERNAL — return a generic "unauthorized" to the client, which
+	// should re-authenticate.
+	ErrTokenRevoked = errors.New("jwt: token has been revoked")
 )

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Glyndor/authcore"
 	"github.com/Glyndor/authcore/internal/clock"
+	"github.com/Glyndor/authcore/internal/keymanager"
 )
 
 // isUUIDv7 reports whether s is a valid UUID v7 string (RFC 9562 §5.7).
@@ -66,6 +67,12 @@ type JWT[T any] struct {
 	clock           clock.Clock // injected; replaced by clock.Fixed in tests
 	primaryAudience string      // cfg.Audience[0] snapshotted at construction; immune to post-init mutation
 	denylist        Denylist    // optional; nil means access tokens are never checked for revocation
+
+	// verifyKeys maps each accepted "kid" to its public key. It always holds
+	// the current signing key and additionally any Config.PreviousPublicKeys,
+	// so a verifier accepts tokens minted under a key being rotated out while
+	// new tokens are signed only with the current key.
+	verifyKeys map[string]ed25519.PublicKey
 }
 
 // New creates and returns a JWT module.
@@ -105,8 +112,15 @@ func New[T any](p authcore.Provider, cfg ...Config) (*JWT[T], error) {
 		denylist:        resolved.Denylist,
 	}
 
-	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s)",
-		resolved.Issuer, resolved.AccessTokenTTL, resolved.RefreshTokenTTL)
+	// Build the verification key set: the current key plus any previous public
+	// keys still in their rotation overlap. Signing always uses the current key.
+	j.verifyKeys = map[string]ed25519.PublicKey{j.kid: j.pub}
+	for _, prev := range resolved.PreviousPublicKeys {
+		j.verifyKeys[keymanager.KeyID(prev)] = prev
+	}
+
+	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s, verify_keys=%d)",
+		resolved.Issuer, resolved.AccessTokenTTL, resolved.RefreshTokenTTL, len(j.verifyKeys))
 
 	return j, nil
 }
@@ -213,7 +227,7 @@ func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
 // is passed to the configured Denylist (if any). The context bounds only the
 // revocation lookup; signature and expiry checks are local and never block.
 func (j *JWT[T]) VerifyAccessTokenContext(ctx context.Context, token string) (*Claims[T], error) {
-	c, err := verifyAccessToken[T](token, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyAccessToken[T](token, j.verifyKeys, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +298,7 @@ func (j *JWT[T]) VerifyRefreshTokenHash(token, storedHash string) bool {
 //
 // Returns the same errors as VerifyAccessToken.
 func (j *JWT[T]) RotateTokens(refreshToken string, extra T) (*TokenPair, error) {
-	c, err := verifyRefreshToken(refreshToken, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
+	c, err := verifyRefreshToken(refreshToken, j.verifyKeys, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/subtle"
 	"fmt"
@@ -64,6 +65,7 @@ type JWT[T any] struct {
 	kid             string      // JOSE "kid" header value, derived from the public key
 	clock           clock.Clock // injected; replaced by clock.Fixed in tests
 	primaryAudience string      // cfg.Audience[0] snapshotted at construction; immune to post-init mutation
+	denylist        Denylist    // optional; nil means access tokens are never checked for revocation
 }
 
 // New creates and returns a JWT module.
@@ -100,6 +102,7 @@ func New[T any](p authcore.Provider, cfg ...Config) (*JWT[T], error) {
 		kid:             p.Keys().KeyID(),
 		clock:           clock.New(p.Config().Timezone),
 		primaryAudience: resolved.Audience[0], // validateConfig guarantees len >= 1
+		denylist:        resolved.Denylist,
 	}
 
 	j.log.Info("jwt: module initialised (issuer=%s, access_ttl=%s, refresh_ttl=%s)",
@@ -192,18 +195,41 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 //	                        or iss/aud claim does not match Config
 //	jwt.ErrTokenMalformed — not a valid three-part JWT string
 //	jwt.ErrWrongTokenType — token is a refresh token, not an access token
+//	jwt.ErrTokenRevoked   — a configured Denylist reports the token's session revoked
 //
 // Use errors.Is for error inspection:
 //
 //	claims, err := jwtMod.VerifyAccessToken(token)
 //	if errors.Is(err, jwt.ErrTokenExpired) { ... }
+//
+// When a Denylist is configured (Config.Denylist), this uses a background
+// context for the revocation lookup. Use VerifyAccessTokenContext to pass your
+// own context (recommended for a network-backed denylist).
 func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
+	return j.VerifyAccessTokenContext(context.Background(), token)
+}
+
+// VerifyAccessTokenContext is VerifyAccessToken with an explicit context that
+// is passed to the configured Denylist (if any). The context bounds only the
+// revocation lookup; signature and expiry checks are local and never block.
+func (j *JWT[T]) VerifyAccessTokenContext(ctx context.Context, token string) (*Claims[T], error) {
 	c, err := verifyAccessToken[T](token, j.pub, j.kid, j.clock.Now(), j.cfg.Issuer, j.primaryAudience, j.cfg.ClockSkewLeeway)
 	if err != nil {
 		return nil, err
 	}
 	if c.Type != tokenTypeAccess {
 		return nil, ErrWrongTokenType
+	}
+	// Revocation is checked last — only an otherwise-valid access token is worth
+	// a denylist lookup, so a garbage or expired token never reaches the store.
+	if j.denylist != nil {
+		revoked, err := j.denylist.IsRevoked(ctx, c.ID)
+		if err != nil {
+			return nil, fmt.Errorf("jwt: denylist lookup: %w", err)
+		}
+		if revoked {
+			return nil, ErrTokenRevoked
+		}
 	}
 	return accessClaimsToClaims(c), nil
 }

--- a/auth/jwt/jwt_test.go
+++ b/auth/jwt/jwt_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Glyndor/authcore"
 	"github.com/Glyndor/authcore/internal/clock"
+	"github.com/Glyndor/authcore/internal/keymanager"
 )
 
 // ---- test infrastructure ----------------------------------------------------
@@ -30,7 +31,7 @@ type fakeKeys struct {
 func (k *fakeKeys) PrivateKey() ed25519.PrivateKey { return k.priv }
 func (k *fakeKeys) PublicKey() ed25519.PublicKey   { return k.pub }
 func (k *fakeKeys) RefreshSecret() []byte          { return k.secret }
-func (k *fakeKeys) KeyID() string                  { return "test0000test0000" }
+func (k *fakeKeys) KeyID() string                  { return keymanager.KeyID(k.pub) }
 
 // fakeProvider satisfies authcore.Provider using in-memory state.
 type fakeProvider struct{ keys *fakeKeys }

--- a/auth/jwt/jwt_tokens_test.go
+++ b/auth/jwt/jwt_tokens_test.go
@@ -194,7 +194,8 @@ func TestCreateTokens_refreshTokenHasIat(t *testing.T) {
 // ---- kid header -------------------------------------------------------------
 
 func TestCreateTokens_accessTokenHeaderContainsKid(t *testing.T) {
-	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+	prov := newFakeProvider(t)
+	j := newTestJWT[struct{}](t, prov, DefaultConfig())
 	pair, _ := j.CreateTokens(testSubject, struct{}{})
 
 	h := tokenHeader(t, pair.AccessToken)
@@ -202,13 +203,14 @@ func TestCreateTokens_accessTokenHeaderContainsKid(t *testing.T) {
 	if !ok || kid == "" {
 		t.Errorf("access token header missing or empty kid: %v", h)
 	}
-	if kid != "test0000test0000" {
-		t.Errorf("kid = %q, want %q", kid, "test0000test0000")
+	if want := prov.Keys().KeyID(); kid != want {
+		t.Errorf("kid = %q, want %q", kid, want)
 	}
 }
 
 func TestCreateTokens_refreshTokenHeaderContainsKid(t *testing.T) {
-	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+	prov := newFakeProvider(t)
+	j := newTestJWT[struct{}](t, prov, DefaultConfig())
 	pair, _ := j.CreateTokens(testSubject, struct{}{})
 
 	h := tokenHeader(t, pair.RefreshToken)
@@ -216,8 +218,8 @@ func TestCreateTokens_refreshTokenHeaderContainsKid(t *testing.T) {
 	if !ok || kid == "" {
 		t.Errorf("refresh token header missing or empty kid: %v", h)
 	}
-	if kid != "test0000test0000" {
-		t.Errorf("kid = %q, want %q", kid, "test0000test0000")
+	if want := prov.Keys().KeyID(); kid != want {
+		t.Errorf("kid = %q, want %q", kid, want)
 	}
 }
 

--- a/auth/jwt/rotation_test.go
+++ b/auth/jwt/rotation_test.go
@@ -1,0 +1,67 @@
+package jwt
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+)
+
+// TestRotation_previousKeyStillVerifies models the overlap window: a new module
+// signs with a fresh key but lists the old public key, so tokens minted by the
+// old key keep verifying.
+func TestRotation_previousKeyStillVerifies(t *testing.T) {
+	provOld := newFakeProvider(t)
+	jOld := newTestJWT[struct{}](t, provOld, DefaultConfig())
+	pair, err := jOld.CreateTokens(testSubject, struct{}{})
+	if err != nil {
+		t.Fatalf("CreateTokens: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.PreviousPublicKeys = []ed25519.PublicKey{provOld.Keys().PublicKey()}
+	jNew := newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+
+	if _, err := jNew.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Errorf("access token from the rotated-out key should still verify, got %v", err)
+	}
+	// Rotation off the old refresh token must also work during the overlap.
+	if _, err := jNew.RotateTokens(pair.RefreshToken, struct{}{}); err != nil {
+		t.Errorf("refresh token from the rotated-out key should still rotate, got %v", err)
+	}
+}
+
+// TestRotation_currentKeyStillVerifies confirms the new module's own tokens
+// verify alongside the accepted previous key.
+func TestRotation_currentKeyStillVerifies(t *testing.T) {
+	provOld := newFakeProvider(t)
+	cfg := DefaultConfig()
+	cfg.PreviousPublicKeys = []ed25519.PublicKey{provOld.Keys().PublicKey()}
+	jNew := newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+
+	pair, _ := jNew.CreateTokens(testSubject, struct{}{})
+	if _, err := jNew.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Errorf("current-key token must verify, got %v", err)
+	}
+}
+
+// TestRotation_unlistedKeyRejected confirms a token signed by a key that is
+// neither current nor listed is refused.
+func TestRotation_unlistedKeyRejected(t *testing.T) {
+	provOld := newFakeProvider(t)
+	jOld := newTestJWT[struct{}](t, provOld, DefaultConfig())
+	pair, _ := jOld.CreateTokens(testSubject, struct{}{})
+
+	jNew := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig()) // no previous keys
+	_, err := jNew.VerifyAccessToken(pair.AccessToken)
+	if !errors.Is(err, ErrTokenInvalid) {
+		t.Errorf("expected ErrTokenInvalid for an unlisted key, got %v", err)
+	}
+}
+
+func TestRotation_badPreviousKeyRejectedAtNew(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.PreviousPublicKeys = []ed25519.PublicKey{[]byte("too-short")}
+	if _, err := New[struct{}](newFakeProvider(t), cfg); !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected ErrInvalidConfig for a wrong-length previous key, got %v", err)
+	}
+}

--- a/auth/jwt/token.go
+++ b/auth/jwt/token.go
@@ -98,11 +98,11 @@ func signToken(claims gjwt.Claims, key ed25519.PrivateKey, kid string) (string, 
 // signed by the same key but issued for a different service would otherwise be
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, kid string, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
+func verifyAccessToken[T any](tokenStr string, keys map[string]ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
 	var c accessClaims[T]
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub, kid),                             // enforce EdDSA alg + kid match; rejects HS256/RS256 confusion attacks and unknown key IDs
+		eddsaKeyFunc(keys), // enforce EdDSA alg + select pub by kid; rejects HS256/RS256 confusion attacks and unknown key IDs
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
@@ -122,11 +122,11 @@ func verifyAccessToken[T any](tokenStr string, pub ed25519.PublicKey, kid string
 // signed by the same key but issued for a different service would otherwise be
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
-func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, kid string, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
+func verifyRefreshToken(tokenStr string, keys map[string]ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
 	var c refreshClaims
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
-		eddsaKeyFunc(pub, kid),                             // enforce EdDSA alg + kid match; rejects HS256/RS256 confusion attacks and unknown key IDs
+		eddsaKeyFunc(keys), // enforce EdDSA alg + select pub by kid; rejects HS256/RS256 confusion attacks and unknown key IDs
 		gjwt.WithTimeFunc(func() time.Time { return now }), // inject clock so tests can freeze time
 		gjwt.WithExpirationRequired(),                      // reject tokens without an exp claim
 		gjwt.WithIssuedAt(),                                // reject tokens with iat in the future
@@ -140,12 +140,14 @@ func verifyRefreshToken(tokenStr string, pub ed25519.PublicKey, kid string, now 
 	return &c, nil
 }
 
-// eddsaKeyFunc returns a gjwt.Keyfunc that enforces EdDSA, validates the
-// token's "kid" header against the expected value, and returns pub.
-// Rejecting unknown kids narrows the verifier to keys the operator has
-// actually authorised, which matters once key rotation is in play (the
-// verifier would otherwise happily try pub against every incoming kid).
-func eddsaKeyFunc(pub ed25519.PublicKey, expectedKID string) gjwt.Keyfunc {
+// eddsaKeyFunc returns a gjwt.Keyfunc that enforces EdDSA and selects the
+// verification key by the token's "kid" header from keys.
+//
+// Holding more than one key lets a verifier accept tokens signed by a previous
+// key while issuing under the current one — the overlap that makes key rotation
+// zero-downtime. A token whose kid is not in the set is rejected, so the
+// verifier only ever trusts keys the operator has authorised.
+func eddsaKeyFunc(keys map[string]ed25519.PublicKey) gjwt.Keyfunc {
 	return func(t *gjwt.Token) (any, error) {
 		// Explicitly reject any algorithm that is not EdDSA.
 		// Without this check an attacker could craft a token with alg=HS256
@@ -154,14 +156,12 @@ func eddsaKeyFunc(pub ed25519.PublicKey, expectedKID string) gjwt.Keyfunc {
 		if _, ok := t.Method.(*gjwt.SigningMethodEd25519); !ok {
 			return nil, fmt.Errorf("%w: unexpected alg %q", ErrTokenInvalid, t.Header["alg"])
 		}
-		// Reject tokens that did not declare a kid or declared one we do not
-		// recognise. Empty expectedKID disables the check (defence in depth
-		// for callers that legitimately sign without a kid header).
-		if expectedKID != "" {
-			kid, _ := t.Header["kid"].(string)
-			if kid != expectedKID {
-				return nil, fmt.Errorf("%w: unexpected kid %q", ErrTokenInvalid, kid)
-			}
+		// Select the public key by the token's kid. An unknown (or missing) kid
+		// is refused — the verifier never falls back to "try every key".
+		kid, _ := t.Header["kid"].(string)
+		pub, ok := keys[kid]
+		if !ok {
+			return nil, fmt.Errorf("%w: unrecognised kid %q", ErrTokenInvalid, kid)
 		}
 		return pub, nil
 	}

--- a/authcore.go
+++ b/authcore.go
@@ -89,7 +89,12 @@ func New(cfg Config) (*AuthCore, error) {
 
 	log := newLogger(cfg)
 
-	km, err := keymanager.New(cfg.KeysDir, log)
+	store := cfg.KeyStore
+	if store == nil {
+		// Default: the zero-config secure-disk store under KeysDir.
+		store = diskKeyStore{dir: cfg.KeysDir, log: log}
+	}
+	keys, err := store.Load()
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrKeyManager, err)
 	}
@@ -97,7 +102,7 @@ func New(cfg Config) (*AuthCore, error) {
 	ac := &AuthCore{
 		config: cfg,
 		log:    log,
-		keys:   km,
+		keys:   keys,
 	}
 
 	ac.log.Info("authcore initialised (timezone=%s, logs=%v, keys=%s)",

--- a/config.go
+++ b/config.go
@@ -30,7 +30,15 @@ type Config struct {
 	//
 	// The directory is created automatically on first use. A .gitignore is
 	// written inside it to prevent accidental commits of key material.
+	//
+	// Ignored when KeyStore is set.
 	KeysDir string
+
+	// KeyStore optionally overrides where cryptographic keys come from. When
+	// nil (the default), authcore uses the disk store under KeysDir. Set it to
+	// source keys from a secret manager, environment, or KMS instead — see
+	// NewKeyStoreFromKeys and NewKeyStoreFromPEM. When set, KeysDir is ignored.
+	KeyStore KeyStore
 }
 
 // DefaultConfig returns a Config populated with safe, production-ready defaults.
@@ -73,8 +81,12 @@ func validateConfig(cfg Config) error {
 	if cfg.Timezone == nil {
 		return ErrInvalidTimezone
 	}
-	if err := validateKeysDir(cfg.KeysDir); err != nil {
-		return err
+	// KeysDir only matters for the default disk store; a custom KeyStore does
+	// not use it, so skip the directory check entirely.
+	if cfg.KeyStore == nil {
+		if err := validateKeysDir(cfg.KeysDir); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -133,10 +133,36 @@ What to do about it:
 
 - **Good enough for most apps:** keep `AccessTokenTTL` short (the 15-minute
   default) so a logged-out token dies quickly on its own.
-- **Need instant kill** (logout-everywhere, compromised account): maintain your
-  own denylist keyed by the `SessionID`/`jti` (it is stable across rotations)
-  and check it in your middleware after `VerifyAccessToken`, or shorten
-  `AccessTokenTTL` further.
+- **Need instant kill** (logout-everywhere, compromised account): set a
+  `Denylist` on the config. `VerifyAccessToken` then checks it on every
+  otherwise-valid access token, keyed by the `jti`/`SessionID` (stable across
+  rotations), and returns `ErrTokenRevoked` for a killed session.
+
+```go
+// Your store — in-memory, Redis, a DB table. Must fail closed.
+type myDenylist struct{ /* ... */ }
+func (d *myDenylist) IsRevoked(ctx context.Context, jti string) (bool, error) {
+    return d.store.Exists(ctx, "revoked:"+jti)
+}
+
+cfg := jwt.DefaultConfig()
+cfg.Denylist = &myDenylist{ /* ... */ }
+jwtMod, _ := jwt.New[MyClaims](auth, cfg)
+
+// On logout / force-logout: add the session id to the store.
+d.store.Add(ctx, "revoked:"+pair.SessionID, pair.RefreshTokenExpiresAt)
+
+// Verification rejects it from then on:
+claims, err := jwtMod.VerifyAccessTokenContext(ctx, token)
+if errors.Is(err, jwt.ErrTokenRevoked) { /* 401, re-authenticate */ }
+```
+
+The denylist is opt-in: leave `Denylist` nil and verification stays fully
+stateless (no per-request lookup). The lookup runs only for tokens that already
+passed signature and expiry, so a garbage token never touches your store. Use
+`VerifyAccessTokenContext` to pass a request context to the lookup; a store
+error fails closed (the token is rejected). Size the store entries to expire at
+the access token's `exp` — past that the token is dead anyway.
 
 ## Clock skew tolerance
 

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -53,8 +53,36 @@ auth, err := authcore.New(cfg)
 > loads and validates them — it never writes. It writes only when generating a
 > missing file on first run, which a pre-generated mount avoids entirely.
 
-A pluggable key source (env / secret manager / KMS instead of files) is on the
-roadmap for deployments that prefer not to use a mounted volume.
+## Sourcing keys without a volume (KeyStore)
+
+If mounting a volume is awkward — serverless, or keys that live only in a secret
+manager — set `Config.KeyStore` to source the material directly instead of from
+disk. `KeysDir` is then ignored.
+
+```go
+cfg := authcore.DefaultConfig()
+
+// Keys arrive as PEM strings from env / a secret manager.
+ks, err := authcore.NewKeyStoreFromPEM(
+    []byte(os.Getenv("AUTHCORE_PRIVATE_PEM")),
+    []byte(os.Getenv("AUTHCORE_PUBLIC_PEM")),
+    refreshSecretBytes, // raw 32 bytes
+)
+if err != nil { log.Fatal(err) }
+cfg.KeyStore = ks
+
+auth, err := authcore.New(cfg)
+```
+
+`NewKeyStoreFromKeys(priv, pub, secret)` takes already-parsed Ed25519 values for
+the same purpose. Both validate that the public key matches the private key and
+that the refresh secret is 32 bytes, so a misconfigured secret fails loudly at
+startup rather than producing tokens no replica can verify. Inject the **same**
+material into every replica, exactly as with a shared volume.
+
+To implement a fully custom source (KMS that signs without exposing the private
+key would need more than this), satisfy the one-method `KeyStore` interface
+yourself: `Load() (authcore.Keys, error)`.
 
 The `KeyID()` accessor returns a 16-character hex digest derived from the public
 key. It is embedded in every token's `kid` JOSE header, enabling zero-downtime

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -85,10 +85,32 @@ key would need more than this), satisfy the one-method `KeyStore` interface
 yourself: `Load() (authcore.Keys, error)`.
 
 The `KeyID()` accessor returns a 16-character hex digest derived from the public
-key. It is embedded in every token's `kid` JOSE header, enabling zero-downtime
-key rotation. Verification rejects tokens whose `kid` does not match the module's
-current key id, so a future multi-key deployment only ever accepts tokens minted
-under an authorised key.
+key. It is embedded in every token's `kid` JOSE header. Verification selects the
+key by `kid` and rejects any token whose `kid` is not one the module accepts.
+
+## Rotating the signing key (zero downtime)
+
+Rotating the Ed25519 key without logging everyone out is a two-phase move that
+relies on `kid`: tokens already in the wild were signed by the old key, so the
+verifier must keep accepting it until they expire.
+
+1. **Overlap.** Make the new key the active one (new `KeysDir` / `KeyStore`
+   material) and list the **old public key** in `jwt.Config.PreviousPublicKeys`.
+   New tokens are signed only with the new key; tokens still bearing the old
+   `kid` keep verifying.
+
+   ```go
+   cfg := jwt.DefaultConfig()
+   cfg.PreviousPublicKeys = []ed25519.PublicKey{oldPublicKey}
+   jwtMod, _ := jwt.New[MyClaims](auth, cfg)
+   ```
+
+2. **Retire.** Once every token signed by the old key has expired (at most one
+   `RefreshTokenTTL`), deploy again without it. The old key is gone.
+
+Each listed key is indexed by its derived `kid`, so a token picks the right key
+automatically. A `kid` that is neither the current key nor a listed previous key
+is rejected as `ErrTokenInvalid`.
 
 > [!NOTE]
 > Key-file loaders enforce a **4 KiB size cap**. A healthy Ed25519 PEM is ~200

--- a/docs/secure-login.md
+++ b/docs/secure-login.md
@@ -157,9 +157,10 @@ db.DeleteSession(session.ID) // stops renewal
 > default). See [JWT — Revocation & logout](jwt.md#revocation--logout).
 
 - **Most apps:** the short access TTL is enough — the token dies on its own.
-- **Need instant kill** (logout-everywhere, account compromise): keep your own
-  denylist keyed by `SessionID`/`jti` (stable across rotations) and check it in
-  middleware after `VerifyAccessToken`, or shorten `AccessTokenTTL`.
+- **Need instant kill** (logout-everywhere, account compromise): set a
+  `jwt.Denylist` on the config and add the `SessionID` to your store on logout —
+  `VerifyAccessToken` then returns `ErrTokenRevoked`. See
+  [JWT — Revocation & logout](jwt.md#revocation--logout).
 
 ## 7. Brute force & lockout
 

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -177,19 +177,7 @@ func readPrivateKey(path string) (ed25519.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, fmt.Errorf("no PEM block found in %q", path)
-	}
-	raw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("parse PKCS#8 private key from %q: %w", path, err)
-	}
-	key, ok := raw.(ed25519.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("key in %q is not an Ed25519 private key (got %T)", path, raw)
-	}
-	return key, nil
+	return decodeEd25519PrivatePEM(data, path)
 }
 
 // readPublicKey parses a PKIX PEM file and returns the Ed25519 public key.
@@ -198,17 +186,41 @@ func readPublicKey(path string) (ed25519.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	return decodeEd25519PublicPEM(data, path)
+}
+
+// decodeEd25519PrivatePEM parses a PKCS#8 PEM block into an Ed25519 private key.
+// src names the origin (a path or "input") for error messages.
+func decodeEd25519PrivatePEM(data []byte, src string) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode(data)
 	if block == nil {
-		return nil, fmt.Errorf("no PEM block found in %q", path)
+		return nil, fmt.Errorf("no PEM block found in %q", src)
+	}
+	raw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKCS#8 private key from %q: %w", src, err)
+	}
+	key, ok := raw.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("key in %q is not an Ed25519 private key (got %T)", src, raw)
+	}
+	return key, nil
+}
+
+// decodeEd25519PublicPEM parses a PKIX PEM block into an Ed25519 public key.
+// src names the origin (a path or "input") for error messages.
+func decodeEd25519PublicPEM(data []byte, src string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %q", src)
 	}
 	raw, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("parse PKIX public key from %q: %w", path, err)
+		return nil, fmt.Errorf("parse PKIX public key from %q: %w", src, err)
 	}
 	key, ok := raw.(ed25519.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("key in %q is not an Ed25519 public key (got %T)", path, raw)
+		return nil, fmt.Errorf("key in %q is not an Ed25519 public key (got %T)", src, raw)
 	}
 	return key, nil
 }

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -116,6 +116,12 @@ func New(dir string, log logger) (*KeyManager, error) {
 	}, nil
 }
 
+// KeyID derives the stable key identifier for pub — the same value a
+// KeyManager reports for its own key. It is exported so the JWT module can
+// index additional verification keys (during rotation) by the same id without
+// duplicating the derivation.
+func KeyID(pub ed25519.PublicKey) string { return computeKeyID(pub) }
+
 // computeKeyID derives a stable identifier from a public key.
 // It returns the first 8 bytes of the SHA-256 digest of the raw public key
 // bytes, hex-encoded (16 lowercase characters). The value changes automatically

--- a/internal/keymanager/material.go
+++ b/internal/keymanager/material.go
@@ -1,0 +1,51 @@
+package keymanager
+
+import (
+	"crypto/ed25519"
+	"fmt"
+)
+
+// FromKeys builds an in-memory KeyManager from already-loaded key material,
+// touching no filesystem. It is the backend for a non-disk KeyStore (keys
+// sourced from a secret manager, environment, or KMS).
+//
+// It validates that pub is the public half of priv and that secret is the
+// expected length, then derives the key id. The returned manager has no
+// directory; Dir returns "".
+func FromKeys(priv ed25519.PrivateKey, pub ed25519.PublicKey, secret []byte) (*KeyManager, error) {
+	if l := len(priv); l != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("private key has wrong length: got %d, want %d", l, ed25519.PrivateKeySize)
+	}
+	if l := len(pub); l != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("public key has wrong length: got %d, want %d", l, ed25519.PublicKeySize)
+	}
+	if !priv.Public().(ed25519.PublicKey).Equal(pub) {
+		return nil, fmt.Errorf("public key does not match private key")
+	}
+	if l := len(secret); l != refreshSecretLen {
+		return nil, fmt.Errorf("refresh secret has wrong length: got %d, want %d", l, refreshSecretLen)
+	}
+
+	return &KeyManager{
+		privateKey:    priv,
+		publicKey:     pub,
+		refreshSecret: secret,
+		keyID:         computeKeyID(pub),
+	}, nil
+}
+
+// FromPEM builds an in-memory KeyManager from PEM-encoded key material — a
+// PKCS#8 private key, a PKIX public key, and the raw 32-byte refresh secret.
+// Use it to source keys from environment variables or a secret store that hands
+// out PEM blocks.
+func FromPEM(privatePEM, publicPEM, refreshSecret []byte) (*KeyManager, error) {
+	priv, err := decodeEd25519PrivatePEM(privatePEM, "private key input")
+	if err != nil {
+		return nil, err
+	}
+	pub, err := decodeEd25519PublicPEM(publicPEM, "public key input")
+	if err != nil {
+		return nil, err
+	}
+	return FromKeys(priv, pub, refreshSecret)
+}

--- a/internal/keymanager/material_fuzz_test.go
+++ b/internal/keymanager/material_fuzz_test.go
@@ -1,0 +1,42 @@
+package keymanager_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+// FuzzFromPEM drives the PEM key-material decoder with arbitrary bytes. FromPEM
+// turns untrusted-looking input (PEM blocks sourced from env/secret stores)
+// into key structures, so it must never panic — only return a manager or an
+// error.
+func FuzzFromPEM(f *testing.F) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		f.Fatalf("seed key: %v", err)
+	}
+	privDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	pubDER, _ := x509.MarshalPKIXPublicKey(pub)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	secret := make([]byte, 32)
+
+	f.Add(privPEM, pubPEM, secret)                          // valid set
+	f.Add([]byte("not a pem"), []byte("not a pem"), secret) // garbage
+	f.Add(privPEM, pubPEM, []byte("short"))                 // bad secret length
+	f.Add([]byte{}, []byte{}, []byte{})                     // empty
+
+	f.Fuzz(func(t *testing.T, privBytes, pubBytes, secretBytes []byte) {
+		km, err := keymanager.FromPEM(privBytes, pubBytes, secretBytes)
+		if err == nil && km == nil {
+			t.Fatal("FromPEM returned a nil manager with a nil error")
+		}
+		if err != nil && km != nil {
+			t.Fatal("FromPEM returned a manager alongside an error")
+		}
+	})
+}

--- a/internal/keymanager/material_test.go
+++ b/internal/keymanager/material_test.go
@@ -1,0 +1,71 @@
+package keymanager_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+func genPair(t *testing.T) (ed25519.PrivateKey, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	return priv, pub
+}
+
+func TestFromKeys_valid(t *testing.T) {
+	priv, pub := genPair(t)
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+
+	km, err := keymanager.FromKeys(priv, pub, secret)
+	if err != nil {
+		t.Fatalf("FromKeys: %v", err)
+	}
+	if km.KeyID() == "" {
+		t.Error("KeyID not derived")
+	}
+	if km.Dir() != "" {
+		t.Errorf("in-memory manager Dir() = %q, want empty", km.Dir())
+	}
+}
+
+func TestFromKeys_rejectsBadInput(t *testing.T) {
+	priv, pub := genPair(t)
+	_, otherPub := genPair(t)
+	good := make([]byte, 32)
+
+	cases := map[string]func() error{
+		"mismatched pair": func() error { _, e := keymanager.FromKeys(priv, otherPub, good); return e },
+		"short secret":    func() error { _, e := keymanager.FromKeys(priv, pub, []byte("x")); return e },
+		"nil private":     func() error { _, e := keymanager.FromKeys(nil, pub, good); return e },
+	}
+	for name, fn := range cases {
+		if fn() == nil {
+			t.Errorf("%s: expected an error, got nil", name)
+		}
+	}
+}
+
+func TestFromPEM_roundTripAndGarbage(t *testing.T) {
+	priv, pub := genPair(t)
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	pubDER, _ := x509.MarshalPKIXPublicKey(pub)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	if _, err := keymanager.FromPEM(privPEM, pubPEM, secret); err != nil {
+		t.Fatalf("FromPEM round-trip: %v", err)
+	}
+	if _, err := keymanager.FromPEM([]byte("garbage"), pubPEM, secret); err == nil {
+		t.Error("expected an error for a non-PEM private key")
+	}
+}

--- a/keystore.go
+++ b/keystore.go
@@ -1,0 +1,74 @@
+package authcore
+
+import (
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+// KeyStore sources authcore's cryptographic key material (the Ed25519 signing
+// pair and the HMAC refresh secret).
+//
+// The default is disk: New generates and loads PEM files under Config.KeysDir.
+// Set Config.KeyStore to override that — for example to source keys from a
+// secret manager, environment variables, or KMS, which is the right fit for
+// serverless or disk-averse deployments where a mounted volume is awkward.
+//
+// Implementations are consulted once, at New time. The returned Keys must be
+// stable for the lifetime of the AuthCore instance.
+type KeyStore interface {
+	// Load returns the key material, or an error if it cannot be obtained or
+	// fails validation.
+	Load() (Keys, error)
+}
+
+// diskKeyStore is the default KeyStore: it generates the key files on first run
+// and loads them on subsequent runs, under dir. It preserves the zero-config
+// secure-disk behaviour when Config.KeyStore is not set.
+type diskKeyStore struct {
+	dir string
+	log Logger
+}
+
+func (d diskKeyStore) Load() (Keys, error) {
+	return keymanager.New(d.dir, d.log)
+}
+
+// staticKeyStore serves pre-built, in-memory key material. It never touches
+// the filesystem.
+type staticKeyStore struct {
+	keys Keys
+}
+
+func (s staticKeyStore) Load() (Keys, error) {
+	return s.keys, nil
+}
+
+// NewKeyStoreFromKeys returns a KeyStore backed by in-memory Ed25519 material,
+// touching no filesystem. Use it to inject keys obtained from a secret manager
+// or KMS at startup.
+//
+// It validates that pub is the public half of priv and that refreshSecret is
+// 32 bytes. Assign the result to Config.KeyStore.
+func NewKeyStoreFromKeys(priv ed25519.PrivateKey, pub ed25519.PublicKey, refreshSecret []byte) (KeyStore, error) {
+	km, err := keymanager.FromKeys(priv, pub, refreshSecret)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrKeyManager, err)
+	}
+	return staticKeyStore{keys: km}, nil
+}
+
+// NewKeyStoreFromPEM returns a KeyStore from PEM-encoded material: a PKCS#8
+// private key, a PKIX public key, and the raw 32-byte refresh secret. This is
+// the convenient form when keys arrive as PEM strings from environment
+// variables or a secret store.
+//
+// Assign the result to Config.KeyStore.
+func NewKeyStoreFromPEM(privatePEM, publicPEM, refreshSecret []byte) (KeyStore, error) {
+	km, err := keymanager.FromPEM(privatePEM, publicPEM, refreshSecret)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrKeyManager, err)
+	}
+	return staticKeyStore{keys: km}, nil
+}

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -1,0 +1,111 @@
+package authcore_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/Glyndor/authcore"
+)
+
+func genMaterial(t *testing.T) (ed25519.PrivateKey, ed25519.PublicKey, []byte) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		t.Fatalf("generate secret: %v", err)
+	}
+	return priv, pub, secret
+}
+
+func TestNewKeyStoreFromKeys_used(t *testing.T) {
+	priv, pub, secret := genMaterial(t)
+	ks, err := authcore.NewKeyStoreFromKeys(priv, pub, secret)
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromKeys: %v", err)
+	}
+
+	cfg := authcore.DefaultConfig()
+	cfg.EnableLogs = false
+	cfg.KeyStore = ks
+	cfg.KeysDir = "" // must be ignored
+
+	ac, err := authcore.New(cfg)
+	if err != nil {
+		t.Fatalf("New with KeyStore: %v", err)
+	}
+	if !ac.Keys().PrivateKey().Equal(priv) {
+		t.Error("module did not use the injected private key")
+	}
+	if string(ac.Keys().RefreshSecret()) != string(secret) {
+		t.Error("module did not use the injected refresh secret")
+	}
+}
+
+func TestNewKeyStoreFromKeys_mismatchedPairRejected(t *testing.T) {
+	priv, _, secret := genMaterial(t)
+	_, otherPub, _ := genMaterial(t)
+	if _, err := authcore.NewKeyStoreFromKeys(priv, otherPub, secret); err == nil {
+		t.Error("expected an error for a mismatched key pair")
+	}
+}
+
+func TestNewKeyStoreFromKeys_badSecretRejected(t *testing.T) {
+	priv, pub, _ := genMaterial(t)
+	if _, err := authcore.NewKeyStoreFromKeys(priv, pub, []byte("too-short")); err == nil {
+		t.Error("expected an error for a wrong-length refresh secret")
+	}
+}
+
+func TestNewKeyStoreFromPEM_roundTrip(t *testing.T) {
+	priv, pub, secret := genMaterial(t)
+	privDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	pubDER, _ := x509.MarshalPKIXPublicKey(pub)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	ks, err := authcore.NewKeyStoreFromPEM(privPEM, pubPEM, secret)
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromPEM: %v", err)
+	}
+	cfg := authcore.DefaultConfig()
+	cfg.EnableLogs = false
+	cfg.KeyStore = ks
+	ac, err := authcore.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !ac.Keys().PublicKey().Equal(pub) {
+		t.Error("module did not load the PEM public key")
+	}
+}
+
+func TestNewKeyStoreFromPEM_garbageRejected(t *testing.T) {
+	_, _, secret := genMaterial(t)
+	if _, err := authcore.NewKeyStoreFromPEM([]byte("nope"), []byte("nope"), secret); err == nil {
+		t.Error("expected an error for non-PEM input")
+	}
+}
+
+func TestNew_keyStoreBypassesKeysDirValidation(t *testing.T) {
+	// A KeyStore makes KeysDir irrelevant, so even an invalid KeysDir must not
+	// block startup.
+	priv, pub, secret := genMaterial(t)
+	ks, err := authcore.NewKeyStoreFromKeys(priv, pub, secret)
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromKeys: %v", err)
+	}
+	cfg := authcore.DefaultConfig()
+	cfg.EnableLogs = false
+	cfg.KeyStore = ks
+	cfg.KeysDir = string([]byte{0}) // would fail validateKeysDir if it ran
+
+	if _, err := authcore.New(cfg); err != nil {
+		t.Errorf("KeyStore must bypass KeysDir validation, got %v", err)
+	}
+}


### PR DESCRIPTION
Release v1.6.0 — token & key lifecycle. All additive, no breaking changes.

## Features
- **Access-token denylist (#126).** Opt-in `Config.Denylist` makes stateless access tokens revocable before they expire — `VerifyAccessToken` rejects a killed session with `ErrTokenRevoked`. Off by default (stateless fast path unchanged). New `VerifyAccessTokenContext` threads a request context.
- **Pluggable KeyStore (#127).** `Config.KeyStore` sources keys from a secret manager / env / KMS instead of disk — `NewKeyStoreFromKeys` and `NewKeyStoreFromPEM`. Disk stays the zero-config default. The fix for serverless and disk-averse deployments.
- **Zero-downtime key rotation (#128).** `Config.PreviousPublicKeys` keeps old keys accepted for verification during a rotation overlap while new tokens sign with the current key, selected by `kid`.

## Tests
- Fuzz target for the new `FromPEM` decoder (#145).

Docs updated: JWT revocation, key-management (KeyStore + two-phase rotation), and the secure-login recipe.
