### PR TITLE
release: v1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Pick only what you need — each is independent, testable, and safe by default.
 | 📧 | **[email](docs/validation.md)** | Validate + normalize. RFC 5321/5322, optional cached DNS MX check. |
 | 👤 | **[username](docs/validation.md)** | Validate + normalize. Reserved-name blocklist, character rules. |
 | 🗝️ | **[apikey](docs/apikey.md)** | Opaque API keys. Generate, keyed-hash for storage, constant-time verify. |
-| 🌐 | **[oauth](docs/oauth.md)** | OIDC client — log in with Google/Microsoft/any OIDC. Auth Code + PKCE, ID-token validation. |
+| 🌐 | **[oauth](docs/oauth.md)** | Social login — Google, Microsoft (OIDC) and GitHub, Discord (OAuth2). Auth Code + PKCE, ID-token validation or userinfo. |
 
 ```mermaid
 flowchart LR

--- a/auth/oauth/config.go
+++ b/auth/oauth/config.go
@@ -18,8 +18,15 @@ type Provider struct {
 	// TokenURL is the token endpoint where the code is exchanged.
 	TokenURL string
 	// JWKSURL is the endpoint serving the provider's signing keys (JWKS),
-	// used to verify ID token signatures.
+	// used to verify ID token signatures. Required for OIDC providers (those
+	// that issue an ID token); leave empty for a plain-OAuth2 provider.
 	JWKSURL string
+
+	// UserInfoURL is the profile endpoint for a plain-OAuth2 provider that does
+	// not issue an ID token (e.g. GitHub, Discord). When set, identity comes
+	// from UserInfo(accessToken) instead of VerifyIDToken. Optional for OIDC
+	// providers, which carry identity in the ID token.
+	UserInfoURL string
 }
 
 // Config configures an OIDC client for a single provider.
@@ -34,8 +41,11 @@ type Config struct {
 	RedirectURL string
 	// Provider holds the provider endpoints.
 	Provider Provider
-	// Scopes requested at authorization. Defaults to {"openid","email","profile"}.
-	// "openid" is always included even if omitted — without it there is no ID token.
+	// Scopes requested at authorization. When empty, defaults to the OIDC set
+	// {"openid","email","profile"}. When you set it, it is used verbatim — for
+	// an OIDC provider include "openid" yourself (without it there is no ID
+	// token); for a plain-OAuth2 provider set that provider's own scopes
+	// (e.g. GitHub's "read:user user:email").
 	Scopes []string
 	// HTTPClient optionally overrides the client used for the token and JWKS
 	// requests. Defaults to a client with a 10-second timeout.
@@ -45,13 +55,12 @@ type Config struct {
 // defaultScopes are requested when Config.Scopes is empty.
 var defaultScopes = []string{"openid", "email", "profile"}
 
-// applyDefaults fills zero-value fields with safe defaults.
+// applyDefaults fills zero-value fields with safe defaults. Caller-supplied
+// scopes are used verbatim (an OIDC caller includes "openid"; an OAuth2 caller
+// sets the provider's own scopes), so the same constructor serves both flows.
 func applyDefaults(cfg Config) Config {
 	if len(cfg.Scopes) == 0 {
 		cfg.Scopes = defaultScopes
-	} else if !containsFold(cfg.Scopes, "openid") {
-		// "openid" is mandatory for OIDC; add it rather than silently failing later.
-		cfg.Scopes = append([]string{"openid"}, cfg.Scopes...)
 	}
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = &http.Client{Timeout: 10 * time.Second}
@@ -60,6 +69,11 @@ func applyDefaults(cfg Config) Config {
 }
 
 // validateConfig returns an error if cfg is missing anything required.
+//
+// Every provider needs the authorization and token endpoints. Identity then
+// comes from one of two sources: an OIDC provider supplies Issuer + JWKSURL
+// (the ID token is validated against them), a plain-OAuth2 provider supplies
+// UserInfoURL. A provider with neither cannot identify the user and is rejected.
 func validateConfig(cfg Config) error {
 	if strings.TrimSpace(cfg.ClientID) == "" {
 		return fmt.Errorf("client id must not be empty")
@@ -67,25 +81,23 @@ func validateConfig(cfg Config) error {
 	if strings.TrimSpace(cfg.RedirectURL) == "" {
 		return fmt.Errorf("redirect URL must not be empty")
 	}
-	for name, v := range map[string]string{
-		"issuer":    cfg.Provider.Issuer,
-		"auth URL":  cfg.Provider.AuthURL,
-		"token URL": cfg.Provider.TokenURL,
-		"JWKS URL":  cfg.Provider.JWKSURL,
-	} {
-		if strings.TrimSpace(v) == "" {
-			return fmt.Errorf("provider %s must not be empty", name)
-		}
+	if strings.TrimSpace(cfg.Provider.AuthURL) == "" {
+		return fmt.Errorf("provider auth URL must not be empty")
+	}
+	if strings.TrimSpace(cfg.Provider.TokenURL) == "" {
+		return fmt.Errorf("provider token URL must not be empty")
+	}
+
+	oidc := cfg.Provider.Issuer != "" && cfg.Provider.JWKSURL != ""
+	oauth2 := cfg.Provider.UserInfoURL != ""
+	if !oidc && !oauth2 {
+		return fmt.Errorf("provider must supply either issuer+JWKS (OIDC) or a userinfo URL (OAuth2)")
+	}
+	// A half-configured OIDC provider (only one of issuer/JWKS) with no userinfo
+	// fallback is a mistake — flag it rather than silently dropping ID-token
+	// verification.
+	if !oauth2 && (cfg.Provider.Issuer == "") != (cfg.Provider.JWKSURL == "") {
+		return fmt.Errorf("OIDC provider needs both issuer and JWKS URL")
 	}
 	return nil
-}
-
-// containsFold reports whether list holds s, case-insensitively.
-func containsFold(list []string, s string) bool {
-	for _, v := range list {
-		if strings.EqualFold(v, s) {
-			return true
-		}
-	}
-	return false
 }

--- a/auth/oauth/errors.go
+++ b/auth/oauth/errors.go
@@ -37,4 +37,16 @@ var (
 	//
 	// Safety: INTERNAL.
 	ErrJWKS = errors.New("oauth: cannot obtain provider signing keys")
+
+	// ErrUserInfo is returned when the userinfo request to a plain-OAuth2
+	// provider fails (network error, non-2xx, or undecodable body).
+	//
+	// Safety: INTERNAL.
+	ErrUserInfo = errors.New("oauth: userinfo request failed")
+
+	// ErrNoUserInfo is returned by UserInfo when the provider has no
+	// UserInfoURL configured (it is an OIDC provider — use VerifyIDToken).
+	//
+	// Safety: INTERNAL — a programming error.
+	ErrNoUserInfo = errors.New("oauth: no userinfo URL configured")
 )

--- a/auth/oauth/oauth_more_test.go
+++ b/auth/oauth/oauth_more_test.go
@@ -19,6 +19,86 @@ import (
 	"github.com/Glyndor/authcore/auth/oauth"
 )
 
+// ---- OAuth2 (userinfo) path -------------------------------------------------
+
+func oauth2Client(t *testing.T, userInfoURL string) *oauth.Client {
+	t.Helper()
+	c, err := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID:    testClientID,
+		RedirectURL: "https://app.example.com/cb",
+		Scopes:      []string{"read:user"},
+		Provider: oauth.Provider{
+			AuthURL:     "https://provider.example/auth",
+			TokenURL:    "https://provider.example/token",
+			UserInfoURL: userInfoURL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New (oauth2): %v", err)
+	}
+	return c
+}
+
+func TestUserInfo_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer the-access-token" {
+			t.Errorf("missing/!wrong bearer: %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"id":42,"login":"octocat"}`))
+	}))
+	defer srv.Close()
+
+	info, err := oauth2Client(t, srv.URL).UserInfo(context.Background(), "the-access-token")
+	if err != nil {
+		t.Fatalf("UserInfo: %v", err)
+	}
+	if info["login"] != "octocat" {
+		t.Errorf("login = %v, want octocat", info["login"])
+	}
+}
+
+func TestUserInfo_noURLConfigured(t *testing.T) {
+	key := mustRSA(t)
+	srv := jwksServer(t, &key.PublicKey)
+	defer srv.Close()
+	// An OIDC client has no UserInfoURL.
+	if _, err := newClient(t, srv).UserInfo(context.Background(), "x"); err == nil {
+		t.Error("expected ErrNoUserInfo on an OIDC client")
+	}
+}
+
+func TestUserInfo_non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	if _, err := oauth2Client(t, srv.URL).UserInfo(context.Background(), "x"); err == nil {
+		t.Error("expected an error on a non-2xx userinfo response")
+	}
+}
+
+func TestNew_oauth2ProviderValid(t *testing.T) {
+	// GitHub/Discord are valid even without issuer/JWKS (they supply userinfo).
+	for _, p := range []oauth.Provider{oauth.GitHub(), oauth.Discord()} {
+		if _, err := oauth.New(fakeProvider{}, oauth.Config{
+			ClientID: "x", RedirectURL: "y", Provider: p, Scopes: []string{"identify"},
+		}); err != nil {
+			t.Errorf("OAuth2 preset rejected: %v", err)
+		}
+	}
+}
+
+func TestNew_providerWithNoIdentitySourceRejected(t *testing.T) {
+	// Auth + token endpoints but neither issuer/JWKS nor userinfo.
+	_, err := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID: "x", RedirectURL: "y",
+		Provider: oauth.Provider{AuthURL: "a", TokenURL: "t"},
+	})
+	if err == nil {
+		t.Error("expected rejection of a provider with no identity source")
+	}
+}
+
 func mustRSA(t *testing.T) *rsa.PrivateKey {
 	t.Helper()
 	k, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -119,14 +199,27 @@ func TestVerifyIDToken_jwksEmpty(t *testing.T) {
 
 // ---- config / presets -------------------------------------------------------
 
-func TestAuthCodeURL_prependsOpenIDScope(t *testing.T) {
+func TestAuthCodeURL_defaultScopesIncludeOpenID(t *testing.T) {
+	// No scopes set -> the OIDC default set (with openid) is used.
 	c, _ := oauth.New(fakeProvider{}, oauth.Config{
 		ClientID: "x", RedirectURL: "y", Provider: oauth.Google(),
-		Scopes: []string{"email"}, // openid intentionally omitted
 	})
 	req, _ := c.AuthCodeURL()
 	if !strings.Contains(req.URL, "openid") {
-		t.Error("openid scope must be added even when the caller omits it")
+		t.Error("default scopes must include openid")
+	}
+}
+
+func TestAuthCodeURL_callerScopesVerbatim(t *testing.T) {
+	// Caller-supplied scopes are used as-is (no openid injected) — required for
+	// plain-OAuth2 providers like GitHub.
+	c, _ := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID: "x", RedirectURL: "y", Provider: oauth.GitHub(),
+		Scopes: []string{"read:user", "user:email"},
+	})
+	req, _ := c.AuthCodeURL()
+	if strings.Contains(req.URL, "openid") {
+		t.Error("openid must not be injected into caller-supplied scopes")
 	}
 }
 

--- a/auth/oauth/presets.go
+++ b/auth/oauth/presets.go
@@ -19,6 +19,30 @@ func Google() Provider {
 	}
 }
 
