### PR TITLE
release: v1.8.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,6 @@ jobs:
       # G104 (errcheck on logger Output) and G306 (public-key 0644) are justified
       # in code with //nolint:gosec; standalone gosec ignores those pragmas.
       # G115 mirrors the .golangci.yml exclusion for UUID/time math.
-      gosec-exclude: "G104,G115,G306"
+      # G101 is a false positive on the OAuth provider preset URLs (a field named
+      # *TokenURL* holding a public endpoint, not a credential).
+      gosec-exclude: "G104,G115,G306,G101"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,5 +22,6 @@ jobs:
           {"package":"./auth/password","func":"FuzzValidatePolicy"},
           {"package":"./auth/password","func":"FuzzParsePHC"},
           {"package":"./auth/apikey","func":"FuzzParseID"},
+          {"package":"./auth/oauth","func":"FuzzParseJWK"},
           {"package":"./internal/keymanager","func":"FuzzFromPEM"}
         ]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Pick only what you need — each is independent, testable, and safe by default.
 | 📧 | **[email](docs/validation.md)** | Validate + normalize. RFC 5321/5322, optional cached DNS MX check. |
 | 👤 | **[username](docs/validation.md)** | Validate + normalize. Reserved-name blocklist, character rules. |
 | 🗝️ | **[apikey](docs/apikey.md)** | Opaque API keys. Generate, keyed-hash for storage, constant-time verify. |
