### PR TITLE
fix(oauth): bound RSA exponent/modulus in JWKS parsing

### DIFF
--- a/auth/oauth/jwks.go
+++ b/auth/oauth/jwks.go
@@ -149,13 +149,17 @@ func parseJWK(k jwk) (crypto.PublicKey, error) {
 			return nil, err
 		}
 		e := new(big.Int).SetBytes(eBytes)
-		if !e.IsInt64() || e.Int64() < 2 {
+		// Bound the exponent to 31 bits: it must fit an int on a 32-bit build
+		// (int(e.Int64()) would otherwise silently truncate), and a real RSA
+		// exponent is tiny (commonly 65537).
+		if !e.IsInt64() || e.Int64() < 2 || e.BitLen() > 31 {
 			return nil, fmt.Errorf("invalid RSA exponent")
 		}
-		// Reject undersized moduli — a small (potentially factorable) RSA key
-		// must never be trusted to verify a signature.
-		if n.BitLen() < 2048 {
-			return nil, fmt.Errorf("RSA modulus too small: %d bits", n.BitLen())
+		// Bound the modulus: reject undersized (potentially factorable) keys, and
+		// cap the upper end so a hostile JWKS cannot publish a multi-megabit
+		// modulus that turns every verification into a heavy modexp (CPU DoS).
+		if bits := n.BitLen(); bits < 2048 || bits > 16384 {
+			return nil, fmt.Errorf("RSA modulus out of range: %d bits", bits)
 		}
 		return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
 	case "EC":

--- a/auth/oauth/oauth_hardening_test.go
+++ b/auth/oauth/oauth_hardening_test.go
@@ -1,6 +1,7 @@
 package oauth_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -11,6 +12,31 @@ import (
 
 	"github.com/Glyndor/authcore/auth/oauth"
 )
+
+func TestVerifyIDToken_rsaBoundsRejected(t *testing.T) {
+	key := mustRSA(t)
+	goodN := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+	hugeN := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0xff}, 2049)) // ~16392 bits, over the cap
+	wideE := base64.RawURLEncoding.EncodeToString([]byte{0x01, 0, 0, 0, 0x03})      // 33-bit exponent
+
+	cases := map[string]string{
+		"oversized modulus": fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":%q,"n":%q,"e":"AQAB"}]}`, testKID, hugeN),
+		"wide exponent":     fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":%q,"n":%q,"e":%q}]}`, testKID, goodN, wideE),
+	}
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(doc))
+			}))
+			defer srv.Close()
+			c := newClient(t, srv)
+			tok := signIDToken(t, key, testKID, validClaims(srv.URL, "n"))
+			if _, err := c.VerifyIDToken(context.Background(), tok, "n"); err == nil {
+				t.Errorf("%s: out-of-range RSA key must be rejected", name)
+			}
+		})
+	}
+}
 
 // ---- HTTPS enforcement ------------------------------------------------------
 

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -143,9 +143,17 @@ func (km *KeyManager) PublicKey() ed25519.PublicKey {
 	return km.publicKey
 }
 
-// RefreshSecret returns the 32-byte secret used as the HMAC-SHA256 key
-// when hashing refresh tokens before database storage.
+// RefreshSecret returns the 32-byte secret used as the HMAC-SHA256 key when
+// hashing refresh tokens (and, in the apikey module, as the key-hash pepper).
 // The returned slice must not be modified by the caller.
+//
+// The secret is intentionally shared across those uses. HMAC-SHA256 is a secure
+// PRF under multi-purpose use and the message namespaces differ (a compact JWT
+// vs an "ak_<id>_<secret>" key), so there is no cross-protocol forgery. It is
+// not split into per-use subkeys (e.g. via HKDF) because the resulting hashes
+// are stored by the consumer: changing the derivation would invalidate every
+// stored refresh-token and API-key hash on upgrade — a forced mass logout the
+// evergreen rule forbids.
 func (km *KeyManager) RefreshSecret() []byte {
 	return km.refreshSecret
 }


### PR DESCRIPTION
From the crypto review of the JWKS parser (verdict: low risk, no home-rolled primitives). Two defense-in-depth bounds, both gated behind controlling the TLS-delivered JWKS:

- Reject RSA exponents wider than 31 bits before `int(e.Int64())`, which would truncate on a 32-bit build.
- Cap the modulus at 16384 bits (2048-bit floor kept) so a hostile JWKS cannot force a heavy modexp per verify (CPU DoS).

Also documents why the refresh secret is intentionally shared (refresh-hash + apikey pepper) rather than HKDF-split: HMAC is a safe PRF here, and changing the derivation would invalidate every consumer-stored hash — a forced mass logout the evergreen rule forbids.

Tests reject an oversized-modulus and a wide-exponent JWK. Build/vet/lint(0)/`-race` all pass.

Closes #168