+// GitHub returns the Provider endpoints for GitHub's OAuth2 service. GitHub is
+// not OIDC — it issues no ID token — so identity comes from UserInfo (the
+// /user endpoint). Request scopes like "read:user" and "user:email".
+func GitHub() Provider {
+	// #nosec G101 -- these are GitHub's public OAuth2 endpoint URLs, not credentials.
+	return Provider{
+		AuthURL:     "https://github.com/login/oauth/authorize",
+		TokenURL:    "https://github.com/login/oauth/access_token",
+		UserInfoURL: "https://api.github.com/user",
+	}
+}
+
+// Discord returns the Provider endpoints for Discord's OAuth2 service. Like
+// GitHub it is not OIDC; identity comes from UserInfo (the users/@me endpoint).
+// Request scopes like "identify" and "email".
+func Discord() Provider {
+	// #nosec G101 -- these are Discord's public OAuth2 endpoint URLs, not credentials.
+	return Provider{
+		AuthURL:     "https://discord.com/oauth2/authorize",
+		TokenURL:    "https://discord.com/api/oauth2/token",
+		UserInfoURL: "https://discord.com/api/users/@me",
+	}
+}
+
 // Microsoft returns the Provider endpoints for the Microsoft identity platform
 // (Azure AD) for the given tenant. Use "common" for multi-tenant + personal
 // accounts, "organizations" for any work/school account, or a specific tenant