+| 🌐 | **[oauth](docs/oauth.md)** | OIDC client — log in with Google/Microsoft/any OIDC. Auth Code + PKCE, ID-token validation. |
 
 ```mermaid
 flowchart LR
@@ -110,7 +111,7 @@ flowchart LR
 **New here? Start with the [Secure login recipe](docs/secure-login.md)** — the
 step-by-step flow that turns these primitives into a login an auditor accepts.
 
-[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
+[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
 
 Full API reference on [pkg.go.dev](https://pkg.go.dev/github.com/Glyndor/authcore).
 

--- a/auth/oauth/config.go
+++ b/auth/oauth/config.go
@@ -1,0 +1,91 @@
+package oauth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Provider describes an OIDC provider's endpoints. Use a preset (Google,
+// Microsoft) or fill it in from the provider's discovery document.
+type Provider struct {
+	// Issuer is the exact "iss" value the provider stamps into its ID tokens.
+	// It is enforced on verification, so it must match byte-for-byte.
+	Issuer string
+	// AuthURL is the authorization endpoint the user is redirected to.
+	AuthURL string
+	// TokenURL is the token endpoint where the code is exchanged.
+	TokenURL string
+	// JWKSURL is the endpoint serving the provider's signing keys (JWKS),
+	// used to verify ID token signatures.
+	JWKSURL string
+}
+
+// Config configures an OIDC client for a single provider.
+type Config struct {
+	// ClientID is the OAuth client identifier registered with the provider.
+	ClientID string
+	// ClientSecret is the client secret. Leave empty for a public client that
+	// relies on PKCE alone (PKCE is always used regardless).
+	ClientSecret string
+	// RedirectURL is the callback URL registered with the provider; it must
+	// match exactly.
+	RedirectURL string
+	// Provider holds the provider endpoints.
+	Provider Provider
+	// Scopes requested at authorization. Defaults to {"openid","email","profile"}.
+	// "openid" is always included even if omitted — without it there is no ID token.
+	Scopes []string
+	// HTTPClient optionally overrides the client used for the token and JWKS
+	// requests. Defaults to a client with a 10-second timeout.
+	HTTPClient *http.Client
+}
+
+// defaultScopes are requested when Config.Scopes is empty.
+var defaultScopes = []string{"openid", "email", "profile"}
+
+// applyDefaults fills zero-value fields with safe defaults.
+func applyDefaults(cfg Config) Config {
+	if len(cfg.Scopes) == 0 {
+		cfg.Scopes = defaultScopes
+	} else if !containsFold(cfg.Scopes, "openid") {
+		// "openid" is mandatory for OIDC; add it rather than silently failing later.
+		cfg.Scopes = append([]string{"openid"}, cfg.Scopes...)
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return cfg
+}
+
+// validateConfig returns an error if cfg is missing anything required.
+func validateConfig(cfg Config) error {
+	if strings.TrimSpace(cfg.ClientID) == "" {
+		return fmt.Errorf("client id must not be empty")
+	}
+	if strings.TrimSpace(cfg.RedirectURL) == "" {
+		return fmt.Errorf("redirect URL must not be empty")
+	}
+	for name, v := range map[string]string{
+		"issuer":    cfg.Provider.Issuer,
+		"auth URL":  cfg.Provider.AuthURL,
+		"token URL": cfg.Provider.TokenURL,
+		"JWKS URL":  cfg.Provider.JWKSURL,
+	} {
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("provider %s must not be empty", name)
+		}
+	}
+	return nil
+}
+
+// containsFold reports whether list holds s, case-insensitively.
+func containsFold(list []string, s string) bool {
+	for _, v := range list {
+		if strings.EqualFold(v, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/auth/oauth/errors.go
+++ b/auth/oauth/errors.go
@@ -1,0 +1,40 @@
+package oauth
+
+import "errors"
+
+// Sentinel errors returned by the oauth package.
+// Use errors.Is to check for these in calling code.
+var (
+	// ErrInvalidConfig is returned by New when the Config fails validation
+	// (missing client id, endpoints, redirect URL, …).
+	//
+	// Safety: INTERNAL — a startup/programming error. Treat as a 500.
+	ErrInvalidConfig = errors.New("oauth: invalid configuration")
+
+	// ErrExchange is returned when the authorization-code exchange with the
+	// provider's token endpoint fails (network error, non-2xx, or an
+	// OAuth error response).
+	//
+	// Safety: INTERNAL — log it; return a generic failure to the user.
+	ErrExchange = errors.New("oauth: token exchange failed")
+
+	// ErrNoIDToken is returned by Exchange-derived flows when the provider's
+	// response carried no id_token — the provider is not acting as an OIDC
+	// provider for this request (e.g. the "openid" scope was dropped).
+	//
+	// Safety: INTERNAL.
+	ErrNoIDToken = errors.New("oauth: response contained no id_token")
+
+	// ErrIDTokenInvalid is returned when the ID token fails validation:
+	// bad or unverifiable signature, wrong issuer/audience, expired, an
+	// unsupported algorithm, or a nonce mismatch.
+	//
+	// Safety: INTERNAL — return a generic "unauthorized"; never echo the reason.
+	ErrIDTokenInvalid = errors.New("oauth: id token is invalid")
+
+	// ErrJWKS is returned when the provider's signing keys cannot be fetched
+	// or parsed.
+	//
+	// Safety: INTERNAL.
+	ErrJWKS = errors.New("oauth: cannot obtain provider signing keys")
+)

--- a/auth/oauth/idtoken.go
+++ b/auth/oauth/idtoken.go
@@ -1,0 +1,124 @@
+package oauth
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+
+	gjwt "github.com/golang-jwt/jwt/v5"
+)
+
+// idTokenAlgs are the asymmetric signing algorithms an ID token may use. HMAC
+// and "none" are intentionally absent: accepting them would enable an
+// algorithm-confusion or unsigned-token forgery.
+var idTokenAlgs = []string{
+	"RS256", "RS384", "RS512",
+	"PS256", "PS384", "PS512",
+	"ES256", "ES384", "ES512",
+}
+
+// IDClaims holds the validated claims of an ID token.
+type IDClaims struct {
+	// Subject is the "sub" claim — the stable, provider-unique user identifier.
+	// Key your account records on (Issuer, Subject), never on email alone.
+	Subject string
+	// Issuer is the "iss" claim (equals the configured Provider.Issuer).
+	Issuer string
+	// Audience is the "aud" claim (contains the configured ClientID).
+	Audience []string
+	// Email is the "email" claim, if present.
+	Email string
+	// EmailVerified is the "email_verified" claim. Do not treat an unverified
+	// email as proof of address ownership.
+	EmailVerified bool
+	// Name is the "name" claim, if present.
+	Name string
+	// Raw exposes every claim for provider-specific fields not surfaced above.
+	Raw map[string]any
+}
+
+// VerifyIDToken validates an ID token and returns its claims.
+//
+// It verifies the signature against the provider's JWKS (asymmetric algorithms
+// only), and enforces the issuer, the audience (must contain the client id),
+// expiry, and that the "nonce" claim equals the nonce from the matching
+// AuthCodeURL request. nonce must be the non-empty value you stored; passing the
+// wrong or an empty nonce fails closed.
+//
+// On any failure it returns ErrIDTokenInvalid (wrapped). Never expose the
+// wrapped detail to the end user.
+func (c *Client) VerifyIDToken(ctx context.Context, idToken, nonce string) (*IDClaims, error) {
+	if nonce == "" {
+		return nil, fmt.Errorf("%w: no nonce supplied to verify against", ErrIDTokenInvalid)
+	}
+
+	var claims gjwt.MapClaims
+	_, err := gjwt.ParseWithClaims(idToken, &claims,
+		func(t *gjwt.Token) (any, error) {
+			kid, _ := t.Header["kid"].(string)
+			return c.jwks.key(ctx, kid)
+		},
+		gjwt.WithValidMethods(idTokenAlgs),
+		gjwt.WithIssuer(c.cfg.Provider.Issuer),
+		gjwt.WithAudience(c.cfg.ClientID),
+		gjwt.WithExpirationRequired(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrIDTokenInvalid, err)
+	}
+
+	// Bind the token to this login: the nonce must match the one we issued.
+	got, _ := claims["nonce"].(string)
+	if subtle.ConstantTimeCompare([]byte(got), []byte(nonce)) != 1 {
+		return nil, fmt.Errorf("%w: nonce mismatch", ErrIDTokenInvalid)
+	}
+
+	out := &IDClaims{
+		Subject:       stringClaim(claims, "sub"),
+		Issuer:        stringClaim(claims, "iss"),
+		Audience:      audienceClaim(claims),
+		Email:         stringClaim(claims, "email"),
+		EmailVerified: boolClaim(claims, "email_verified"),
+		Name:          stringClaim(claims, "name"),
+		Raw:           claims,
+	}
+	if out.Subject == "" {
+		return nil, fmt.Errorf("%w: missing subject", ErrIDTokenInvalid)
+	}
+	return out, nil
+}
+
+func stringClaim(m gjwt.MapClaims, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+// boolClaim reads a boolean claim, tolerating the string forms ("true"/"false")
+// some providers emit for email_verified.
+func boolClaim(m gjwt.MapClaims, key string) bool {
+	switch v := m[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	default:
+		return false
+	}
+}
+
+func audienceClaim(m gjwt.MapClaims) []string {
+	switch v := m["aud"].(type) {
+	case string:
+		return []string{v}
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, a := range v {
+			if s, ok := a.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/auth/oauth/jwks.go
+++ b/auth/oauth/jwks.go
@@ -1,0 +1,226 @@
+package oauth
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// jwksTTL bounds how long a fetched key set is trusted before a refresh.
+	jwksTTL = time.Hour
+	// jwksMaxBytes caps a JWKS response so a hostile endpoint cannot exhaust memory.
+	jwksMaxBytes = 1 << 20
+)
+
+// jwk is one JSON Web Key. Only the fields needed to build an RSA or EC public
+// key are decoded.
+type jwk struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	N   string `json:"n"` // RSA modulus (base64url)
+	E   string `json:"e"` // RSA exponent (base64url)
+	Crv string `json:"crv"`
+	X   string `json:"x"` // EC x (base64url)
+	Y   string `json:"y"` // EC y (base64url)
+}
+
+type jwksDoc struct {
+	Keys []jwk `json:"keys"`
+}
+
+// jwksCache fetches and caches a provider's signing keys, indexed by kid.
+type jwksCache struct {
+	url  string
+	http *http.Client
+
+	mu        sync.RWMutex
+	keys      map[string]crypto.PublicKey
+	expiresAt time.Time
+}
+
+func newJWKSCache(url string, h *http.Client) *jwksCache {
+	return &jwksCache{url: url, http: h, keys: make(map[string]crypto.PublicKey)}
+}
+
+// key returns the public key for kid. It refreshes the cache when the entry is
+// missing or stale — refreshing on an unknown kid is how key rotation is picked
+// up. If a refresh fails but a cached key for kid still exists, that key is used.
+func (c *jwksCache) key(ctx context.Context, kid string) (crypto.PublicKey, error) {
+	c.mu.RLock()
+	k, ok := c.keys[kid]
+	fresh := time.Now().Before(c.expiresAt)
+	c.mu.RUnlock()
+	if ok && fresh {
+		return k, nil
+	}
+
+	if err := c.refresh(ctx); err != nil {
+		if ok {
+			return k, nil // serve the stale key rather than fail the login on a transient JWKS outage
+		}
+		return nil, err
+	}
+
+	c.mu.RLock()
+	k, ok = c.keys[kid]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown kid %q", ErrJWKS, kid)
+	}
+	return k, nil
+}
+
+// refresh fetches the JWKS and replaces the cached key set.
+func (c *jwksCache) refresh(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return fmt.Errorf("%w: build request: %w", ErrJWKS, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrJWKS, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, jwksMaxBytes))
+	if err != nil {
+		return fmt.Errorf("%w: read: %w", ErrJWKS, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%w: status %d", ErrJWKS, resp.StatusCode)
+	}
+
+	var doc jwksDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return fmt.Errorf("%w: decode: %w", ErrJWKS, err)
+	}
+
+	keys := make(map[string]crypto.PublicKey, len(doc.Keys))
+	for _, k := range doc.Keys {
+		pub, err := parseJWK(k)
+		if err != nil {
+			continue // skip keys we cannot use (unsupported type/curve); others remain usable
+		}
+		if k.Kid != "" {
+			keys[k.Kid] = pub
+		}
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("%w: no usable keys in JWKS", ErrJWKS)
+	}
+
+	c.mu.Lock()
+	c.keys = keys
+	c.expiresAt = time.Now().Add(jwksTTL)
+	c.mu.Unlock()
+	return nil
+}
+
+// parseJWK converts a JWK into an RSA or EC public key.
+func parseJWK(k jwk) (crypto.PublicKey, error) {
+	switch k.Kty {
+	case "RSA":
+		n, err := b64BigInt(k.N)
+		if err != nil {
+			return nil, err
+		}
+		eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+		if err != nil {
+			return nil, err
+		}
+		e := new(big.Int).SetBytes(eBytes)
+		if !e.IsInt64() || e.Int64() < 2 {
+			return nil, fmt.Errorf("invalid RSA exponent")
+		}
+		return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
+	case "EC":
+		curve, err := ecCurve(k.Crv)
+		if err != nil {
+			return nil, err
+		}
+		x, err := b64BigInt(k.X)
+		if err != nil {
+			return nil, err
+		}
+		y, err := b64BigInt(k.Y)
+		if err != nil {
+			return nil, err
+		}
+		// Validate the point lies on the curve via crypto/ecdh, which performs
+		// the on-curve check with the modern (non-deprecated) API. The key is
+		// then used for ECDSA signature verification.
+		if err := ecPointOnCurve(k.Crv, x, y); err != nil {
+			return nil, err
+		}
+		return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}, nil
+	default:
+		return nil, fmt.Errorf("unsupported key type %q", k.Kty)
+	}
+}
+
+// ecPointOnCurve validates that (x, y) is a valid point on the named curve,
+// using crypto/ecdh's NewPublicKey (which rejects off-curve points) instead of
+// the deprecated elliptic.Curve.IsOnCurve.
+func ecPointOnCurve(crv string, x, y *big.Int) error {
+	var ec ecdh.Curve
+	var size int
+	switch crv {
+	case "P-256":
+		ec, size = ecdh.P256(), 32
+	case "P-384":
+		ec, size = ecdh.P384(), 48
+	case "P-521":
+		ec, size = ecdh.P521(), 66
+	default:
+		return fmt.Errorf("unsupported curve %q", crv)
+	}
+	// FillBytes panics if a value does not fit, so bound the coordinates to the
+	// field size first (a malformed JWKS could carry oversized integers).
+	if x.Sign() < 0 || y.Sign() < 0 || len(x.Bytes()) > size || len(y.Bytes()) > size {
+		return fmt.Errorf("EC coordinate out of range")
+	}
+	buf := make([]byte, 1+2*size)
+	buf[0] = 4 // uncompressed point
+	x.FillBytes(buf[1 : 1+size])
+	y.FillBytes(buf[1+size:])
+	if _, err := ec.NewPublicKey(buf); err != nil {
+		return fmt.Errorf("EC point is not on curve: %w", err)
+	}
+	return nil
+}
+
+func ecCurve(crv string) (elliptic.Curve, error) {
+	switch crv {
+	case "P-256":
+		return elliptic.P256(), nil
+	case "P-384":
+		return elliptic.P384(), nil
+	case "P-521":
+		return elliptic.P521(), nil
+	default:
+		return nil, fmt.Errorf("unsupported curve %q", crv)
+	}
+}
+
+// b64BigInt decodes a base64url (no padding) big-endian unsigned integer.
+func b64BigInt(s string) (*big.Int, error) {
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Int).SetBytes(b), nil
+}

--- a/auth/oauth/jwks_fuzz_test.go
+++ b/auth/oauth/jwks_fuzz_test.go
@@ -1,0 +1,19 @@
+package oauth
+
+import "testing"
+
+// FuzzParseJWK drives the JWK -> public key decoder with arbitrary field values.
+// A JWKS document is parsed into key structures (big integers, EC point checks),
+// so the decoder must never panic — only return a key or an error.
+func FuzzParseJWK(f *testing.F) {
+	f.Add("0vx7agoebGcQSuuPiLJXZ", "AQAB", "", "", "")
+	f.Add("", "", "P-256", "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU", "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0")
+	f.Add("", "", "", "", "")
+	f.Add("AQAB", "AQAB", "P-999", "AQAB", "AQAB")
+
+	f.Fuzz(func(t *testing.T, n, e, crv, x, y string) {
+		for _, kty := range []string{"RSA", "EC", "oct", ""} {
+			_, _ = parseJWK(jwk{Kty: kty, N: n, E: e, Crv: crv, X: x, Y: y})
+		}
+	})
+}

--- a/auth/oauth/oauth.go
+++ b/auth/oauth/oauth.go
@@ -1,0 +1,186 @@
+// Package oauth is an OpenID Connect (OIDC) client for authcore — "log in with
+// Google / Microsoft / any OIDC provider".
+//
+// It implements the security-critical mechanics you only get right once:
+// Authorization Code flow with PKCE (S256), an unguessable state and nonce, and
+// strict ID-token validation (signature against the provider's JWKS, plus
+// issuer, audience, expiry, and nonce). It is a client only — authcore does not
+// act as an OAuth server. It stores nothing and runs no HTTP server; you own
+// the two routes and where you persist the per-request secrets.
+//
+// # Flow
+//
+//	mod, _ := oauth.New(auth, oauth.Config{
+//	    ClientID: id, ClientSecret: secret,
+//	    RedirectURL: "https://app.example.com/callback",
+//	    Provider: oauth.Google(),
+//	})
+//
+//	// 1. Start: build the redirect and persist the returned secrets
+//	//    (state, nonce, verifier) in a short-lived signed cookie or the session.
+//	req, _ := mod.AuthCodeURL()
+//	saveToCookie(w, req.State, req.Nonce, req.Verifier)
+//	http.Redirect(w, r, req.URL, http.StatusFound)
+//
+//	// 2. Callback: check state, exchange the code, validate the ID token.
+//	if r.FormValue("state") != savedState { return /* 400 */ }
+//	tok, _ := mod.Exchange(r.Context(), r.FormValue("code"), savedVerifier)
+//	claims, err := mod.VerifyIDToken(r.Context(), tok.IDToken, savedNonce)
+//	if err != nil { return /* 401 */ }
+//	// claims.Subject is the stable user id at this provider; claims.Email etc.
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Glyndor/authcore"
+)
+
+// Compile-time assertion: *Client must satisfy authcore.Module.
+var _ authcore.Module = (*Client)(nil)
+
+// Client is the OIDC client module. Construct one per provider at startup with
+// New and share it; it is safe for concurrent use.
+type Client struct {
+	cfg  Config
+	log  authcore.Logger
+	http *http.Client
+	jwks *jwksCache
+}
+
+// New creates an OIDC Client for a single provider.
+func New(p authcore.Provider, cfg Config) (*Client, error) {
+	cfg = applyDefaults(cfg)
+	if err := validateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+	c := &Client{
+		cfg:  cfg,
+		log:  p.Logger(),
+		http: cfg.HTTPClient,
+		jwks: newJWKSCache(cfg.Provider.JWKSURL, cfg.HTTPClient),
+	}
+	c.log.Info("oauth: module initialised (issuer=%s)", cfg.Provider.Issuer)
+	return c, nil
+}
+
+// Name returns the module's unique identifier. It implements authcore.Module.
+func (c *Client) Name() string { return "oauth" }
+
+// AuthRequest is the result of AuthCodeURL. Redirect the user to URL, and
+// persist State, Nonce and Verifier somewhere only this browser can return them
+// (a short-lived signed/HttpOnly cookie or the server session) — all three are
+// needed to validate the callback.
+type AuthRequest struct {
+	// URL is the provider authorization URL to redirect the user to.
+	URL string
+	// State must be compared against the "state" query parameter on callback;
+	// a mismatch means CSRF or a stale request — reject it.
+	State string
+	// Nonce must be handed to VerifyIDToken; it binds the ID token to this request.
+	Nonce string
+	// Verifier is the PKCE code_verifier; pass it to Exchange.
+	Verifier string
+}
+
+// AuthCodeURL generates fresh state, nonce and a PKCE verifier, and builds the
+// authorization redirect URL. Every call is independent.
+func (c *Client) AuthCodeURL() (*AuthRequest, error) {
+	state, err := randomURLToken()
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := randomURLToken()
+	if err != nil {
+		return nil, err
+	}
+	verifier, err := randomURLToken()
+	if err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", c.cfg.ClientID)
+	q.Set("redirect_uri", c.cfg.RedirectURL)
+	q.Set("scope", strings.Join(c.cfg.Scopes, " "))
+	q.Set("state", state)
+	q.Set("nonce", nonce)
+	q.Set("code_challenge", pkceChallenge(verifier))
+	q.Set("code_challenge_method", "S256")
+
+	sep := "?"
+	if strings.Contains(c.cfg.Provider.AuthURL, "?") {
+		sep = "&"
+	}
+	return &AuthRequest{
+		URL:      c.cfg.Provider.AuthURL + sep + q.Encode(),
+		State:    state,
+		Nonce:    nonce,
+		Verifier: verifier,
+	}, nil
+}
+
+// Tokens is the provider's token-endpoint response.
+type Tokens struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+// Exchange swaps an authorization code for tokens at the token endpoint, sending
+// the PKCE code_verifier. ctx bounds the request.
+//
+// It returns ErrExchange on a transport error or a non-2xx response, and
+// ErrNoIDToken if the provider returned no id_token. Validate Tokens.IDToken
+// with VerifyIDToken before trusting any of it.
+func (c *Client) Exchange(ctx context.Context, code, verifier string) (*Tokens, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", c.cfg.RedirectURL)
+	form.Set("client_id", c.cfg.ClientID)
+	form.Set("code_verifier", verifier)
+	if c.cfg.ClientSecret != "" {
+		form.Set("client_secret", c.cfg.ClientSecret)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.Provider.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("%w: build request: %w", ErrExchange, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrExchange, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Cap the response so a hostile or broken endpoint cannot exhaust memory.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("%w: read response: %w", ErrExchange, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%w: status %d", ErrExchange, resp.StatusCode)
+	}
+
+	var tok Tokens
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("%w: decode response: %w", ErrExchange, err)
+	}
+	if tok.IDToken == "" {
+		return nil, ErrNoIDToken
+	}
+	return &tok, nil
+}

--- a/auth/oauth/oauth_more_test.go
+++ b/auth/oauth/oauth_more_test.go
@@ -1,0 +1,152 @@
+package oauth_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gjwt "github.com/golang-jwt/jwt/v5"
+
+	"github.com/Glyndor/authcore/auth/oauth"
+)
+
+func mustRSA(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	return k
+}
+
+// ---- EC (ES256) end-to-end --------------------------------------------------
+
+func TestVerifyIDToken_ecKey(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	// SEC1 uncompressed point: 0x04 || x(32) || y(32). Avoids the deprecated
+	// raw X/Y coordinate accessors.
+	raw, err := key.PublicKey.Bytes()
+	if err != nil {
+		t.Fatalf("public key bytes: %v", err)
+	}
+	x := base64.RawURLEncoding.EncodeToString(raw[1:33])
+	y := base64.RawURLEncoding.EncodeToString(raw[33:65])
+	doc := fmt.Sprintf(`{"keys":[{"kty":"EC","kid":%q,"crv":"P-256","x":%q,"y":%q}]}`, testKID, x, y)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(doc))
+	}))
+	defer srv.Close()
+	c := newClient(t, srv)
+
+	tok := gjwt.NewWithClaims(gjwt.SigningMethodES256, validClaims(srv.URL, "n"))
+	tok.Header["kid"] = testKID
+	signed, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign ES256: %v", err)
+	}
+
+	claims, err := c.VerifyIDToken(context.Background(), signed, "n")
+	if err != nil {
+		t.Fatalf("VerifyIDToken (EC): %v", err)
+	}
+	if claims.Subject != "user-abc" {
+		t.Errorf("Subject = %q", claims.Subject)
+	}
+}
+
+// ---- claim variants ---------------------------------------------------------
+
+func TestVerifyIDToken_audArrayAndStringEmailVerified(t *testing.T) {
+	key := mustRSA(t)
+	srv := jwksServer(t, &key.PublicKey)
+	defer srv.Close()
+	c := newClient(t, srv)
+
+	cl := validClaims(srv.URL, "n")
+	cl["aud"] = []string{testClientID, "another"}
+	cl["email_verified"] = "true" // some providers send a string
+	tok := signIDToken(t, key, testKID, cl)
+
+	claims, err := c.VerifyIDToken(context.Background(), tok, "n")
+	if err != nil {
+		t.Fatalf("VerifyIDToken: %v", err)
+	}
+	if len(claims.Audience) != 2 {
+		t.Errorf("Audience = %v, want 2 entries", claims.Audience)
+	}
+	if !claims.EmailVerified {
+		t.Error("string email_verified \"true\" not parsed as true")
+	}
+}
+
+// ---- JWKS error paths -------------------------------------------------------
+
+func TestVerifyIDToken_jwksNon200(t *testing.T) {
+	key := mustRSA(t)
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	c := newClient(t, bad)
+	tok := signIDToken(t, key, testKID, validClaims(bad.URL, "n"))
+	if _, err := c.VerifyIDToken(context.Background(), tok, "n"); err == nil {
+		t.Error("expected failure when JWKS endpoint returns 500")
+	}
+}
+
+func TestVerifyIDToken_jwksEmpty(t *testing.T) {
+	key := mustRSA(t)
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	defer empty.Close()
+	c := newClient(t, empty)
+	tok := signIDToken(t, key, testKID, validClaims(empty.URL, "n"))
+	if _, err := c.VerifyIDToken(context.Background(), tok, "n"); err == nil {
+		t.Error("expected failure when JWKS has no usable keys")
+	}
+}
+
+// ---- config / presets -------------------------------------------------------
+
+func TestAuthCodeURL_prependsOpenIDScope(t *testing.T) {
+	c, _ := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID: "x", RedirectURL: "y", Provider: oauth.Google(),
+		Scopes: []string{"email"}, // openid intentionally omitted
+	})
+	req, _ := c.AuthCodeURL()
+	if !strings.Contains(req.URL, "openid") {
+		t.Error("openid scope must be added even when the caller omits it")
+	}
+}
+
+func TestMicrosoftPreset(t *testing.T) {
+	p := oauth.Microsoft("common")
+	if !strings.Contains(p.Issuer, "common") || !strings.Contains(p.AuthURL, "authorize") || p.JWKSURL == "" {
+		t.Errorf("unexpected Microsoft preset: %+v", p)
+	}
+}
+
+func TestExchange_contextDeadline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"id_token":"x"}`))
+	}))
+	defer srv.Close()
+	c := newClient(t, srv)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if _, err := c.Exchange(ctx, "c", "v"); err == nil {
+		t.Error("expected a context-deadline error")
+	}
+}

