### PR TITLE
docs: apply the Markdown review fixes (were dropped from #180)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [basic, email, fiber, gin, jwt, oauth, password, username]
+        example: [apikey, basic, email, fiber, gin, jwt, oauth, password, username]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,12 @@
 
 **Auth is the code you only get wrong once. authcore does the dangerous parts for you.**
 
-Argon2id passwords · EdDSA tokens · refresh rotation · email + username validation —
-secure by default, in pure Go. No database. No framework. No crypto PhD.
-
-![secure by default](https://img.shields.io/badge/secure-by_default-3fb950)
-![passwords Argon2id](https://img.shields.io/badge/passwords-Argon2id-3fb950)
-![tokens EdDSA](https://img.shields.io/badge/tokens-EdDSA_Ed25519-3fb950)
-![timing-safe](https://img.shields.io/badge/comparisons-timing--safe-3fb950)
-![zero config](https://img.shields.io/badge/config-zero-3fb950)
+Argon2id passwords · EdDSA tokens · refresh rotation · API keys · social login
+(OIDC + OAuth2) · email + username validation — all secure by default, timing-safe,
+zero-config, in pure Go. No database. No framework. No crypto PhD. Apache-2.0.
 
 [![CI](https://github.com/Glyndor/authcore/actions/workflows/ci.yml/badge.svg)](https://github.com/Glyndor/authcore/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Glyndor/authcore.svg)](https://pkg.go.dev/github.com/Glyndor/authcore)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 [**Install**](#-install) · [**Quick start**](#-quick-start) · [**Why**](#-why) · [**Modules**](#-modules) · [**Examples**](examples/) · [**Docs**](docs/)
 
@@ -102,7 +96,7 @@ Pick only what you need — each is independent, testable, and safe by default.
 flowchart LR
     App["Your app"] -->|init once| Core["authcore"]
     Core -->|auto-generates| Keys[("🔑 Ed25519 + HMAC<br/>on disk")]
-    Core -->|Provider| M["password · jwt<br/>email · username"]
+    Core -->|Provider| M["password · jwt · apikey · oauth<br/>email · username"]
     M -->|hash · sign · verify| App
 ```
 
@@ -114,18 +108,6 @@ step-by-step flow that turns these primitives into a login an auditor accepts.
 [Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
 
 Full API reference on [pkg.go.dev](https://pkg.go.dev/github.com/Glyndor/authcore).
-
-<details>
-<summary><b>🗺️ Roadmap</b></summary>
-
-Shipped: `password`, `jwt`, `email`, `username`, automatic key management.
-
-Planned (no hard ETA): `apikey` (opaque keys + pluggable store), key-rotation
-helpers, an optional access-token revocation hook, a pluggable key source
-(KMS / env / in-memory), and `oauth` (OAuth2 / OIDC). Have a use case? Open an
-[issue](https://github.com/Glyndor/authcore/issues).
-
-</details>
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,10 +6,15 @@
 type Config struct {
     EnableLogs bool             // emit log output; default true via DefaultConfig()
     Timezone   *time.Location   // time zone for all operations; default time.UTC
-    Logger     authcore.Logger  // custom logger (slog, zap, zerolog, …); overrides EnableLogs
-    KeysDir    string           // key storage directory; default ".authcore"
+    Logger     authcore.Logger   // custom logger (slog, zap, zerolog, …); overrides EnableLogs
+    KeysDir    string            // key storage directory; default ".authcore"; ignored when KeyStore is set
+    KeyStore   authcore.KeyStore // optional: source keys from a secret manager / env / KMS instead of disk
 }
 ```
+
+`KeyStore` lets you supply key material instead of using the disk under
+`KeysDir` — see [Key management](key-management.md) (`NewKeyStoreFromKeys`,
+`NewKeyStoreFromPEM`). Leave it nil for the zero-config disk default.
 
 Always start from `DefaultConfig()` and override only what you need:
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -27,6 +27,7 @@ if errors.Is(err, jwt.ErrTokenExpired) {
 | `jwt.ErrTokenMalformed` | not a valid three-part JWT string |
 | `jwt.ErrWrongTokenType` | access token passed where refresh expected, or vice-versa |
 | `jwt.ErrInvalidSubject` | subject passed to `CreateTokens` is not a UUID v7 |
+| `jwt.ErrTokenRevoked` | a configured `Denylist` reports the token's session revoked |
 
 ## `auth/password` package
 
@@ -49,4 +50,24 @@ if errors.Is(err, jwt.ErrTokenExpired) {
 | Error | Client-safe? | When |
 |---|---|---|
 | `username.ErrInvalidUsername` | ✓ Yes | Username fails a validation rule; `errors.Unwrap` gives the specific rule |
+
+## `auth/apikey` package
+
+| Error | Client-safe? | When |
+|---|---|---|
+| `apikey.ErrInvalidConfig` | ✗ No | `apikey.Config` validation failed (e.g. malformed prefix) — startup error |
+| `apikey.ErrInvalidKey` | ✗ No | Presented key is malformed (`ParseID`); return a generic unauthorized |
+
+## `auth/oauth` package
+
+| Error | Client-safe? | When |
+|---|---|---|
+| `oauth.ErrInvalidConfig` | ✗ No | `oauth.Config` validation failed (missing/non-https endpoints, no identity source) |
+| `oauth.ErrExchange` | ✗ No | Authorization-code exchange failed (transport, non-2xx, or OAuth error) |
+| `oauth.ErrNoIDToken` | ✗ No | OIDC provider returned no `id_token` |
+| `oauth.ErrIDTokenInvalid` | ✗ No | ID token failed validation (signature, alg, `iss`/`aud`/`exp`/`nonce`/`azp`) — return generic unauthorized |
+| `oauth.ErrJWKS` | ✗ No | Provider signing keys could not be fetched or parsed |
+| `oauth.ErrUserInfo` | ✗ No | Userinfo request failed (transport, non-2xx, undecodable) |
+| `oauth.ErrNoUserInfo` | ✗ No | `UserInfo` called on a provider with no userinfo URL — programming error |
+| `oauth.ErrDiscovery` | ✗ No | OIDC discovery failed (fetch/parse, or issuer mismatch) |
 | `username.ErrInvalidConfig` | ✗ No | `username.Config` validation failed (startup error, treat as 500) |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -122,7 +122,9 @@ authcore/
 │   ├── jwt/             # JSON Web Token authentication (EdDSA / Ed25519)
 │   ├── password/        # Argon2id password hashing
 │   ├── email/           # Email validation, normalization, DNS MX verification
-│   └── username/        # Username validation, normalization, reserved name blocklist
+│   ├── username/        # Username validation, normalization, reserved name blocklist
+│   ├── apikey/          # Opaque API keys (HMAC-SHA256 keyed hash)
+│   └── oauth/           # OpenID Connect / OAuth2 client (social login)
 │
 └── examples/
     ├── basic/           # authcore initialisation strategies
@@ -130,6 +132,8 @@ authcore/
     ├── password/        # Password: policy, hash, verify
     ├── email/           # Email: validate, normalize, DNS MX verification
     ├── username/        # Username: validate, normalize, reserved names
+    ├── apikey/          # API keys: generate, verify, parse
+    ├── oauth/           # Social login: OIDC + OAuth2 flow (separate module)
     ├── fiber/           # Full auth API with Fiber v3 (separate module)
     └── gin/             # Full auth API with Gin (separate module)
 ```
@@ -141,5 +145,7 @@ authcore/
 | `…/auth/password` | public | Argon2id password hashing module |
 | `…/auth/email` | public | Email validation, normalization, MX verification |
 | `…/auth/username` | public | Username validation, normalization, reserved names |
+| `…/auth/apikey` | public | Opaque API key generation and verification |
+| `…/auth/oauth` | public | OpenID Connect / OAuth2 client |
 | `…/internal/clock` | internal | Shared time abstraction |
 | `…/internal/keymanager` | internal | Key generation and persistence |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -14,7 +14,8 @@ emailMod, err := email.New(auth)
 if err != nil {
     log.Fatal(err)
 }
-defer emailMod.Close() // stops the background cache eviction goroutine
+// Close is an optional no-op kept for backward compatibility — the module runs
+// no background goroutine, so no cleanup is required.
 ```
 
 ### Validating and normalizing


### PR DESCRIPTION
The Markdown review fixes intended for #180 were dropped when a failed `git add` of a non-existent `go.sum` aborted staging — only the apikey example landed. This commits the actual changes:

- README: removed the stale Roadmap and the third-party shields.io badges (kept GitHub-native CI + pkg.go.dev; feature tags moved into the pitch); added apikey/oauth to the architecture diagram.
- docs/validation.md: the email `Close()` is an optional no-op, not goroutine cleanup.
- docs/errors.md: added the apikey and oauth error sections and `jwt.ErrTokenRevoked`.
- docs/configuration.md: documented the `KeyStore` field.
- docs/testing.md: added apikey/oauth to the layout tree and import table.
- examples CI matrix now includes the apikey example.

Docs + CI matrix only.
