### PR TITLE
release: v1.7.0

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,5 +21,6 @@ jobs:
           {"package":"./auth/jwt","func":"FuzzIsUUIDv7"},
           {"package":"./auth/password","func":"FuzzValidatePolicy"},
           {"package":"./auth/password","func":"FuzzParsePHC"},
+          {"package":"./auth/apikey","func":"FuzzParseID"},
           {"package":"./internal/keymanager","func":"FuzzFromPEM"}
         ]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Pick only what you need — each is independent, testable, and safe by default.
 | 🎫 | **[jwt](docs/jwt.md)** | Access + refresh tokens. EdDSA / Ed25519, generic claims, rotation. |
 | 📧 | **[email](docs/validation.md)** | Validate + normalize. RFC 5321/5322, optional cached DNS MX check. |
 | 👤 | **[username](docs/validation.md)** | Validate + normalize. Reserved-name blocklist, character rules. |
+| 🗝️ | **[apikey](docs/apikey.md)** | Opaque API keys. Generate, keyed-hash for storage, constant-time verify. |
 
 ```mermaid
 flowchart LR
@@ -109,7 +110,7 @@ flowchart LR
 **New here? Start with the [Secure login recipe](docs/secure-login.md)** — the
 step-by-step flow that turns these primitives into a login an auditor accepts.
 
-[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
+[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
 
 Full API reference on [pkg.go.dev](https://pkg.go.dev/github.com/Glyndor/authcore).
 

--- a/auth/apikey/apikey.go
+++ b/auth/apikey/apikey.go
@@ -1,0 +1,179 @@
+// Package apikey issues and verifies opaque API keys for authcore.
+//
+// # What it is for
+//
+// API keys authenticate machines — a CLI, a service, a webhook caller — where
+// a username/password or a short-lived JWT does not fit. authcore generates a
+// high-entropy opaque key, returns a hash for you to store, and verifies a
+// presented key against that hash in constant time. The library never stores
+// anything; you own the database.
+//
+// # Key shape
+//
+//		<prefix>_<id>_<secret>
+//
+//	  - prefix — a short fixed tag (default "ak") so a leaked key is recognisable
+//	    in logs and can be scanned for.
+//	  - id     — a random public identifier. Store it in plaintext and use it as
+//	    the database lookup key, so verification is an O(1) row fetch, not a scan.
+//	  - secret — 256 bits of CSPRNG output, hex-encoded. Only its keyed hash is
+//	    stored.
+//
+// # Storage model
+//
+// The key is high-entropy random, so it is hashed with keyed HMAC-SHA256 (fast,
+// constant-time-verifiable, peppered with the library's managed secret) rather
+// than a slow password hash — a per-request API call must not pay Argon2id cost,
+// and a 256-bit random key has no need of it.
+//
+//	auth, _   := authcore.New(authcore.DefaultConfig())
+//	keyMod, _ := apikey.New(auth)
+//
+//	// Issue — show key.Key to the user ONCE; store key.ID and key.Hash.
+//	key, _ := keyMod.Generate()
+//	db.StoreAPIKey(key.ID, key.Hash, userID)
+//
+//	// Verify — extract the id, fetch the row, compare in constant time.
+//	id, err := keyMod.ParseID(presented)
+//	if err != nil { return http.StatusUnauthorized }
+//	row, err := db.FindAPIKey(id)
+//	if err != nil || !keyMod.Verify(presented, row.Hash) { return http.StatusUnauthorized }
+package apikey
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/Glyndor/authcore"
+)
+
+const (
+	idLen     = 16 // bytes — 128-bit public identifier, hex-encoded (32 chars)
+	secretLen = 32 // bytes — 256-bit secret, hex-encoded (64 chars)
+)
+
+// Compile-time assertion: *APIKey must satisfy authcore.Module.
+var _ authcore.Module = (*APIKey)(nil)
+
+// APIKey is the opaque API-key module.
+//
+// Construct one instance at application startup using New and share it across
+// goroutines. APIKey is safe for concurrent use after construction.
+type APIKey struct {
+	cfg    Config
+	log    authcore.Logger
+	secret []byte // HMAC-SHA256 pepper, sourced from the parent AuthCore instance
+}
+
+// GeneratedKey is the result of Generate.
+//
+// Show Key to the user exactly once — it is never recoverable afterwards.
+// Persist ID (plaintext, the lookup key) and Hash (never the raw key).
+type GeneratedKey struct {
+	// Key is the full opaque API key to hand to the caller, once.
+	Key string
+	// ID is the public identifier embedded in Key. Store it and use it to look
+	// up the stored hash on verification.
+	ID string
+	// Hash is the keyed HMAC-SHA256 digest of Key. Store only this.
+	Hash string
+}
+
+// New creates an APIKey module.
+//
+// cfg is optional — omit it for the default key prefix ("ak"):
+//
+//	keyMod, err := apikey.New(auth)
+//	keyMod, err := apikey.New(auth, apikey.Config{Prefix: "svc"})
+func New(p authcore.Provider, cfg ...Config) (*APIKey, error) {
+	var resolved Config
+	if len(cfg) > 0 {
+		resolved = cfg[0]
+	}
+	resolved = applyDefaults(resolved)
+	if err := validateConfig(resolved); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	a := &APIKey{cfg: resolved, log: p.Logger(), secret: p.Keys().RefreshSecret()}
+	a.log.Info("apikey: module initialised (prefix=%s)", resolved.Prefix)
+	return a, nil
+}
+
+// Name returns the module's unique identifier. It implements authcore.Module.
+func (a *APIKey) Name() string { return "apikey" }
+
+// Generate mints a new opaque API key. The id and secret are independent
+// CSPRNG draws; the returned Hash is what you store.
+func (a *APIKey) Generate() (*GeneratedKey, error) {
+	idBytes := make([]byte, idLen)
+	if _, err := rand.Read(idBytes); err != nil {
+		return nil, fmt.Errorf("apikey: generate id: %w", err)
+	}
+	secretBytes := make([]byte, secretLen)
+	if _, err := rand.Read(secretBytes); err != nil {
+		return nil, fmt.Errorf("apikey: generate secret: %w", err)
+	}
+
+	id := hex.EncodeToString(idBytes)
+	secret := hex.EncodeToString(secretBytes)
+	full := a.cfg.Prefix + "_" + id + "_" + secret
+
+	return &GeneratedKey{Key: full, ID: id, Hash: a.hash(full)}, nil
+}
+
+// Hash returns the keyed HMAC-SHA256 digest of key. Use it to recompute the
+// stored value (it matches GeneratedKey.Hash for the same key).
+func (a *APIKey) Hash(key string) string {
+	return a.hash(key)
+}
+
+// Verify reports whether key matches storedHash, comparing in constant time to
+// prevent timing attacks.
+func (a *APIKey) Verify(key, storedHash string) bool {
+	return subtle.ConstantTimeCompare([]byte(a.hash(key)), []byte(storedHash)) == 1
+}
+
+// ParseID extracts the public identifier from a presented key without verifying
+// it, so you can fetch the stored hash before the constant-time comparison.
+//
+// It returns ErrInvalidKey if key is not a well-formed key for this module
+// (wrong prefix, wrong structure, or a malformed id).
+func (a *APIKey) ParseID(key string) (string, error) {
+	prefix := a.cfg.Prefix + "_"
+	rest, ok := strings.CutPrefix(key, prefix)
+	if !ok {
+		return "", ErrInvalidKey
+	}
+	id, secret, ok := strings.Cut(rest, "_")
+	if !ok || secret == "" {
+		return "", ErrInvalidKey
+	}
+	if len(id) != hex.EncodedLen(idLen) || !isHex(id) {
+		return "", ErrInvalidKey
+	}
+	return id, nil
+}
+
+// hash computes the keyed HMAC-SHA256 hex digest of key.
+func (a *APIKey) hash(key string) string {
+	mac := hmac.New(sha256.New, a.secret)
+	mac.Write([]byte(key))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// isHex reports whether s is all lowercase hexadecimal digits.
+func isHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/auth/apikey/apikey_fuzz_test.go
+++ b/auth/apikey/apikey_fuzz_test.go
@@ -1,0 +1,36 @@
+package apikey_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseID drives ParseID with arbitrary input. ParseID runs on the raw key
+// a client presents, so it must never panic — only return an id or ErrInvalidKey
+// — and must never accept a key whose structure it cannot validate.
+func FuzzParseID(f *testing.F) {
+	m := newMod(f)
+
+	key, _ := m.Generate()
+	f.Add(key.Key)
+	f.Add("")
+	f.Add("ak_")
+	f.Add("ak_" + strings.Repeat("0", 32) + "_secret")
+	f.Add("not-even-close")
+	f.Add("ak_zzzz_zzzz")
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		id, err := m.ParseID(raw)
+		if err != nil {
+			return // rejected — fine
+		}
+		// A returned id must be the canonical 32-char hex and must round-trip
+		// back out of the input.
+		if len(id) != 32 {
+			t.Fatalf("ParseID accepted %q and returned a non-canonical id %q", raw, id)
+		}
+		if !strings.Contains(raw, id) {
+			t.Fatalf("ParseID(%q) returned id %q that is not in the input", raw, id)
+		}
+	})
+}

--- a/auth/apikey/apikey_test.go
+++ b/auth/apikey/apikey_test.go
@@ -1,0 +1,155 @@
+package apikey_test
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/auth/apikey"
+)
+
+// ---- test infrastructure ----------------------------------------------------
+
+type fakeKeys struct{ secret []byte }
+
+func (fakeKeys) PrivateKey() ed25519.PrivateKey { return nil }
+func (fakeKeys) PublicKey() ed25519.PublicKey   { return nil }
+func (k fakeKeys) RefreshSecret() []byte        { return k.secret }
+func (fakeKeys) KeyID() string                  { return "test" }
+
+type fakeProvider struct{ keys authcore.Keys }
+
+func (fakeProvider) Config() authcore.Config { return authcore.DefaultConfig() }
+func (fakeProvider) Logger() authcore.Logger { return silentLogger{} }
+func (p fakeProvider) Keys() authcore.Keys   { return p.keys }
+
+type silentLogger struct{}
+
+func (silentLogger) Debug(string, ...any) {}
+func (silentLogger) Info(string, ...any)  {}
+func (silentLogger) Warn(string, ...any)  {}
+func (silentLogger) Error(string, ...any) {}
+
+func newMod(tb testing.TB, cfg ...apikey.Config) *apikey.APIKey {
+	tb.Helper()
+	p := fakeProvider{keys: fakeKeys{secret: []byte("0123456789abcdef0123456789abcdef")}}
+	m, err := apikey.New(p, cfg...)
+	if err != nil {
+		tb.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+// ---- New --------------------------------------------------------------------
+
+func TestNew_defaultPrefix(t *testing.T) {
+	m := newMod(t)
+	if m.Name() != "apikey" {
+		t.Errorf("Name() = %q, want apikey", m.Name())
+	}
+}
+
+func TestNew_invalidPrefixRejected(t *testing.T) {
+	p := fakeProvider{keys: fakeKeys{secret: make([]byte, 32)}}
+	for _, prefix := range []string{"has_underscore", "UPPER", "with space", strings.Repeat("x", 17)} {
+		if _, err := apikey.New(p, apikey.Config{Prefix: prefix}); !errors.Is(err, apikey.ErrInvalidConfig) {
+			t.Errorf("prefix %q: expected ErrInvalidConfig, got %v", prefix, err)
+		}
+	}
+}
+
+// ---- Generate / Verify ------------------------------------------------------
+
+func TestGenerate_shapeAndVerify(t *testing.T) {
+	m := newMod(t)
+	key, err := m.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.HasPrefix(key.Key, "ak_") {
+		t.Errorf("key %q missing prefix", key.Key)
+	}
+	if parts := strings.Split(key.Key, "_"); len(parts) != 3 {
+		t.Errorf("key has %d parts, want 3", len(parts))
+	}
+	id, err := m.ParseID(key.Key)
+	if err != nil {
+		t.Fatalf("ParseID: %v", err)
+	}
+	if id != key.ID {
+		t.Errorf("ParseID = %q, want embedded ID %q", id, key.ID)
+	}
+	if !m.Verify(key.Key, key.Hash) {
+		t.Error("Verify rejected a freshly generated key")
+	}
+}
+
+func TestGenerate_uniquePerCall(t *testing.T) {
+	m := newMod(t)
+	a, _ := m.Generate()
+	b, _ := m.Generate()
+	if a.Key == b.Key || a.ID == b.ID || a.Hash == b.Hash {
+		t.Error("two Generate calls produced colliding output")
+	}
+}
+
+func TestVerify_wrongKeyRejected(t *testing.T) {
+	m := newMod(t)
+	key, _ := m.Generate()
+	if m.Verify("ak_"+strings.Repeat("0", 32)+"_tampered", key.Hash) {
+		t.Error("Verify accepted a key that does not match the stored hash")
+	}
+}
+
+func TestVerify_peppered(t *testing.T) {
+	// A hash made under one server secret must not verify under another.
+	m1 := newMod(t)
+	key, _ := m1.Generate()
+
+	p2 := fakeProvider{keys: fakeKeys{secret: []byte("ffffffffffffffffffffffffffffffff")}}
+	m2, _ := apikey.New(p2)
+	if m2.Verify(key.Key, key.Hash) {
+		t.Error("a key verified under a different server secret; HMAC pepper is not applied")
+	}
+}
+
+func TestHash_deterministic(t *testing.T) {
+	m := newMod(t)
+	key, _ := m.Generate()
+	if m.Hash(key.Key) != key.Hash {
+		t.Error("Hash is not deterministic for the same key")
+	}
+}
+
+// ---- ParseID ----------------------------------------------------------------
+
+func TestParseID_malformedRejected(t *testing.T) {
+	m := newMod(t)
+	cases := []string{
+		"",
+		"nope",
+		"ak_onlytwo",
+		"wrong_" + strings.Repeat("0", 32) + "_secret",
+		"ak_" + strings.Repeat("z", 32) + "_secret", // non-hex id
+		"ak_" + strings.Repeat("0", 10) + "_secret", // short id
+		"ak_" + strings.Repeat("0", 32) + "_",       // empty secret
+	}
+	for _, c := range cases {
+		if _, err := m.ParseID(c); !errors.Is(err, apikey.ErrInvalidKey) {
+			t.Errorf("ParseID(%q) = %v, want ErrInvalidKey", c, err)
+		}
+	}
+}
+
+func TestParseID_customPrefix(t *testing.T) {
+	m := newMod(t, apikey.Config{Prefix: "svc"})
+	key, _ := m.Generate()
+	if !strings.HasPrefix(key.Key, "svc_") {
+		t.Errorf("custom prefix not applied: %q", key.Key)
+	}
+	if _, err := m.ParseID(key.Key); err != nil {
+		t.Errorf("ParseID with custom prefix: %v", err)
+	}
+}

--- a/auth/apikey/config.go
+++ b/auth/apikey/config.go
@@ -1,0 +1,55 @@
+package apikey
+
+import (
+	"fmt"
+	"strings"
+)
+
+// maxPrefixLen bounds the key prefix. A prefix is a short recognisable tag, not
+// a payload; capping it keeps keys tidy and scannable.
+const maxPrefixLen = 16
+
+// Config holds the apikey module configuration.
+type Config struct {
+	// Prefix is the fixed tag at the start of every key (e.g. "ak" -> "ak_...").
+	// Pick something short and product-specific so a leaked key is recognisable
+	// in logs and secret scanners. Must be 1–16 lowercase letters or digits and
+	// must not contain "_" (the field separator).
+	//
+	// Defaults to "ak".
+	Prefix string
+}
+
+// DefaultConfig returns a Config with safe defaults.
+func DefaultConfig() Config {
+	return Config{Prefix: "ak"}
+}
+
+// applyDefaults fills zero-value fields with values from DefaultConfig.
+func applyDefaults(cfg Config) Config {
+	if cfg.Prefix == "" {
+		cfg.Prefix = DefaultConfig().Prefix
+	}
+	return cfg
+}
+
+// validateConfig returns an error if cfg contains invalid values.
+func validateConfig(cfg Config) error {
+	if cfg.Prefix == "" {
+		return fmt.Errorf("prefix must not be empty")
+	}
+	if len(cfg.Prefix) > maxPrefixLen {
+		return fmt.Errorf("prefix must be at most %d characters, got %d", maxPrefixLen, len(cfg.Prefix))
+	}
+	if strings.Contains(cfg.Prefix, "_") {
+		return fmt.Errorf("prefix must not contain '_' (the key field separator)")
+	}
+	for _, r := range cfg.Prefix {
+		isLower := r >= 'a' && r <= 'z'
+		isDigit := r >= '0' && r <= '9'
+		if !isLower && !isDigit {
+			return fmt.Errorf("prefix must be lowercase letters or digits only, got %q", cfg.Prefix)
+		}
+	}
+	return nil
+}

--- a/auth/apikey/errors.go
+++ b/auth/apikey/errors.go
@@ -1,0 +1,20 @@
+package apikey
+
+import "errors"
+
+// Sentinel errors returned by the apikey package.
+// Use errors.Is to check for these in calling code.
+var (
+	// ErrInvalidConfig is returned by New when the provided Config fails
+	// validation (e.g. an empty or malformed Prefix).
+	//
+	// Safety: INTERNAL — a startup/programming error. Treat as a 500.
+	ErrInvalidConfig = errors.New("apikey: invalid configuration")
+
+	// ErrInvalidKey is returned by ParseID when the presented key is not a
+	// well-formed key for this module (wrong prefix, structure, or id).
+	//
+	// Safety: INTERNAL — return a generic "unauthorized" to the client; never
+	// echo back why the key was rejected.
+	ErrInvalidKey = errors.New("apikey: malformed key")
+)

--- a/docs/apikey.md
+++ b/docs/apikey.md
@@ -1,0 +1,63 @@
+# API keys
+
+`auth/apikey` issues and verifies opaque API keys — for authenticating machines
+(a CLI, a service, a webhook caller) where a password or a short-lived JWT does
+not fit. The library never stores anything; you store a hash. See the
+[error reference](errors.md).
+
+## Setup
+
+```go
+auth, err := authcore.New(authcore.DefaultConfig())
+keyMod, err := apikey.New(auth) // default prefix "ak"
+```
+
+## Key shape
+
+```
+ak_<id>_<secret>
+```
+
+- **prefix** — a short fixed tag (default `ak`) so a leaked key is recognisable
+  in logs and secret scanners. Override with `apikey.Config{Prefix: "svc"}` —
+  1–16 lowercase letters/digits.
+- **id** — a random public identifier. Store it in plaintext and use it as the
+  database lookup key, so verification is an O(1) row fetch, not a scan.
+- **secret** — 256 bits of CSPRNG output. Only its keyed hash is stored.
+
+## Issuing
+
+```go
+key, err := keyMod.Generate()
+// Show key.Key to the user ONCE — it is never recoverable.
+// Store key.ID (lookup) and key.Hash. Never store key.Key.
+db.StoreAPIKey(key.ID, key.Hash, userID)
+```
+
+## Verifying
+
+```go
+id, err := keyMod.ParseID(presented)
+if err != nil { return http.StatusUnauthorized } // malformed
+
+row, err := db.FindAPIKey(id)
+if err != nil || !keyMod.Verify(presented, row.Hash) {
+    return http.StatusUnauthorized
+}
+// authenticated as row.UserID
+```
+
+`Verify` compares in **constant time** (`crypto/subtle`).
+
+> **Why not Argon2id?** An API key is 256 bits of random — brute-forcing it is
+> infeasible regardless of hash speed, and a per-request call must not pay
+> Argon2id's cost. Keys are hashed with **keyed HMAC-SHA256**, peppered with the
+> library's managed secret, so a leaked database of hashes is useless without
+> the server secret too. (Passwords are different — they are low-entropy and use
+> Argon2id; see [Password hashing](password.md).)
+
+## Revoking
+
+Delete the row (or flag it) and check on lookup. There is no token to expire —
+an API key lives until you remove it, so build rotation/expiry into your own
+schema if you need it.

--- a/module.go
+++ b/module.go
@@ -69,6 +69,8 @@ type Provider interface {
 //	                  email.New(p authcore.Provider) (*email.Email, error)
 //	auth/username — username validation, normalization, reserved name blocklist
 //	                  username.New(p authcore.Provider) (*username.Username, error)
+//	auth/apikey   — opaque API key generation, hashing, and verification
+//	                  apikey.New(p authcore.Provider, cfg ...apikey.Config) (*apikey.APIKey, error)
 //
 // Conventions shared by every module:
 //


### PR DESCRIPTION
Release v1.7.0 — API keys. No breaking changes.

## Feature
- **New module `auth/apikey` (#129).** Opaque API keys for machine authentication. `Generate` mints a `prefix_id_secret` key (recognisable prefix, random public id for O(1) lookup, 256-bit secret); keys are stored as a keyed HMAC-SHA256 digest and verified in constant time. `ParseID` extracts the lookup id from a presented key. HMAC rather than Argon2id because a 256-bit random key needs no slow hash. Storage-agnostic, like the rest of authcore. Includes a fuzz target for the request-facing parser.