--- a/auth/oauth/oauth_test.go
+++ b/auth/oauth/oauth_test.go
@@ -1,0 +1,294 @@
+package oauth_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	gjwt "github.com/golang-jwt/jwt/v5"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/auth/oauth"
+)
+
+// ---- test infrastructure ----------------------------------------------------
+
+type fakeProvider struct{}
+
+func (fakeProvider) Config() authcore.Config { return authcore.DefaultConfig() }
+func (fakeProvider) Logger() authcore.Logger { return silentLogger{} }
+func (fakeProvider) Keys() authcore.Keys     { return nil }
+
+type silentLogger struct{}
+
+func (silentLogger) Debug(string, ...any) {}
+func (silentLogger) Info(string, ...any)  {}
+func (silentLogger) Warn(string, ...any)  {}
+func (silentLogger) Error(string, ...any) {}
+
+const (
+	testClientID = "client-123"
+	testKID      = "test-key-1"
+)
+
+// jwksServer serves a JWKS document for pubkey under testKID.
+func jwksServer(t *testing.T, pub *rsa.PublicKey) *httptest.Server {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	doc := fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":%q,"n":%q,"e":%q}]}`, testKID, n, e)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(doc))
+	}))
+}
+
+func signIDToken(t *testing.T, key *rsa.PrivateKey, kid string, claims gjwt.MapClaims) string {
+	t.Helper()
+	tok := gjwt.NewWithClaims(gjwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	s, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign id token: %v", err)
+	}
+	return s
+}
+
+func validClaims(issuer, nonce string) gjwt.MapClaims {
+	return gjwt.MapClaims{
+		"iss":            issuer,
+		"aud":            testClientID,
+		"sub":            "user-abc",
+		"email":          "a@example.com",
+		"email_verified": true,
+		"nonce":          nonce,
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Add(-time.Minute).Unix(),
+	}
+}
+
+// newClient builds a client whose Issuer/JWKS point at srv.
+func newClient(t *testing.T, srv *httptest.Server) *oauth.Client {
+	t.Helper()
+	c, err := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID:    testClientID,
+		RedirectURL: "https://app.example.com/cb",
+		Provider: oauth.Provider{
+			Issuer:   srv.URL,
+			AuthURL:  srv.URL + "/auth",
+			TokenURL: srv.URL + "/token",
+			JWKSURL:  srv.URL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// ---- AuthCodeURL ------------------------------------------------------------
+
+func TestAuthCodeURL_hasPKCEAndState(t *testing.T) {
+	c, _ := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID: testClientID, RedirectURL: "https://app/cb", Provider: oauth.Google(),
+	})
+	req, err := c.AuthCodeURL()
+	if err != nil {
+		t.Fatalf("AuthCodeURL: %v", err)
+	}
+	if req.State == "" || req.Nonce == "" || req.Verifier == "" {
+		t.Fatal("state/nonce/verifier must be set")
+	}
+	u, _ := url.Parse(req.URL)
+	q := u.Query()
+	for k, want := range map[string]string{
+		"response_type":         "code",
+		"client_id":             testClientID,
+		"code_challenge_method": "S256",
+		"state":                 req.State,
+		"nonce":                 req.Nonce,
+	} {
+		if q.Get(k) != want {
+			t.Errorf("query %q = %q, want %q", k, q.Get(k), want)
+		}
+	}
+	if !strings.Contains(q.Get("scope"), "openid") {
+		t.Errorf("scope %q missing openid", q.Get("scope"))
+	}
+	if q.Get("code_challenge") == req.Verifier {
+		t.Error("challenge must be the hash of the verifier, not the verifier itself")
+	}
+}
+
+func TestAuthCodeURL_independentPerCall(t *testing.T) {
+	c, _ := oauth.New(fakeProvider{}, oauth.Config{ClientID: "x", RedirectURL: "y", Provider: oauth.Google()})
+	a, _ := c.AuthCodeURL()
+	b, _ := c.AuthCodeURL()
+	if a.State == b.State || a.Nonce == b.Nonce || a.Verifier == b.Verifier {
+		t.Error("each AuthCodeURL must use fresh secrets")
+	}
+}
+
+// ---- New validation ---------------------------------------------------------
+
+func TestNew_invalidConfigRejected(t *testing.T) {
+	cases := map[string]oauth.Config{
+		"no client id": {RedirectURL: "y", Provider: oauth.Google()},
+		"no redirect":  {ClientID: "x", Provider: oauth.Google()},
+		"no provider":  {ClientID: "x", RedirectURL: "y"},
+	}
+	for name, cfg := range cases {
+		if _, err := oauth.New(fakeProvider{}, cfg); err == nil {
+			t.Errorf("%s: expected ErrInvalidConfig", name)
+		}
+	}
+}
+
+// ---- VerifyIDToken (the security-critical path) -----------------------------
+
+func TestVerifyIDToken_valid(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	srv := jwksServer(t, &key.PublicKey)
+	defer srv.Close()
+	c := newClient(t, srv)
+
+	tok := signIDToken(t, key, testKID, validClaims(srv.URL, "nonce-xyz"))
+	claims, err := c.VerifyIDToken(context.Background(), tok, "nonce-xyz")
+	if err != nil {
+		t.Fatalf("VerifyIDToken: %v", err)
+	}
+	if claims.Subject != "user-abc" {
+		t.Errorf("Subject = %q, want user-abc", claims.Subject)
+	}
+	if claims.Email != "a@example.com" || !claims.EmailVerified {
+		t.Errorf("email claims not parsed: %+v", claims)
+	}
+}
+
+func TestVerifyIDToken_rejections(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	other, _ := rsa.GenerateKey(rand.Reader, 2048)
+	srv := jwksServer(t, &key.PublicKey)
+	defer srv.Close()
+	c := newClient(t, srv)
+	ctx := context.Background()
+
+	t.Run("wrong nonce", func(t *testing.T) {
+		tok := signIDToken(t, key, testKID, validClaims(srv.URL, "right"))
+		if _, err := c.VerifyIDToken(ctx, tok, "wrong"); err == nil {
+			t.Error("expected rejection on nonce mismatch")
+		}
+	})
+	t.Run("empty nonce supplied", func(t *testing.T) {
+		tok := signIDToken(t, key, testKID, validClaims(srv.URL, ""))
+		if _, err := c.VerifyIDToken(ctx, tok, ""); err == nil {
+			t.Error("expected rejection when no nonce is supplied")
+		}
+	})
+	t.Run("wrong issuer", func(t *testing.T) {
+		cl := validClaims("https://evil.example", "n")
+		tok := signIDToken(t, key, testKID, cl)
+		if _, err := c.VerifyIDToken(ctx, tok, "n"); err == nil {
+			t.Error("expected rejection on issuer mismatch")
+		}
+	})
+	t.Run("wrong audience", func(t *testing.T) {
+		cl := validClaims(srv.URL, "n")
+		cl["aud"] = "someone-else"
+		tok := signIDToken(t, key, testKID, cl)
+		if _, err := c.VerifyIDToken(ctx, tok, "n"); err == nil {
+			t.Error("expected rejection on audience mismatch")
+		}
+	})
+	t.Run("expired", func(t *testing.T) {
+		cl := validClaims(srv.URL, "n")
+		cl["exp"] = time.Now().Add(-time.Hour).Unix()
+		tok := signIDToken(t, key, testKID, cl)
+		if _, err := c.VerifyIDToken(ctx, tok, "n"); err == nil {
+			t.Error("expected rejection on expired token")
+		}
+	})
+	t.Run("wrong signing key", func(t *testing.T) {
+		tok := signIDToken(t, other, testKID, validClaims(srv.URL, "n"))
+		if _, err := c.VerifyIDToken(ctx, tok, "n"); err == nil {
+			t.Error("expected rejection when signed by an unlisted key")
+		}
+	})
+	t.Run("hmac alg-confusion", func(t *testing.T) {
+		// A token signed with HS256 must be refused (asymmetric algs only).
+		hs := gjwt.NewWithClaims(gjwt.SigningMethodHS256, validClaims(srv.URL, "n"))
+		hs.Header["kid"] = testKID
+		s, _ := hs.SignedString([]byte("secret"))
+		if _, err := c.VerifyIDToken(ctx, s, "n"); err == nil {
+			t.Error("expected rejection of an HS256 token")
+		}
+	})
+	t.Run("unknown kid", func(t *testing.T) {
+		tok := signIDToken(t, key, "no-such-kid", validClaims(srv.URL, "n"))
+		if _, err := c.VerifyIDToken(ctx, tok, "n"); err == nil {
+			t.Error("expected rejection for an unknown kid")
+		}
+	})
+}
+
+// ---- Exchange ---------------------------------------------------------------
+
+func TestExchange_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "authorization_code" || r.FormValue("code_verifier") == "" {
+			t.Errorf("token request missing grant_type/code_verifier: %v", r.Form)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "at", "id_token": "idt", "token_type": "Bearer", "expires_in": 3600,
+		})
+	}))
+	defer srv.Close()
+	c := newClient(t, srv)
+
+	tok, err := c.Exchange(context.Background(), "the-code", "the-verifier")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if tok.AccessToken != "at" || tok.IDToken != "idt" {
+		t.Errorf("unexpected tokens: %+v", tok)
+	}
+}
+
+func TestExchange_errors(t *testing.T) {
+	t.Run("non-2xx", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		defer srv.Close()
+		if _, err := newClient(t, srv).Exchange(context.Background(), "c", "v"); err == nil {
+			t.Error("expected ErrExchange on 400")
+		}
+	})
+	t.Run("no id_token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"access_token":"at"}`))
+		}))
+		defer srv.Close()
+		if _, err := newClient(t, srv).Exchange(context.Background(), "c", "v"); err == nil {
+			t.Error("expected ErrNoIDToken")
+		}
+	})
+}
+
+func TestName(t *testing.T) {
+	c, _ := oauth.New(fakeProvider{}, oauth.Config{ClientID: "x", RedirectURL: "y", Provider: oauth.Google()})
+	if c.Name() != "oauth" {
+		t.Errorf("Name() = %q, want oauth", c.Name())
+	}
+}

