### PR TITLE
docs: self-contained code doc-comments for API consumers

### DIFF
--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -217,8 +217,8 @@ func (j *JWT[T]) issueTokens(subject, jti string, extra T) (*TokenPair, error) {
 //	if errors.Is(err, jwt.ErrTokenExpired) { ... }
 //
 // When a Denylist is configured (Config.Denylist), the revocation lookup runs
-// under a background context bounded by a default timeout (defaultDenylistTimeout)
-// so a slow or hung store cannot block the verifying goroutine forever. Use
+// under a background context bounded by a default 5-second timeout so a slow or
+// hung store cannot block the verifying goroutine forever. Use
 // VerifyAccessTokenContext to pass your own context (recommended for a
 // network-backed denylist, e.g. to inherit the request deadline).
 func (j *JWT[T]) VerifyAccessToken(token string) (*Claims[T], error) {

--- a/auth/oauth/presets.go
+++ b/auth/oauth/presets.go
@@ -52,7 +52,7 @@ func Discord() Provider {
 // signed-in user's own tenant GUID, never the alias, and VerifyIDToken enforces
 // an exact issuer match — so an alias-based config rejects every token. Verifying
 // across arbitrary tenants needs per-tenant issuer validation, which exact-match
-// does not provide (tracked separately); pin a single tenant here.
+// does not provide and which is not currently supported; pin a single tenant here.
 func Microsoft(tenant string) Provider {
 	base := fmt.Sprintf("https://login.microsoftonline.com/%s", tenant)
 	return Provider{

--- a/authcore.go
+++ b/authcore.go
@@ -14,9 +14,12 @@
 // independent package that accepts an authcore.Provider — the narrow interface
 // that *AuthCore satisfies — so modules remain independently testable.
 //
-//	auth/jwt    — JSON Web Tokens
-//	auth/apikey — opaque API key generation and validation
-//	auth/oauth  — OAuth 2.0 / OIDC
+//	auth/jwt      — JSON Web Tokens (access + refresh, EdDSA)
+//	auth/password — Argon2id password hashing
+//	auth/email    — email validation and normalization
+//	auth/username — username validation and normalization
+//	auth/apikey   — opaque API key generation and validation
+//	auth/oauth    — OpenID Connect / OAuth 2.0 client (social login)
 //
 // # Key management
 //

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -152,8 +152,8 @@ func (km *KeyManager) PublicKey() ed25519.PublicKey {
 // vs an "ak_<id>_<secret>" key), so there is no cross-protocol forgery. It is
 // not split into per-use subkeys (e.g. via HKDF) because the resulting hashes
 // are stored by the consumer: changing the derivation would invalidate every
-// stored refresh-token and API-key hash on upgrade — a forced mass logout the
-// evergreen rule forbids.
+// stored refresh-token and API-key hash on upgrade, forcing all users to
+// re-authenticate — a breaking change the library avoids by design.
 func (km *KeyManager) RefreshSecret() []byte {
 	return km.refreshSecret
 }


### PR DESCRIPTION
From the doc-audience review of the code doc-comments (verdict: docs address the right third-party reader; these are small self-containment fixes):

- `internal/keymanager`: drop the internal "evergreen rule" term from the `RefreshSecret` rationale — state the consequence (forced re-authentication on upgrade) directly.
- `auth/oauth`: the Microsoft preset doc no longer says multi-tenant is "tracked separately" (an internal-backlog reference a pkg.go.dev reader cannot resolve) — it says "not currently supported".
- `auth/jwt`: `VerifyAccessToken` states the default 5-second denylist timeout instead of naming the unexported `defaultDenylistTimeout` symbol.
- `authcore` package overview: list all six modules — `password`/`email`/`username` were missing from the landing godoc.

Docs only. Build/vet/lint(0) pass.