--- a/auth/oauth/userinfo.go
+++ b/auth/oauth/userinfo.go
@@ -1,0 +1,58 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// userInfoMaxBytes caps a userinfo response so a hostile or broken endpoint
+// cannot exhaust memory.
+const userInfoMaxBytes = 1 << 20
+
+// UserInfo fetches the authenticated user's profile from a plain-OAuth2
+// provider's userinfo endpoint, presenting the access token as a Bearer
+// credential. Use it for providers that do not issue an ID token (GitHub,
+// Discord, …); for OIDC providers prefer VerifyIDToken.
+//
+// The returned map is the provider's raw JSON — its shape is provider-specific,
+// so read the fields you need (e.g. GitHub "id"/"login", Discord "id"/
+// "username"). The provider's stable user id is the value to key your account
+// on, never the email or display name.
+//
+// Returns ErrNoUserInfo if the provider has no UserInfoURL, or ErrUserInfo on a
+// transport error, a non-2xx response, or an undecodable body.
+func (c *Client) UserInfo(ctx context.Context, accessToken string) (map[string]any, error) {
+	if c.cfg.Provider.UserInfoURL == "" {
+		return nil, ErrNoUserInfo
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.Provider.UserInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build request: %w", ErrUserInfo, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUserInfo, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, userInfoMaxBytes))
+	if err != nil {
+		return nil, fmt.Errorf("%w: read: %w", ErrUserInfo, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%w: status %d", ErrUserInfo, resp.StatusCode)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("%w: decode: %w", ErrUserInfo, err)
+	}
+	return out, nil
+}

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -8,9 +8,11 @@ audience, expiry, and nonce). It is a client only — authcore is not an OAuth
 server. It stores nothing and runs no HTTP server; you own the two routes.
 
 > [!NOTE]
-> This covers OIDC providers (Google, Microsoft, Auth0, Keycloak…) that issue an
-> ID token. Pure-OAuth2 providers that don't (e.g. GitHub) need a userinfo
-> fetch and are not yet covered.
+> Two kinds of provider are supported. **OIDC** providers (Google, Microsoft,
+> Auth0, Keycloak…) issue an ID token — validate it with `VerifyIDToken`.
+> **Plain-OAuth2** providers (GitHub, Discord…) issue no ID token — fetch the
+> profile with `UserInfo` instead. The authorization + PKCE + exchange steps are
+> identical for both.
 
 ## Setup
 
@@ -62,6 +64,35 @@ if err != nil { /* 401 — never show the reason */ }
 // claims.Subject is the stable user id AT THIS PROVIDER.
 // Key your account on (claims.Issuer, claims.Subject), not on email.
 ```
+
+## Plain-OAuth2 providers (GitHub, Discord, …)
+
+Providers that issue no ID token use the same start/exchange steps, then
+`UserInfo` instead of `VerifyIDToken`:
+
+```go
+mod, _ := oauth.New(auth, oauth.Config{
+    ClientID: id, ClientSecret: secret,
+    RedirectURL: "https://app.example.com/auth/callback",
+    Provider:    oauth.GitHub(),            // or oauth.Discord()
+    Scopes:      []string{"read:user", "user:email"}, // provider's own scopes
+})
+
+// Callback: check state, exchange, then fetch the profile.
+tok, _ := mod.Exchange(r.Context(), code, savedVerifier)
+info, err := mod.UserInfo(r.Context(), tok.AccessToken)
+if err != nil { /* 401 */ }
+// info is the provider's raw JSON: GitHub "id"/"login", Discord "id"/"username".
+// Key your account on (provider, info["id"]).
+```
+
+`UserInfo` sends the access token as a Bearer credential, caps the response, and
+returns the decoded JSON. There is no ID token to validate here — identity is
+whatever the userinfo endpoint returns, so trust only the provider's stable id.
+
+> Custom OAuth2 provider: set `Provider{AuthURL, TokenURL, UserInfoURL}` (no
+> issuer/JWKS). A provider with neither issuer+JWKS nor a userinfo URL is
+> rejected at `New` — it could not identify the user.
 
 ## What it guarantees
 


### PR DESCRIPTION
Release v1.9.0 — social login for non-OIDC providers.

## Feature
- **auth/oauth: plain-OAuth2 providers via userinfo (#152).** GitHub, Discord and other OAuth2 providers that issue no ID token are now supported: `Provider.UserInfoURL` + `UserInfo(ctx, accessToken)` fetch the profile with a Bearer token. A provider is valid with either OIDC (issuer+JWKS) or OAuth2 (userinfo). `GitHub()` and `Discord()` presets added. Scopes are now used verbatim when set (the empty-scopes default remains the OIDC set); include `openid` yourself for OIDC providers.

With this, the oauth module covers both OIDC (Google, Microsoft, …) and plain-OAuth2 (GitHub, Discord, …) social login.
