### PR TITLE
fix(oauth,jwt): harden from the review sweep

### DIFF
--- a/auth/jwt/denylist.go
+++ b/auth/jwt/denylist.go
@@ -1,6 +1,15 @@
 package jwt
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// defaultDenylistTimeout bounds the revocation lookup when VerifyAccessToken is
+// called (the context-less convenience method). It keeps a slow or hung
+// Denylist store from blocking the verifying goroutine indefinitely. Use
+// VerifyAccessTokenContext to supply your own deadline instead.
+const defaultDenylistTimeout = 5 * time.Second
 
 // Denylist is the optional, opt-in hook that makes a stateless access token
 // revocable before it expires.

--- a/auth/jwt/denylist_test.go
+++ b/auth/jwt/denylist_test.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -87,6 +88,39 @@ func TestVerifyAccessToken_noDenylistSkipsLookup(t *testing.T) {
 	pair, _ := j.CreateTokens(testSubject, struct{}{})
 	if _, err := j.VerifyAccessToken(pair.AccessToken); err != nil {
 		t.Fatalf("verify without a denylist must succeed, got %v", err)
+	}
+}
+
+// deadlineStub records whether the context it was handed carried a deadline.
+type deadlineStub struct{ hadDeadline bool }
+
+func (s *deadlineStub) IsRevoked(ctx context.Context, _ string) (bool, error) {
+	_, s.hadDeadline = ctx.Deadline()
+	return false, nil
+}
+
+func TestVerifyAccessToken_denylistRunsUnderDeadline(t *testing.T) {
+	// The context-less convenience method must bound the denylist lookup with a
+	// default timeout so a hung store cannot block forever.
+	stub := &deadlineStub{}
+	cfg := DefaultConfig()
+	cfg.Denylist = stub
+	j := newTestJWT[struct{}](t, newFakeProvider(t), cfg)
+	pair, _ := j.CreateTokens(testSubject, struct{}{})
+
+	if _, err := j.VerifyAccessToken(pair.AccessToken); err != nil {
+		t.Fatalf("VerifyAccessToken: %v", err)
+	}
+	if !stub.hadDeadline {
+		t.Error("denylist lookup should run under a deadline when called via VerifyAccessToken")
+	}
+}
+
+func TestVerifyAccessToken_oversizedTokenRejected(t *testing.T) {
+	j := newTestJWT[struct{}](t, newFakeProvider(t), DefaultConfig())
+	oversized := strings.Repeat("a", 9000) // over the 8 KiB cap
+	if _, err := j.VerifyAccessToken(oversized); !errors.Is(err, ErrTokenMalformed) {
+		t.Errorf("expected ErrTokenMalformed for an oversized token, got %v", err)
 	}
 }
 

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -216,11 +216,18 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 //	claims, err := jwtMod.VerifyAccessToken(token)
 //	if errors.Is(err, jwt.ErrTokenExpired) { ... }
 //
-// When a Denylist is configured (Config.Denylist), this uses a background
-// context for the revocation lookup. Use VerifyAccessTokenContext to pass your
-// own context (recommended for a network-backed denylist).
+// When a Denylist is configured (Config.Denylist), the revocation lookup runs
+// under a background context bounded by a default timeout (defaultDenylistTimeout)
+// so a slow or hung store cannot block the verifying goroutine forever. Use
+// VerifyAccessTokenContext to pass your own context (recommended for a
+// network-backed denylist, e.g. to inherit the request deadline).
 func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {
-	return j.VerifyAccessTokenContext(context.Background(), token)
+	if j.denylist == nil {
+		return j.VerifyAccessTokenContext(context.Background(), token)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultDenylistTimeout)
+	defer cancel()
+	return j.VerifyAccessTokenContext(ctx, token)
 }
 
 // VerifyAccessTokenContext is VerifyAccessToken with an explicit context that

--- a/auth/jwt/token.go
+++ b/auth/jwt/token.go
@@ -33,6 +33,12 @@ const (
 	tokenTypeRefresh = "refresh"
 )
 
