### PR TITLE
docs: fix Markdown staleness/gaps + add apikey example

### DIFF
--- a/examples/apikey/README.md
+++ b/examples/apikey/README.md
@@ -1,0 +1,21 @@
+# auth/apikey — opaque API key example
+
+Issue an opaque API key, then verify a presented key the way a request handler
+would (parse the id, look up the stored hash, constant-time compare).
+
+## Run
+
+```bash
+go run ./examples/apikey
+```
+
+## What it shows
+
+| Step | API |
+|---|---|
+| Issue — key to show once, id + hash to store | `keyMod.Generate()` |
+| Extract the lookup id from a presented key | `keyMod.ParseID(key)` |
+| Verify in constant time | `keyMod.Verify(key, storedHash)` |
+
+The library stores nothing — you persist `key.ID` (lookup) and `key.Hash`, never
+the raw key. See [API keys](../../docs/apikey.md).

--- a/examples/apikey/go.mod
+++ b/examples/apikey/go.mod
@@ -1,0 +1,7 @@
+module github.com/Glyndor/authcore/examples/apikey
+
+go 1.26.4
+
+require github.com/Glyndor/authcore v1.10.6
+
+replace github.com/Glyndor/authcore => ../../

--- a/examples/apikey/main.go
+++ b/examples/apikey/main.go
@@ -1,0 +1,46 @@
+// Command apikey is a runnable example of authcore's opaque API key module:
+// issue a key, then verify a presented key the way a request handler would.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/auth/apikey"
+)
+
+func main() {
+	auth, err := authcore.New(authcore.DefaultConfig())
+	if err != nil {
+		log.Fatalf("authcore: %v", err)
+	}
+	keyMod, err := apikey.New(auth)
+	if err != nil {
+		log.Fatalf("apikey: %v", err)
+	}
+
+	// Issue — show key.Key to the user exactly once; store key.ID and key.Hash.
+	key, err := keyMod.Generate()
+	if err != nil {
+		log.Fatalf("generate: %v", err)
+	}
+	fmt.Println("Give to the user ONCE :", key.Key)
+	fmt.Println("Store (lookup id)     :", key.ID)
+	fmt.Println("Store (hash)          :", key.Hash)
+
+	// Verify — what a request handler does: parse the id, fetch the stored hash
+	// by id, then compare in constant time.
+	id, err := keyMod.ParseID(key.Key)
+	if err != nil {
+		log.Fatalf("parse id: %v", err)
+	}
+	fmt.Println("\nIncoming request key parsed to id:", id)
+	fmt.Println("Verify correct key  :", keyMod.Verify(key.Key, key.Hash))       // true
+	fmt.Println("Verify tampered key :", keyMod.Verify(key.Key+"x", key.Hash))   // false
+
+	// A malformed key is rejected before any lookup.
+	if _, err := keyMod.ParseID("not-a-key"); err != nil {
+		fmt.Println("Malformed key rejected:", err)
+	}
+}

--- a/examples/apikey/main.go
+++ b/examples/apikey/main.go
@@ -36,8 +36,8 @@ func main() {
 		log.Fatalf("parse id: %v", err)
 	}
 	fmt.Println("\nIncoming request key parsed to id:", id)
-	fmt.Println("Verify correct key  :", keyMod.Verify(key.Key, key.Hash))       // true
-	fmt.Println("Verify tampered key :", keyMod.Verify(key.Key+"x", key.Hash))   // false
+	fmt.Println("Verify correct key  :", keyMod.Verify(key.Key, key.Hash))     // true
+	fmt.Println("Verify tampered key :", keyMod.Verify(key.Key+"x", key.Hash)) // false
 
 	// A malformed key is rejected before any lookup.
 	if _, err := keyMod.ParseID("not-a-key"); err != nil {


### PR DESCRIPTION
From the Markdown docs review (verdict: marketing surface is captivating and well-sized; defects were staleness and completeness). All findings addressed:

1. **README stale Roadmap** — deleted; every item (apikey, rotation, revocation hook, pluggable key source, oauth) shipped and is in the Modules table above it.
2. **docs/validation.md** — the email `Close()` comment described a background goroutine that no longer exists; it is now an optional no-op.
3. **docs/errors.md** — added the `auth/apikey` and `auth/oauth` error sections and the `jwt.ErrTokenRevoked` row (referenced by jwt.md/secure-login.md but previously unlisted).
4. **README badges** — removed the third-party shields.io badges (kept the GitHub-native CI badge + the canonical pkg.go.dev one); the feature tags moved into the pitch text.
5. **README Mermaid** — added `apikey`/`oauth` to the architecture diagram.
6. **docs/testing.md** — added `apikey`/`oauth` to the layout tree and import table, plus the oauth/apikey examples.
7. **docs/configuration.md** — documented the `KeyStore` field.
8. **examples/apikey/** — added a runnable example for parity (every other module has one) and to the CI matrix.

Docs + one new example module. `go build`, `go vet`, `golangci-lint` (0 issues) pass; the apikey example builds in readonly mode.
