### PR TITLE
release: v1.10.7

### DIFF
--- a/examples/apikey/README.md
+++ b/examples/apikey/README.md
@@ -1,0 +1,21 @@
+# auth/apikey — opaque API key example
+
+Issue an opaque API key, then verify a presented key the way a request handler
+would (parse the id, look up the stored hash, constant-time compare).
+
+## Run
+
+```bash
+go run ./examples/apikey
+```
+
+## What it shows
+
+| Step | API |
+|---|---|
+| Issue — key to show once, id + hash to store | `keyMod.Generate()` |
+| Extract the lookup id from a presented key | `keyMod.ParseID(key)` |
+| Verify in constant time | `keyMod.Verify(key, storedHash)` |
+
+The library stores nothing — you persist `key.ID` (lookup) and `key.Hash`, never
+the raw key. See [API keys](../../docs/apikey.md).

--- a/examples/apikey/go.mod
+++ b/examples/apikey/go.mod
@@ -1,0 +1,7 @@
+module github.com/Glyndor/authcore/examples/apikey
+
+go 1.26.4
+
+require github.com/Glyndor/authcore v1.10.6
+
+replace github.com/Glyndor/authcore => ../../

--- a/examples/apikey/main.go
+++ b/examples/apikey/main.go
@@ -1,0 +1,46 @@
+// Command apikey is a runnable example of authcore's opaque API key module:
+// issue a key, then verify a presented key the way a request handler would.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/auth/apikey"
+)
+
+func main() {
+	auth, err := authcore.New(authcore.DefaultConfig())
+	if err != nil {
+		log.Fatalf("authcore: %v", err)
+	}
+	keyMod, err := apikey.New(auth)
+	if err != nil {
+		log.Fatalf("apikey: %v", err)
+	}
+
+	// Issue — show key.Key to the user exactly once; store key.ID and key.Hash.
+	key, err := keyMod.Generate()
+	if err != nil {
+		log.Fatalf("generate: %v", err)
+	}
+	fmt.Println("Give to the user ONCE :", key.Key)
+	fmt.Println("Store (lookup id)     :", key.ID)
+	fmt.Println("Store (hash)          :", key.Hash)
+
+	// Verify — what a request handler does: parse the id, fetch the stored hash
+	// by id, then compare in constant time.
+	id, err := keyMod.ParseID(key.Key)
+	if err != nil {
+		log.Fatalf("parse id: %v", err)
+	}
+	fmt.Println("\nIncoming request key parsed to id:", id)
+	fmt.Println("Verify correct key  :", keyMod.Verify(key.Key, key.Hash))     // true
+	fmt.Println("Verify tampered key :", keyMod.Verify(key.Key+"x", key.Hash)) // false
+
+	// A malformed key is rejected before any lookup.
+	if _, err := keyMod.ParseID("not-a-key"); err != nil {
+		fmt.Println("Malformed key rejected:", err)
+	}
+}


### PR DESCRIPTION
Release v1.10.7 — documentation. One new example, no library code changes.

From the Markdown docs review: removed the stale README Roadmap and the third-party shields.io badges, fixed the false email Close() goroutine comment, completed the error reference (apikey/oauth/ErrTokenRevoked), documented the KeyStore config field, added apikey/oauth to the architecture diagram and the testing layout/import table, and added a runnable examples/apikey for parity. (#180)
