### PR TITLE
feat(oauth): OIDC discovery (.well-known)

### DIFF
--- a/auth/oauth/discovery.go
+++ b/auth/oauth/discovery.go
@@ -1,0 +1,84 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	discoveryPath     = "/.well-known/openid-configuration"
+	discoveryMaxBytes = 1 << 20
+)
+
+// Discover builds a Provider from an OIDC issuer's discovery document, instead
+// of hardcoding endpoints. Pass the issuer URL (e.g.
+// "https://accounts.google.com", an Auth0/Okta tenant, a Keycloak realm) and
+// the authorization, token, JWKS and userinfo endpoints are read from the
+// provider itself — always current, never a stale constant.
+//
+// It enforces that the document's "issuer" equals the requested issuer (per
+// OpenID Connect Discovery), so a substituted discovery document cannot point
+// the client at attacker endpoints under a victim's name. ctx bounds the fetch;
+// httpClient is optional (a 10-second-timeout client is used when nil).
+//
+//	p, err := oauth.Discover(ctx, "https://accounts.google.com", nil)
+//	if err != nil { ... }
+//	mod, _ := oauth.New(auth, oauth.Config{ClientID: id, RedirectURL: cb, Provider: p})
+func Discover(ctx context.Context, issuer string, httpClient *http.Client) (Provider, error) {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	trimmed := strings.TrimRight(issuer, "/")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, trimmed+discoveryPath, nil)
+	if err != nil {
+		return Provider{}, fmt.Errorf("%w: build request: %w", ErrDiscovery, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Provider{}, fmt.Errorf("%w: %w", ErrDiscovery, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, discoveryMaxBytes))
+	if err != nil {
+		return Provider{}, fmt.Errorf("%w: read: %w", ErrDiscovery, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Provider{}, fmt.Errorf("%w: status %d", ErrDiscovery, resp.StatusCode)
+	}
+
+	var doc struct {
+		Issuer   string `json:"issuer"`
+		Auth     string `json:"authorization_endpoint"`
+		Token    string `json:"token_endpoint"`
+		JWKS     string `json:"jwks_uri"`
+		UserInfo string `json:"userinfo_endpoint"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return Provider{}, fmt.Errorf("%w: decode: %w", ErrDiscovery, err)
+	}
+
+	// The discovered issuer must match the one asked for (OIDC Discovery §4.3).
+	if doc.Issuer != issuer && doc.Issuer != trimmed {
+		return Provider{}, fmt.Errorf("%w: issuer mismatch: document says %q", ErrDiscovery, doc.Issuer)
+	}
+	if doc.Auth == "" || doc.Token == "" || doc.JWKS == "" {
+		return Provider{}, fmt.Errorf("%w: document missing required endpoints", ErrDiscovery)
+	}
+
+	return Provider{
+		Issuer:      doc.Issuer,
+		AuthURL:     doc.Auth,
+		TokenURL:    doc.Token,
+		JWKSURL:     doc.JWKS,
+		UserInfoURL: doc.UserInfo,
+	}, nil
+}

--- a/auth/oauth/discovery_test.go
+++ b/auth/oauth/discovery_test.go
@@ -1,0 +1,87 @@
+package oauth_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Glyndor/authcore/auth/oauth"
+)
+
+func discoveryServer(t *testing.T, issuer func() string, extra string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/.well-known/openid-configuration") {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintf(w, `{
+			"issuer": %q,
+			"authorization_endpoint": "%s/auth",
+			"token_endpoint": "%s/token",
+			"jwks_uri": "%s/jwks",
+			"userinfo_endpoint": "%s/userinfo"
+			%s
+		}`, issuer(), issuer(), issuer(), issuer(), issuer(), extra)
+	}))
+}
+
+func TestDiscover_success(t *testing.T) {
+	var srv *httptest.Server
+	srv = discoveryServer(t, func() string { return srv.URL }, "")
+	defer srv.Close()
+
+	p, err := oauth.Discover(context.Background(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if p.Issuer != srv.URL || p.AuthURL != srv.URL+"/auth" || p.JWKSURL != srv.URL+"/jwks" {
+		t.Errorf("unexpected provider: %+v", p)
+	}
+	if p.UserInfoURL != srv.URL+"/userinfo" {
+		t.Errorf("userinfo not discovered: %q", p.UserInfoURL)
+	}
+}
+
+func TestDiscover_issuerMismatchRejected(t *testing.T) {
+	// The document claims a different issuer than the one requested.
+	srv := discoveryServer(t, func() string { return "https://evil.example" }, "")
+	defer srv.Close()
+	if _, err := oauth.Discover(context.Background(), srv.URL, nil); err == nil {
+		t.Error("expected rejection on issuer mismatch")
+	}
+}
+
+func TestDiscover_non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	if _, err := oauth.Discover(context.Background(), srv.URL, nil); err == nil {
+		t.Error("expected error on non-200")
+	}
+}
+
+func TestDiscover_missingEndpoints(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// issuer matches but no endpoints.
+		fmt.Fprintf(w, `{"issuer":"http://%s"}`, r.Host)
+	}))
+	defer srv.Close()
+	if _, err := oauth.Discover(context.Background(), "http://"+srv.Listener.Addr().String(), nil); err == nil {
+		t.Error("expected error when required endpoints are missing")
+	}
+}
+
+func TestDiscover_garbage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	if _, err := oauth.Discover(context.Background(), srv.URL, nil); err == nil {
+		t.Error("expected error on undecodable document")
+	}
+}

--- a/auth/oauth/errors.go
+++ b/auth/oauth/errors.go
@@ -49,4 +49,10 @@ var (
 	//
 	// Safety: INTERNAL — a programming error.
 	ErrNoUserInfo = errors.New("oauth: no userinfo URL configured")
+
+	// ErrDiscovery is returned by Discover when the OIDC discovery document
+	// cannot be fetched or parsed, or its issuer does not match.
+	//
+	// Safety: INTERNAL.
+	ErrDiscovery = errors.New("oauth: OIDC discovery failed")
 )

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -26,7 +26,23 @@ mod, err := oauth.New(auth, oauth.Config{
 })
 ```
 
-A custom provider is just four endpoints (from its `.well-known/openid-configuration`):
+### Any OIDC provider — discovery
+
+You don't need a preset or hand-written endpoints. `Discover` reads the
+provider's `.well-known/openid-configuration` and builds the `Provider` for you
+— always-current endpoints, works for Apple, Okta, Auth0, GitLab, Cognito,
+Keycloak, any standard OIDC issuer:
+
+```go
+p, err := oauth.Discover(ctx, "https://accounts.google.com", nil)
+if err != nil { log.Fatal(err) }
+mod, _ := oauth.New(auth, oauth.Config{ClientID: id, ClientSecret: secret, RedirectURL: cb, Provider: p})
+```
+
+Discovery enforces that the document's issuer matches the one you asked for, so
+a substituted document cannot redirect the client to attacker endpoints.
+
+Or hand-write the four endpoints if you prefer:
 
 ```go
 Provider: oauth.Provider{


### PR DESCRIPTION
Roadmap #157. Instead of shipping more per-provider endpoint presets I cannot verify against the live services, this adds OIDC **discovery** — the standard, correct way to obtain a provider's endpoints.

- `Discover(ctx, issuer, httpClient)` fetches `<issuer>/.well-known/openid-configuration` and returns a `Provider` (auth, token, JWKS, userinfo). Endpoints come from the provider, so they are always current.
- Enforces that the document's `issuer` matches the requested issuer (OIDC Discovery §4.3) — a substituted document cannot redirect the client to attacker endpoints under a victim's name. Bounded body read.

Any standard OIDC provider — Apple, Okta, Auth0, GitLab, Cognito, Keycloak — now works in one line, with no risk of a stale hardcoded URL. The Google/Microsoft/GitHub/Discord presets stay as convenient shortcuts.

Tests: success, issuer mismatch rejected, non-200, missing endpoints, garbage body. `go build`, `go vet`, `golangci-lint` (0 issues) and the suite with `-race` pass.

Closes #157
