### PR TITLE
chore: stop publishing AI-tool ignore patterns in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,13 +46,3 @@ Thumbs.db
 
 # authcore managed key directory — never commit cryptographic keys
 .authcore/
-
-
-# Agent / AI-tool artifacts — never commit (zero AI trace).
-.claude/
-.agents/
-.cursor/
-.aider*
-.continue/
-.playwright-mcp/
-**/*-mcp/


### PR DESCRIPTION
The committed `.gitignore` announced agent/AI-tool directories (`.claude/`, `.cursor/`, `.playwright-mcp/`, …) under a "zero AI trace" comment — itself an AI-tooling disclosure in a public repo (flagged by the zero-ai-trace audit).

These artifacts are already ignored by the global `core.excludesFile`, so removing them here loses no protection (verified: `.claude` is still ignored via the global file) while dropping the disclosure. Key, secret, editor, and OS-junk ignores stay.

Note: the two historical commits that introduced this block (PR #68) and their text remain in published tags; scrubbing those needs a history rewrite, which is a separate maintainer decision.
