### PR TITLE
docs(examples): runnable oauth (OIDC/OAuth2) example

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [basic, email, fiber, gin, jwt, password, username]
+        example: [basic, email, fiber, gin, jwt, oauth, password, username]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/examples/oauth/README.md
+++ b/examples/oauth/README.md
@@ -1,0 +1,42 @@
+# auth/oauth — social login example
+
+A runnable two-route OIDC / OAuth2 login flow. Point it at a live provider to
+smoke-test the whole handshake end to end.
+
+## Run
+
+```bash
+OAUTH_PROVIDER=google \
+OAUTH_CLIENT_ID=your-client-id \
+OAUTH_CLIENT_SECRET=your-client-secret \
+go run ./examples/oauth
+```
+
+Then open <http://localhost:8080/login>. After you approve at the provider, the
+callback prints the resolved identity as JSON.
+
+Register `http://localhost:8080/callback` as the redirect URI with your provider
+(or set `OAUTH_REDIRECT_URL`).
+
+## Providers
+
+| `OAUTH_PROVIDER` | Kind | Identity from |
+|---|---|---|
+| `google` (default) | OIDC | `VerifyIDToken` |
+| `microsoft` | OIDC | `VerifyIDToken` (set `OAUTH_TENANT`, default `common`) |
+| `github` | OAuth2 | `UserInfo` |
+| `discord` | OAuth2 | `UserInfo` |
+
+## What it shows
+
+| Step | API |
+|---|---|
+| Start — build redirect with PKCE + state + nonce | `mod.AuthCodeURL()` |
+| Callback — verify state, swap the code | `mod.Exchange(ctx, code, verifier)` |
+| OIDC — validate the ID token | `mod.VerifyIDToken(ctx, idToken, nonce)` |
+| OAuth2 — fetch the profile | `mod.UserInfo(ctx, accessToken)` |
+
+> The example keeps `state`/`nonce`/`verifier` in a plain `HttpOnly` cookie for
+> brevity. In production sign that cookie (and set `Secure`) or use a
+> server-side session, and serve over HTTPS — see the
+> [secure login recipe](../../docs/secure-login.md).

--- a/examples/oauth/go.mod
+++ b/examples/oauth/go.mod
@@ -1,0 +1,9 @@
+module github.com/Glyndor/authcore/examples/oauth
+
+go 1.26.3
+
+require github.com/Glyndor/authcore v1.9.0
+
+require github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+
+replace github.com/Glyndor/authcore => ../../

--- a/examples/oauth/go.sum
+++ b/examples/oauth/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=

--- a/examples/oauth/main.go
+++ b/examples/oauth/main.go
@@ -1,0 +1,151 @@
+// Command oauth is a runnable end-to-end example of authcore's OIDC / OAuth2
+// client — a real two-route social-login flow you can point at a live provider.
+//
+// Configure it with environment variables and run:
+//
+//	OAUTH_PROVIDER=google \
+//	OAUTH_CLIENT_ID=... OAUTH_CLIENT_SECRET=... \
+//	go run ./examples/oauth
+//
+// then open http://localhost:8080/login. Supported OAUTH_PROVIDER values:
+// google, microsoft (OIDC), github, discord (plain OAuth2).
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/auth/oauth"
+)
+
+func main() {
+	auth, err := authcore.New(authcore.DefaultConfig())
+	if err != nil {
+		log.Fatalf("authcore: %v", err)
+	}
+
+	provider := env("OAUTH_PROVIDER", "google")
+	cfg := oauth.Config{
+		ClientID:     os.Getenv("OAUTH_CLIENT_ID"),
+		ClientSecret: os.Getenv("OAUTH_CLIENT_SECRET"),
+		RedirectURL:  env("OAUTH_REDIRECT_URL", "http://localhost:8080/callback"),
+	}
+	switch provider {
+	case "google":
+		cfg.Provider = oauth.Google()
+	case "microsoft":
+		cfg.Provider = oauth.Microsoft(env("OAUTH_TENANT", "common"))
+	case "github":
+		cfg.Provider = oauth.GitHub()
+		cfg.Scopes = []string{"read:user", "user:email"}
+	case "discord":
+		cfg.Provider = oauth.Discord()
+		cfg.Scopes = []string{"identify", "email"}
+	default:
+		log.Fatalf("unknown OAUTH_PROVIDER %q (want google|microsoft|github|discord)", provider)
+	}
+
+	mod, err := oauth.New(auth, cfg)
+	if err != nil {
+		log.Fatalf("oauth: %v", err)
+	}
+	oidc := provider == "google" || provider == "microsoft"
+
+	mux := http.NewServeMux()
+
+	// /login starts the flow: build the redirect, persist the per-request
+	// secrets. DEMO ONLY: a plain cookie holds them; in production sign it
+	// (HttpOnly+Secure) or use a server-side session.
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		req, err := mod.AuthCodeURL()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		setFlowCookie(w, req.State+"|"+req.Nonce+"|"+req.Verifier)
+		http.Redirect(w, r, req.URL, http.StatusFound)
+	})
+
+	// /callback finishes it: check state, exchange the code, then validate the
+	// ID token (OIDC) or fetch the profile (OAuth2).
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		state, nonce, verifier, ok := readFlowCookie(r)
+		if !ok {
+			http.Error(w, "missing or bad flow cookie", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("state") != state {
+			http.Error(w, "state mismatch", http.StatusBadRequest)
+			return
+		}
+
+		tok, err := mod.Exchange(r.Context(), r.FormValue("code"), verifier)
+		if err != nil {
+			http.Error(w, "token exchange failed", http.StatusUnauthorized)
+			return
+		}
+
+		var identity any
+		if oidc {
+			identity, err = mod.VerifyIDToken(r.Context(), tok.IDToken, nonce)
+		} else {
+			identity, err = mod.UserInfo(r.Context(), tok.AccessToken)
+		}
+		if err != nil {
+			http.Error(w, "identity check failed", http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(identity)
+	})
+
+	addr := env("OAUTH_ADDR", ":8080")
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Printf("oauth example (provider=%s) listening on %s — open http://localhost%s/login", provider, addr, addr)
+	log.Fatal(srv.ListenAndServe())
+}
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func setFlowCookie(w http.ResponseWriter, value string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "oauthflow",
+		Value:    base64.RawURLEncoding.EncodeToString([]byte(value)),
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   300,
+	})
+}
+
+func readFlowCookie(r *http.Request) (state, nonce, verifier string, ok bool) {
+	c, err := r.Cookie("oauthflow")
+	if err != nil {
+		return "", "", "", false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(c.Value)
+	if err != nil {
+		return "", "", "", false
+	}
+	parts := strings.SplitN(string(raw), "|", 3)
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
+}


### PR DESCRIPTION
A runnable end-to-end example for the oauth module — the bridge from unit tests to a real provider, and onboarding alongside the other module examples.

A two-route HTTP server: `/login` builds the redirect with PKCE + state + nonce; `/callback` checks state, exchanges the code, then validates the ID token (OIDC: google/microsoft) or fetches the profile (OAuth2: github/discord), chosen by `OAUTH_PROVIDER`. Run it with real client credentials to smoke-test the whole handshake.

- Standalone module with a local `replace`, added to the examples CI matrix (the caller only).
- The example keeps the per-request secrets in a plain `HttpOnly` cookie for brevity and says, in code and README, to sign it / use HTTPS in production (links the secure-login recipe).

`go build` and `go vet` pass in the example module; the root suite is unaffected.
