### PR TITLE
fix(deps): bump go to 1.26.4 (GO-2026-5037)

### DIFF
--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/basic
 
-go 1.26.3
+go 1.26.4
 
 require github.com/Glyndor/authcore v1.2.2
 

--- a/examples/email/go.mod
+++ b/examples/email/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/email
 
-go 1.26.3
+go 1.26.4
 
 require github.com/Glyndor/authcore v1.2.2
 

--- a/examples/fiber/go.mod
+++ b/examples/fiber/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/fiber
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Glyndor/authcore v1.1.1

--- a/examples/gin/go.mod
+++ b/examples/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/gin
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Glyndor/authcore v1.1.1

--- a/examples/jwt/go.mod
+++ b/examples/jwt/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/jwt
 
-go 1.26.3
+go 1.26.4
 
 require github.com/Glyndor/authcore v1.2.2
 

--- a/examples/oauth/go.mod
+++ b/examples/oauth/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/oauth
 
-go 1.26.3
+go 1.26.4
 
 require github.com/Glyndor/authcore v1.9.0
 

--- a/examples/password/go.mod
+++ b/examples/password/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/password
 
-go 1.26.3
+go 1.26.4
 
 require github.com/Glyndor/authcore v1.2.2
 

--- a/examples/username/go.mod
+++ b/examples/username/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/username
 
-go 1.26.3
+go 1.26.4
 
 require github.com/Glyndor/authcore v1.2.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
govulncheck flagged **GO-2026-5037** — a `crypto/x509` hostname-parsing DoS in the go1.26.3 standard library, reachable via the oauth `Exchange` TLS path. Fixed in go1.26.4.

Bump the `go` directive in the root and every `examples/*` module to 1.26.4 so the patched toolchain is required. `govulncheck ./...` reports **No vulnerabilities found** after the bump; build + full suite pass on go1.26.4.

Patch-level MSRV raise, justified by the advisory.

Closes #171