+// maxTokenLen caps the length of a token string before it is parsed. A genuine
+// access/refresh token is a few hundred bytes; refusing anything over 8 KiB
+// stops an attacker from forcing base64+JSON work on a multi-megabyte string
+// before the signature is even checked.
+const maxTokenLen = 8 * 1024
+
 // accessClaims is the internal claim set for access tokens.
 // T carries the application-specific fields stored under the "extra" key.
 type accessClaims[T any] struct {
@@ -99,6 +105,9 @@ func signToken(claims gjwt.Claims, key ed25519.PrivateKey, kid string) (string, 
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
 func verifyAccessToken[T any](tokenStr string, keys map[string]ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*accessClaims[T], error) {
+	if len(tokenStr) > maxTokenLen {
+		return nil, ErrTokenMalformed
+	}
 	var c accessClaims[T]
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,
@@ -123,6 +132,9 @@ func verifyAccessToken[T any](tokenStr string, keys map[string]ed25519.PublicKey
 // accepted here.
 // leeway is added to the expiration window to tolerate small clock skew between servers.
 func verifyRefreshToken(tokenStr string, keys map[string]ed25519.PublicKey, now time.Time, issuer, audience string, leeway time.Duration) (*refreshClaims, error) {
+	if len(tokenStr) > maxTokenLen {
+		return nil, ErrTokenMalformed
+	}
 	var c refreshClaims
 	_, err := gjwt.ParseWithClaims(
 		tokenStr, &c,

--- a/auth/oauth/jwks.go
+++ b/auth/oauth/jwks.go
@@ -22,6 +22,11 @@ const (
 	jwksTTL = time.Hour
 	// jwksMaxBytes caps a JWKS response so a hostile endpoint cannot exhaust memory.
 	jwksMaxBytes = 1 << 20
+	// minRefreshInterval throttles refreshes triggered by an unknown kid. Without
+	// it, a flood of tokens carrying bogus kids would force one outbound JWKS GET
+	// per verification (request amplification). A genuine key rotation is still
+	// picked up within this window.
+	minRefreshInterval = time.Minute
 )
 
 // jwk is one JSON Web Key. Only the fields needed to build an RSA or EC public
@@ -46,9 +51,10 @@ type jwksCache struct {
 	url  string
 	http *http.Client
 
-	mu        sync.RWMutex
-	keys      map[string]crypto.PublicKey
-	expiresAt time.Time
+	mu          sync.RWMutex
+	keys        map[string]crypto.PublicKey
+	expiresAt   time.Time
+	lastAttempt time.Time // last refresh attempt, to throttle unknown-kid-driven fetches
 }
 
 func newJWKSCache(url string, h *http.Client) *jwksCache {
@@ -62,9 +68,16 @@ func (c *jwksCache) key(ctx context.Context, kid string) (crypto.PublicKey, erro
 	c.mu.RLock()
 	k, ok := c.keys[kid]
 	fresh := time.Now().Before(c.expiresAt)
+	throttled := time.Since(c.lastAttempt) < minRefreshInterval
 	c.mu.RUnlock()
 	if ok && fresh {
 		return k, nil
+	}
+	// An unknown kid normally triggers a refresh (to pick up rotation), but only
+	// if we have not just refreshed — otherwise bogus kids would force a fetch
+	// per request. A known-but-stale key still refreshes (gated by the TTL).
+	if !ok && throttled {
+		return nil, fmt.Errorf("%w: unknown kid %q", ErrJWKS, kid)
 	}
 
 	if err := c.refresh(ctx); err != nil {
@@ -85,6 +98,12 @@ func (c *jwksCache) key(ctx context.Context, kid string) (crypto.PublicKey, erro
 
 // refresh fetches the JWKS and replaces the cached key set.
 func (c *jwksCache) refresh(ctx context.Context) error {
+	// Record the attempt up front (success or failure) so the unknown-kid path
+	// is throttled to at most one fetch per minRefreshInterval.
+	c.mu.Lock()
+	c.lastAttempt = time.Now()
+	c.mu.Unlock()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
 	if err != nil {
 		return fmt.Errorf("%w: build request: %w", ErrJWKS, err)

--- a/auth/oauth/oauth_hardening_test.go
+++ b/auth/oauth/oauth_hardening_test.go
@@ -3,6 +3,9 @@ package oauth_test
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"math/big"
@@ -12,6 +15,41 @@ import (
 
 	"github.com/Glyndor/authcore/auth/oauth"
 )
+
+func TestVerifyIDToken_ecOffCurveAndBadCurveRejected(t *testing.T) {
+	signKey := mustRSA(t)
+	ec, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ec: %v", err)
+	}
+	raw, err := ec.PublicKey.Bytes()
+	if err != nil {
+		t.Fatalf("ec bytes: %v", err)
+	}
+	x := base64.RawURLEncoding.EncodeToString(raw[1:33])
+	yGood := raw[33:65]
+	yBad := append([]byte(nil), yGood...)
+	yBad[len(yBad)-1] ^= 0xff // perturb y so the point is no longer on the curve
+	xB64 := x
+
+	cases := map[string]string{
+		"off-curve point":   fmt.Sprintf(`{"keys":[{"kty":"EC","kid":%q,"crv":"P-256","x":%q,"y":%q}]}`, testKID, xB64, base64.RawURLEncoding.EncodeToString(yBad)),
+		"unsupported curve": fmt.Sprintf(`{"keys":[{"kty":"EC","kid":%q,"crv":"P-999","x":%q,"y":%q}]}`, testKID, xB64, base64.RawURLEncoding.EncodeToString(yGood)),
+	}
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(doc))
+			}))
+			defer srv.Close()
+			c := newClient(t, srv)
+			tok := signIDToken(t, signKey, testKID, validClaims(srv.URL, "n"))
+			if _, err := c.VerifyIDToken(context.Background(), tok, "n"); err == nil {
+				t.Errorf("%s: invalid EC key must be rejected", name)
+			}
+		})
+	}
+}
 
 func TestVerifyIDToken_rsaBoundsRejected(t *testing.T) {
 	key := mustRSA(t)

--- a/auth/oauth/presets.go
+++ b/auth/oauth/presets.go
@@ -44,10 +44,15 @@ func Discord() Provider {
 }
 
 // Microsoft returns the Provider endpoints for the Microsoft identity platform
-// (Azure AD) for the given tenant. Use "common" for multi-tenant + personal
-// accounts, "organizations" for any work/school account, or a specific tenant
-// id. The issuer for the multi-tenant endpoints contains the tenant id of the
-// signed-in user, so prefer a single-tenant id when you can pin the issuer.
+// (Azure AD) for a SPECIFIC tenant id.
+//
+// Pass your concrete tenant id (a GUID, or a verified domain like
+// "contoso.onmicrosoft.com"). Do NOT pass the multi-tenant aliases "common",
+// "organizations", or "consumers": a real ID token's "iss" carries the
+// signed-in user's own tenant GUID, never the alias, and VerifyIDToken enforces
+// an exact issuer match — so an alias-based config rejects every token. Verifying
+// across arbitrary tenants needs per-tenant issuer validation, which exact-match
+// does not provide (tracked separately); pin a single tenant here.
 func Microsoft(tenant string) Provider {
 	base := fmt.Sprintf("https://login.microsoftonline.com/%s", tenant)
 	return Provider{

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -37,7 +37,7 @@ mod, err := oauth.New(auth, oauth.Config{
     ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
     ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
     RedirectURL:  "https://app.example.com/auth/callback",
-    Provider:     oauth.Google(), // or oauth.Microsoft("common"), or a custom Provider
+    Provider:     oauth.Google(), // or oauth.Microsoft("<your-tenant-id>"), or a custom Provider
 })
 ```
 

--- a/examples/oauth/README.md
+++ b/examples/oauth/README.md
@@ -23,7 +23,7 @@ Register `http://localhost:8080/callback` as the redirect URI with your provider
 | `OAUTH_PROVIDER` | Kind | Identity from |
 |---|---|---|
 | `google` (default) | OIDC | `VerifyIDToken` |
-| `microsoft` | OIDC | `VerifyIDToken` (set `OAUTH_TENANT`, default `common`) |
+| `microsoft` | OIDC | `VerifyIDToken` (set `OAUTH_TENANT` to a specific tenant id — the `common`/`organizations` aliases fail exact-issuer validation) |
 | `github` | OAuth2 | `UserInfo` |
 | `discord` | OAuth2 | `UserInfo` |
 

--- a/examples/oauth/main.go
+++ b/examples/oauth/main.go
@@ -41,7 +41,14 @@ func main() {
 	case "google":
 		cfg.Provider = oauth.Google()
 	case "microsoft":
-		cfg.Provider = oauth.Microsoft(env("OAUTH_TENANT", "common"))
+		// A specific tenant id is required: the multi-tenant aliases
+		// (common/organizations/consumers) fail exact-issuer validation.
+		tenant := env("OAUTH_TENANT", "")
+		switch tenant {
+		case "", "common", "organizations", "consumers":
+			log.Fatal("set OAUTH_TENANT to a specific Microsoft tenant id (GUID or verified domain); the common/organizations aliases do not pass exact-issuer validation")
+		}
+		cfg.Provider = oauth.Microsoft(tenant)
 	case "github":
 		cfg.Provider = oauth.GitHub()
 		cfg.Scopes = []string{"read:user", "user:email"}


### PR DESCRIPTION
From the multi-agent review sweep (bug + security + test reviewers).

- **Microsoft preset (functional bug, confirmed x2):** `Microsoft("common"/"organizations"/"consumers")` builds a config whose `iss` is the literal alias, but real multi-tenant tokens carry the signed-in user's tenant GUID, so exact-issuer `VerifyIDToken` always failed — multi-tenant login could never succeed. Documented that a specific tenant id is required; the example now refuses the aliases. Proper multi-tenant validation tracked in #174.
- **Denylist timeout (P2):** `VerifyAccessToken` ran the revocation lookup under `context.Background()`; a hung store blocked the verifying goroutine. It now bounds the lookup with a default 5s timeout; `VerifyAccessTokenContext` still honours the caller's context.
- **Token length cap (P2):** reject tokens over 8 KiB before parsing (DoS on oversized input).
- **JWKS unknown-kid amplification (P2):** throttle JWKS refresh to once per minute for unknown kids, so a flood of bogus-kid tokens cannot force one outbound JWKS GET per verify. A real rotation is still picked up within the window.

Tests added: EC off-curve + unsupported-curve rejection (previously only fuzzed — a security path), the denylist deadline, and the oversized-token cap.

`go build`, `go vet`, `golangci-lint` (0 issues) and the full suite with `-race` pass.

Closes #173
