### PR TITLE
fix(oauth): harden from security review (https, OAuth2 exchange, azp)

### DIFF
--- a/auth/oauth/config.go
+++ b/auth/oauth/config.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -99,5 +100,47 @@ func validateConfig(cfg Config) error {
 	if !oauth2 && (cfg.Provider.Issuer == "") != (cfg.Provider.JWKSURL == "") {
 		return fmt.Errorf("OIDC provider needs both issuer and JWKS URL")
 	}
+
+	// Every endpoint and the redirect must be https (loopback excepted), so a
+	// MITM cannot intercept the code/token exchange or substitute the JWKS.
+	for label, raw := range map[string]string{
+		"redirect URL":          cfg.RedirectURL,
+		"provider auth URL":     cfg.Provider.AuthURL,
+		"provider token URL":    cfg.Provider.TokenURL,
+		"provider JWKS URL":     cfg.Provider.JWKSURL,
+		"provider userinfo URL": cfg.Provider.UserInfoURL,
+		"provider issuer":       cfg.Provider.Issuer,
+	} {
+		if raw == "" {
+			continue
+		}
+		if err := requireHTTPS(label, raw); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// requireHTTPS rejects a URL whose scheme is not https. Plain http is allowed
+// only for an explicit loopback host (local development), and that is the loud
+// exception — the secure transport is the default everywhere else.
+func requireHTTPS(label, raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid URL: %w", label, err)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s must use https (got %q in %q)", label, u.Scheme, raw)
+}
+
+// isLoopbackHost reports whether host is a loopback address (dev-only http).
+func isLoopbackHost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }

--- a/auth/oauth/discovery.go
+++ b/auth/oauth/discovery.go
@@ -33,6 +33,11 @@ func Discover(ctx context.Context, issuer string, httpClient *http.Client) (Prov
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 10 * time.Second}
 	}
+	// Never fetch discovery over plaintext — the whole trust chain (the jwks_uri
+	// the ID-token signature hangs on) comes from this document.
+	if err := requireHTTPS("issuer", issuer); err != nil {
+		return Provider{}, fmt.Errorf("%w: %w", ErrDiscovery, err)
+	}
 	trimmed := strings.TrimRight(issuer, "/")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, trimmed+discoveryPath, nil)