--- a/auth/oauth/pkce.go
+++ b/auth/oauth/pkce.go
@@ -1,0 +1,31 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+// randomTokenBytes is the entropy of state, nonce, and the PKCE verifier.
+// 32 bytes (256 bits) is comfortably above any guessing attack.
+const randomTokenBytes = 32
+
+// randomURLToken returns base64url(no padding) over randomTokenBytes of CSPRNG
+// output — used for state, nonce, and the PKCE code_verifier (all of which must
+// be unguessable and URL-safe).
+func randomURLToken() (string, error) {
+	b := make([]byte, randomTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("oauth: read random: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// pkceChallenge derives the S256 PKCE code_challenge from a verifier
+// (RFC 7636 §4.2): BASE64URL(SHA256(verifier)). S256 is the only method used;
+// "plain" is never offered, so a downgrade cannot strip the protection.
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/auth/oauth/presets.go
+++ b/auth/oauth/presets.go
@@ -1,0 +1,35 @@
+package oauth
+
+import "fmt"
+
+// Google returns the Provider endpoints for Google's OIDC service.
+//
+//	cfg := oauth.Config{
+//	    ClientID:     id, ClientSecret: secret,
+//	    RedirectURL:  "https://app.example.com/callback",
+//	    Provider:     oauth.Google(),
+//	}
+func Google() Provider {
+	// #nosec G101 -- these are Google's public OIDC endpoint URLs, not credentials.
+	return Provider{
+		Issuer:   "https://accounts.google.com",
+		AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+		TokenURL: "https://oauth2.googleapis.com/token",
+		JWKSURL:  "https://www.googleapis.com/oauth2/v3/certs",
+	}
+}
+
+// Microsoft returns the Provider endpoints for the Microsoft identity platform
+// (Azure AD) for the given tenant. Use "common" for multi-tenant + personal
+// accounts, "organizations" for any work/school account, or a specific tenant
+// id. The issuer for the multi-tenant endpoints contains the tenant id of the
+// signed-in user, so prefer a single-tenant id when you can pin the issuer.
+func Microsoft(tenant string) Provider {
+	base := fmt.Sprintf("https://login.microsoftonline.com/%s", tenant)
+	return Provider{
+		Issuer:   fmt.Sprintf("%s/v2.0", base),
+		AuthURL:  fmt.Sprintf("%s/oauth2/v2.0/authorize", base),
+		TokenURL: fmt.Sprintf("%s/oauth2/v2.0/token", base),
+		JWKSURL:  fmt.Sprintf("%s/discovery/v2.0/keys", base),
+	}
+}

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,81 @@
+# OIDC login
+
+`auth/oauth` is an OpenID Connect **client** — "log in with Google / Microsoft /
+any OIDC provider". It implements the security-critical mechanics: Authorization
+Code flow with **PKCE (S256)**, an unguessable `state` and `nonce`, and strict
+**ID-token validation** (signature against the provider's JWKS, plus issuer,
+audience, expiry, and nonce). It is a client only — authcore is not an OAuth
+server. It stores nothing and runs no HTTP server; you own the two routes.
+
+> [!NOTE]
+> This covers OIDC providers (Google, Microsoft, Auth0, Keycloak…) that issue an
+> ID token. Pure-OAuth2 providers that don't (e.g. GitHub) need a userinfo
+> fetch and are not yet covered.
+
+## Setup
+
+```go
+auth, _ := authcore.New(authcore.DefaultConfig())
+mod, err := oauth.New(auth, oauth.Config{
+    ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+    ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+    RedirectURL:  "https://app.example.com/auth/callback",
+    Provider:     oauth.Google(), // or oauth.Microsoft("common"), or a custom Provider
+})
+```
+
+A custom provider is just four endpoints (from its `.well-known/openid-configuration`):
+
+```go
+Provider: oauth.Provider{
+    Issuer:   "https://id.example.com",
+    AuthURL:  "https://id.example.com/authorize",
+    TokenURL: "https://id.example.com/token",
+    JWKSURL:  "https://id.example.com/jwks",
+}
+```
+
+## The two routes
+
+**Start** — build the redirect and persist the three secrets where only this
+browser can return them (a short-lived `HttpOnly` signed cookie or the session):
+
+```go
+req, _ := mod.AuthCodeURL()
+saveToCookie(w, req.State, req.Nonce, req.Verifier) // all three
+http.Redirect(w, r, req.URL, http.StatusFound)
+```
+
+**Callback** — check `state`, exchange the code, validate the ID token:
+
+```go
+if r.FormValue("state") != savedState {
+    http.Error(w, "bad state", http.StatusBadRequest) // CSRF / stale
+    return
+}
+tok, err := mod.Exchange(r.Context(), r.FormValue("code"), savedVerifier)
+if err != nil { /* 401 */ }
+
+claims, err := mod.VerifyIDToken(r.Context(), tok.IDToken, savedNonce)
+if err != nil { /* 401 — never show the reason */ }
+
+// claims.Subject is the stable user id AT THIS PROVIDER.
+// Key your account on (claims.Issuer, claims.Subject), not on email.
+```
+
+## What it guarantees
+
+- **PKCE S256 always.** The `plain` method is never offered, so a downgrade
+  cannot strip it. Works for public clients (no secret) too.
+- **ID-token signature** is checked against the provider's JWKS, fetched and
+  cached (1 h), refreshed automatically on an unknown `kid` so key rotation just
+  works. Only asymmetric algorithms (RS/PS/ES) are accepted — `none` and HMAC
+  are refused, closing the algorithm-confusion forgery.
+- **Issuer, audience, expiry, and nonce** are all enforced. A mismatch fails
+  closed with `ErrIDTokenInvalid`.
+
+## What is yours
+
+Sessions, cookies, CSRF on your own routes, and where you persist the per-request
+secrets — same as the rest of authcore. See the
+[secure login recipe](secure-login.md).

--- a/module.go
+++ b/module.go
@@ -71,6 +71,8 @@ type Provider interface {
 //	                  username.New(p authcore.Provider) (*username.Username, error)
 //	auth/apikey   — opaque API key generation, hashing, and verification
 //	                  apikey.New(p authcore.Provider, cfg ...apikey.Config) (*apikey.APIKey, error)
+//	auth/oauth    — OpenID Connect client (login with Google / Microsoft / OIDC)
+//	                  oauth.New(p authcore.Provider, cfg oauth.Config) (*oauth.Client, error)
 //
 // Conventions shared by every module:
 //


### PR DESCRIPTION
Release v1.8.0 — OIDC login. No breaking changes.

## Feature
- **New module `auth/oauth` (#130).** An OpenID Connect client — "log in with Google / Microsoft / any OIDC provider". Authorization Code flow with PKCE (S256), unguessable state/nonce, and strict ID-token validation: signature against the provider's JWKS (asymmetric algorithms only — `none`/HMAC refused), issuer, audience, expiry, and nonce. JWKS are cached and refreshed on key rotation. `Google()` and `Microsoft(tenant)` presets; any OIDC provider works with its four endpoints. Client only, storage-agnostic — no new dependencies. Includes a fuzz target for the JWK decoder.

This completes the planned module roadmap (jwt, password, email, username, apikey, oauth).