@@ -72,6 +77,22 @@ func Discover(ctx context.Context, issuer string, httpClient *http.Client) (Prov
 	}
 	if doc.Auth == "" || doc.Token == "" || doc.JWKS == "" {
 		return Provider{}, fmt.Errorf("%w: document missing required endpoints", ErrDiscovery)
+	}
+	// The endpoints are not constrained to the issuer's origin, so a substituted
+	// (or simply misconfigured) document could point them at plaintext hosts —
+	// require https on each.
+	for label, raw := range map[string]string{
+		"authorization_endpoint": doc.Auth,
+		"token_endpoint":         doc.Token,
+		"jwks_uri":               doc.JWKS,
+		"userinfo_endpoint":      doc.UserInfo,
+	} {
+		if raw == "" {
+			continue
+		}
+		if err := requireHTTPS(label, raw); err != nil {
+			return Provider{}, fmt.Errorf("%w: %w", ErrDiscovery, err)
+		}
 	}
 
 	return Provider{

--- a/auth/oauth/idtoken.go
+++ b/auth/oauth/idtoken.go
@@ -62,6 +62,7 @@ func (c *Client) VerifyIDToken(ctx context.Context, idToken, nonce string) (*IDC
 		gjwt.WithIssuer(c.cfg.Provider.Issuer),
 		gjwt.WithAudience(c.cfg.ClientID),
 		gjwt.WithExpirationRequired(),
+		gjwt.WithIssuedAt(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrIDTokenInvalid, err)
@@ -73,10 +74,21 @@ func (c *Client) VerifyIDToken(ctx context.Context, idToken, nonce string) (*IDC
 		return nil, fmt.Errorf("%w: nonce mismatch", ErrIDTokenInvalid)
 	}
 
+	// WithAudience only requires that our client id is *present* in "aud". When
+	// the token names more than one audience, or carries an authorized-party
+	// claim, OIDC Core §3.1.3.7 requires "azp" to equal our client id — so a
+	// token a provider minted for a different client cannot be replayed here.
+	aud := audienceClaim(claims)
+	if azp, hasAZP := claims["azp"]; len(aud) > 1 || hasAZP {
+		if s, _ := azp.(string); s != c.cfg.ClientID {
+			return nil, fmt.Errorf("%w: azp does not match client id", ErrIDTokenInvalid)
+		}
+	}
+
 	out := &IDClaims{
 		Subject:       stringClaim(claims, "sub"),
 		Issuer:        stringClaim(claims, "iss"),
-		Audience:      audienceClaim(claims),
+		Audience:      aud,
 		Email:         stringClaim(claims, "email"),
 		EmailVerified: boolClaim(claims, "email_verified"),
 		Name:          stringClaim(claims, "name"),

--- a/auth/oauth/jwks.go
+++ b/auth/oauth/jwks.go
@@ -29,8 +29,9 @@ const (
 type jwk struct {
 	Kty string `json:"kty"`
 	Kid string `json:"kid"`
-	N   string `json:"n"` // RSA modulus (base64url)
-	E   string `json:"e"` // RSA exponent (base64url)
+	Use string `json:"use"` // "sig" or "enc"; only signing keys are used here
+	N   string `json:"n"`   // RSA modulus (base64url)
+	E   string `json:"e"`   // RSA exponent (base64url)
 	Crv string `json:"crv"`
 	X   string `json:"x"` // EC x (base64url)
 	Y   string `json:"y"` // EC y (base64url)
@@ -111,6 +112,11 @@ func (c *jwksCache) refresh(ctx context.Context) error {
 
 	keys := make(map[string]crypto.PublicKey, len(doc.Keys))
 	for _, k := range doc.Keys {
+		// Only signature keys are eligible. A key explicitly published for
+		// encryption must never be selected to verify a token signature.
+		if k.Use != "" && k.Use != "sig" {
+			continue
+		}
 		pub, err := parseJWK(k)
 		if err != nil {
 			continue // skip keys we cannot use (unsupported type/curve); others remain usable
@@ -145,6 +151,11 @@ func parseJWK(k jwk) (crypto.PublicKey, error) {
 		e := new(big.Int).SetBytes(eBytes)
 		if !e.IsInt64() || e.Int64() < 2 {
 			return nil, fmt.Errorf("invalid RSA exponent")
+		}
+		// Reject undersized moduli — a small (potentially factorable) RSA key
+		// must never be trusted to verify a signature.
+		if n.BitLen() < 2048 {
+			return nil, fmt.Errorf("RSA modulus too small: %d bits", n.BitLen())
 		}
 		return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
 	case "EC":

--- a/auth/oauth/oauth.go
+++ b/auth/oauth/oauth.go
@@ -23,7 +23,7 @@
 //	http.Redirect(w, r, req.URL, http.StatusFound)
 //
 //	// 2. Callback: check state, exchange the code, validate the ID token.
-//	if r.FormValue("state") != savedState { return /* 400 */ }
+//	if subtle.ConstantTimeCompare([]byte(r.FormValue("state")), []byte(savedState)) != 1 { return /* 400 */ }
 //	tok, _ := mod.Exchange(r.Context(), r.FormValue("code"), savedVerifier)
 //	claims, err := mod.VerifyIDToken(r.Context(), tok.IDToken, savedNonce)
 //	if err != nil { return /* 401 */ }
@@ -139,9 +139,10 @@ type Tokens struct {
 // Exchange swaps an authorization code for tokens at the token endpoint, sending
 // the PKCE code_verifier. ctx bounds the request.
 //
-// It returns ErrExchange on a transport error or a non-2xx response, and
-// ErrNoIDToken if the provider returned no id_token. Validate Tokens.IDToken
-// with VerifyIDToken before trusting any of it.
+// It returns ErrExchange on a transport error or a non-2xx response. For an
+// OIDC provider it also returns ErrNoIDToken when the response carried no
+// id_token; validate that token with VerifyIDToken before trusting it. For a
+// plain-OAuth2 provider (no issuer/JWKS) there is no id_token — call UserInfo.
 func (c *Client) Exchange(ctx context.Context, code, verifier string) (*Tokens, error) {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
@@ -179,8 +180,18 @@ func (c *Client) Exchange(ctx context.Context, code, verifier string) (*Tokens, 
 	if err := json.Unmarshal(body, &tok); err != nil {
 		return nil, fmt.Errorf("%w: decode response: %w", ErrExchange, err)
 	}
-	if tok.IDToken == "" {
+	// An ID token is required only for an OIDC provider (one that has an issuer
+	// and JWKS to validate it against). A plain-OAuth2 provider (GitHub,
+	// Discord) returns no id_token — identity comes from UserInfo — so requiring
+	// one here would make every such login fail.
+	if c.isOIDC() && tok.IDToken == "" {
 		return nil, ErrNoIDToken
 	}
 	return &tok, nil
+}
+
+// isOIDC reports whether the provider issues an ID token (issuer + JWKS set),
+// as opposed to a plain-OAuth2 provider identified via UserInfo.
+func (c *Client) isOIDC() bool {
+	return c.cfg.Provider.Issuer != "" && c.cfg.Provider.JWKSURL != ""
 }

--- a/auth/oauth/oauth_hardening_test.go
+++ b/auth/oauth/oauth_hardening_test.go
@@ -1,0 +1,104 @@
+package oauth_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Glyndor/authcore/auth/oauth"
+)
+
+// ---- HTTPS enforcement ------------------------------------------------------
+
+func TestNew_rejectsNonHTTPSEndpoint(t *testing.T) {
+	_, err := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID:    "x",
+		RedirectURL: "https://app.example/cb",
+		Provider: oauth.Provider{
+			Issuer:   "https://id.example",
+			AuthURL:  "http://id.example/auth", // plaintext — must be rejected
+			TokenURL: "https://id.example/token",
+			JWKSURL:  "https://id.example/jwks",
+		},
+	})
+	if err == nil {
+		t.Error("expected a non-https endpoint to be rejected")
+	}
+}
+
+func TestNew_allowsLoopbackHTTP(t *testing.T) {
+	_, err := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID:    "x",
+		RedirectURL: "http://localhost:8080/cb",
+		Provider: oauth.Provider{
+			AuthURL:     "http://127.0.0.1:9000/auth",
+			TokenURL:    "http://127.0.0.1:9000/token",
+			UserInfoURL: "http://127.0.0.1:9000/userinfo",
+		},
+	})
+	if err != nil {
+		t.Errorf("loopback http should be allowed for local dev, got %v", err)
+	}
+}
+
+func TestDiscover_rejectsNonHTTPSIssuer(t *testing.T) {
+	if _, err := oauth.Discover(context.Background(), "http://id.example", nil); err == nil {
+		t.Error("expected a non-https issuer to be rejected before any fetch")
+	}
+}
+
+// ---- OAuth2 Exchange no longer requires an id_token -------------------------
+
+func TestExchange_oauth2ReturnsTokensWithoutIDToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A plain-OAuth2 provider returns no id_token.
+		_, _ = w.Write([]byte(`{"access_token":"at","token_type":"bearer"}`))
+	}))
+	defer srv.Close()
+
+	c, err := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID:    testClientID,
+		RedirectURL: "https://app.example/cb",
+		Scopes:      []string{"read:user"},
+		Provider: oauth.Provider{
+			AuthURL:     srv.URL + "/auth",
+			TokenURL:    srv.URL + "/token",
+			UserInfoURL: srv.URL + "/userinfo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tok, err := c.Exchange(context.Background(), "code", "verifier")
+	if err != nil {
+		t.Fatalf("OAuth2 exchange must succeed without an id_token, got %v", err)
+	}
+	if tok.AccessToken != "at" {
+		t.Errorf("access token = %q, want at", tok.AccessToken)
+	}
+}
+
+// ---- JWKS: encryption keys are not used for signature verification ----------
+
+func TestVerifyIDToken_encUseKeySkipped(t *testing.T) {
+	key := mustRSA(t)
+	n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
+	// The only key carries use:"enc" — it must not be selected to verify a signature.
+	doc := fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":%q,"use":"enc","n":%q,"e":%q}]}`, testKID, n, e)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(doc))
+	}))
+	defer srv.Close()
+	c := newClient(t, srv)
+
+	tok := signIDToken(t, key, testKID, validClaims(srv.URL, "n"))
+	if _, err := c.VerifyIDToken(context.Background(), tok, "n"); err == nil {
+		t.Error("an enc-use key must not verify a token signature")
+	}
+}

--- a/auth/oauth/oauth_more_test.go
+++ b/auth/oauth/oauth_more_test.go
@@ -81,7 +81,7 @@ func TestNew_oauth2ProviderValid(t *testing.T) {
 	// GitHub/Discord are valid even without issuer/JWKS (they supply userinfo).
 	for _, p := range []oauth.Provider{oauth.GitHub(), oauth.Discord()} {
 		if _, err := oauth.New(fakeProvider{}, oauth.Config{
-			ClientID: "x", RedirectURL: "y", Provider: p, Scopes: []string{"identify"},
+			ClientID: "x", RedirectURL: "https://app.example/cb", Provider: p, Scopes: []string{"identify"},
 		}); err != nil {
 			t.Errorf("OAuth2 preset rejected: %v", err)
 		}
@@ -91,7 +91,7 @@ func TestNew_oauth2ProviderValid(t *testing.T) {
 func TestNew_providerWithNoIdentitySourceRejected(t *testing.T) {
 	// Auth + token endpoints but neither issuer/JWKS nor userinfo.
 	_, err := oauth.New(fakeProvider{}, oauth.Config{
-		ClientID: "x", RedirectURL: "y",
+		ClientID: "x", RedirectURL: "https://app.example/cb",
 		Provider: oauth.Provider{AuthURL: "a", TokenURL: "t"},
 	})
 	if err == nil {
@@ -154,6 +154,7 @@ func TestVerifyIDToken_audArrayAndStringEmailVerified(t *testing.T) {
 
 	cl := validClaims(srv.URL, "n")
 	cl["aud"] = []string{testClientID, "another"}
+	cl["azp"] = testClientID      // OIDC: multi-aud token must name us as authorized party
 	cl["email_verified"] = "true" // some providers send a string
 	tok := signIDToken(t, key, testKID, cl)
 
@@ -166,6 +167,23 @@ func TestVerifyIDToken_audArrayAndStringEmailVerified(t *testing.T) {
 	}
 	if !claims.EmailVerified {
 		t.Error("string email_verified \"true\" not parsed as true")
+	}
+}
+
+func TestVerifyIDToken_multiAudWrongAZPRejected(t *testing.T) {
+	key := mustRSA(t)
+	srv := jwksServer(t, &key.PublicKey)
+	defer srv.Close()
+	c := newClient(t, srv)
+
+	// Our client id is in aud, but the token was authorized for another client.
+	cl := validClaims(srv.URL, "n")
+	cl["aud"] = []string{testClientID, "another"}
+	cl["azp"] = "another"
+	tok := signIDToken(t, key, testKID, cl)
+
+	if _, err := c.VerifyIDToken(context.Background(), tok, "n"); err == nil {
+		t.Error("expected rejection of a multi-audience token whose azp is another client")
 	}
 }
 
@@ -202,7 +220,7 @@ func TestVerifyIDToken_jwksEmpty(t *testing.T) {
 func TestAuthCodeURL_defaultScopesIncludeOpenID(t *testing.T) {
 	// No scopes set -> the OIDC default set (with openid) is used.
 	c, _ := oauth.New(fakeProvider{}, oauth.Config{
-		ClientID: "x", RedirectURL: "y", Provider: oauth.Google(),
+		ClientID: "x", RedirectURL: "https://app.example/cb", Provider: oauth.Google(),
 	})
 	req, _ := c.AuthCodeURL()
 	if !strings.Contains(req.URL, "openid") {
@@ -214,7 +232,7 @@ func TestAuthCodeURL_callerScopesVerbatim(t *testing.T) {
 	// Caller-supplied scopes are used as-is (no openid injected) — required for
 	// plain-OAuth2 providers like GitHub.
 	c, _ := oauth.New(fakeProvider{}, oauth.Config{
-		ClientID: "x", RedirectURL: "y", Provider: oauth.GitHub(),
+		ClientID: "x", RedirectURL: "https://app.example/cb", Provider: oauth.GitHub(),
 		Scopes: []string{"read:user", "user:email"},
 	})
 	req, _ := c.AuthCodeURL()

--- a/auth/oauth/oauth_test.go
+++ b/auth/oauth/oauth_test.go
@@ -130,7 +130,7 @@ func TestAuthCodeURL_hasPKCEAndState(t *testing.T) {
 }
 
 func TestAuthCodeURL_independentPerCall(t *testing.T) {
-	c, _ := oauth.New(fakeProvider{}, oauth.Config{ClientID: "x", RedirectURL: "y", Provider: oauth.Google()})
+	c, _ := oauth.New(fakeProvider{}, oauth.Config{ClientID: "x", RedirectURL: "https://app.example/cb", Provider: oauth.Google()})
 	a, _ := c.AuthCodeURL()
 	b, _ := c.AuthCodeURL()
 	if a.State == b.State || a.Nonce == b.Nonce || a.Verifier == b.Verifier {
@@ -142,9 +142,9 @@ func TestAuthCodeURL_independentPerCall(t *testing.T) {
 
 func TestNew_invalidConfigRejected(t *testing.T) {
 	cases := map[string]oauth.Config{
-		"no client id": {RedirectURL: "y", Provider: oauth.Google()},
+		"no client id": {RedirectURL: "https://app.example/cb", Provider: oauth.Google()},
 		"no redirect":  {ClientID: "x", Provider: oauth.Google()},
-		"no provider":  {ClientID: "x", RedirectURL: "y"},
+		"no provider":  {ClientID: "x", RedirectURL: "https://app.example/cb"},
 	}
 	for name, cfg := range cases {
 		if _, err := oauth.New(fakeProvider{}, cfg); err == nil {
@@ -287,7 +287,7 @@ func TestExchange_errors(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
-	c, _ := oauth.New(fakeProvider{}, oauth.Config{ClientID: "x", RedirectURL: "y", Provider: oauth.Google()})
+	c, _ := oauth.New(fakeProvider{}, oauth.Config{ClientID: "x", RedirectURL: "https://app.example/cb", Provider: oauth.Google()})
 	if c.Name() != "oauth" {
 		t.Errorf("Name() = %q, want oauth", c.Name())
 	}

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -67,7 +67,7 @@ http.Redirect(w, r, req.URL, http.StatusFound)
 **Callback** — check `state`, exchange the code, validate the ID token:
 
 ```go
-if r.FormValue("state") != savedState {
+if subtle.ConstantTimeCompare([]byte(r.FormValue("state")), []byte(savedState)) != 1 {
     http.Error(w, "bad state", http.StatusBadRequest) // CSRF / stale
     return
 }

--- a/examples/oauth/main.go
+++ b/examples/oauth/main.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"log"
@@ -80,7 +81,7 @@ func main() {
 			http.Error(w, "missing or bad flow cookie", http.StatusBadRequest)
 			return
 		}
-		if r.FormValue("state") != state {
+		if subtle.ConstantTimeCompare([]byte(r.FormValue("state")), []byte(state)) != 1 {
 			http.Error(w, "state mismatch", http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
Two independent security reviews (authn + misuse-resistance) of the new oauth module. Verdict: no account-takeover path — `alg:none`/HMAC blocked, PKCE S256 forced, state/nonce 256-bit, nonce bound constant-time, issuer/audience/expiry fail closed. These are the hardening gaps and the one functional bug they found.

**Functional bug**
- `Exchange` required an `id_token` unconditionally, so the documented OAuth2 path (GitHub/Discord → Exchange → UserInfo) and the shipped example never ran — login failed at exchange. Now an `id_token` is required only for OIDC providers (issuer+JWKS set).

**Security hardening**
- **HTTPS enforced** on every endpoint (auth/token/JWKS/userinfo), the redirect URL, and the discovery issuer; plain `http` only for loopback. A plaintext endpoint was MITM-substitutable (forged JWKS → forged ID token; lifted code/token).
- **OIDC `azp`**: when an ID token names multiple audiences or carries `azp`, require `azp == client id` — a token minted for another client can't be replayed.
- Reject JWKS RSA keys with modulus < 2048 bits; skip keys whose JWK `use` is not `sig`.
- Add an `iat` sanity check (`WithIssuedAt`).
- Constant-time `state` comparison in the docs, package example and runnable example.

No public signatures changed. Behaviour note: a non-loopback `http` endpoint is now rejected at `New` (it was always insecure). Tests added for each fix; `go build`, `go vet`, `golangci-lint` (0 issues), the full suite with `-race`, and the example all pass. Aggregate coverage 90.6%.

Closes #160
