### PR TITLE
release: v1.11.0

### DIFF
--- a/auth/oauth/config.go
+++ b/auth/oauth/config.go
@@ -51,6 +51,20 @@ type Config struct {
 	// HTTPClient optionally overrides the client used for the token and JWKS
 	// requests. Defaults to a client with a 10-second timeout.
 	HTTPClient *http.Client
+
+	// IssuerValidator optionally replaces the default exact "iss" match with a
+	// predicate. It is nil by default (exact match against Provider.Issuer).
+	//
+	// Set it for a multi-tenant provider whose tokens carry a per-tenant issuer
+	// that no single string can match — e.g. Azure AD "common", where each
+	// user's token issuer contains their own tenant id (see AzureMultiTenantIssuer).
+	// When set, Provider.Issuer is ignored for verification and VerifyIDToken
+	// accepts a token whose iss the function approves.
+	//
+	// Returning true for an issuer means trusting every token it mints, so keep
+	// the predicate tight (a fixed pattern), and if you must restrict to certain
+	// tenants, additionally check the "tid" claim via IDClaims.Raw.
+	IssuerValidator func(issuer string) bool
 }
 
 // defaultScopes are requested when Config.Scopes is empty.
@@ -89,16 +103,21 @@ func validateConfig(cfg Config) error {
 		return fmt.Errorf("provider token URL must not be empty")
 	}
 
-	oidc := cfg.Provider.Issuer != "" && cfg.Provider.JWKSURL != ""
+	// OIDC needs the JWKS to verify signatures, plus an issuer to check — either
+	// a fixed Issuer or an IssuerValidator predicate (multi-tenant).
+	oidc := cfg.Provider.JWKSURL != "" && (cfg.Provider.Issuer != "" || cfg.IssuerValidator != nil)
 	oauth2 := cfg.Provider.UserInfoURL != ""
 	if !oidc && !oauth2 {
-		return fmt.Errorf("provider must supply either issuer+JWKS (OIDC) or a userinfo URL (OAuth2)")
+		return fmt.Errorf("provider must supply either JWKS + (issuer or IssuerValidator) for OIDC, or a userinfo URL for OAuth2")
 	}
-	// A half-configured OIDC provider (only one of issuer/JWKS) with no userinfo
-	// fallback is a mistake — flag it rather than silently dropping ID-token
-	// verification.
-	if !oauth2 && (cfg.Provider.Issuer == "") != (cfg.Provider.JWKSURL == "") {
-		return fmt.Errorf("OIDC provider needs both issuer and JWKS URL")
+	// A JWKS without any issuer check (no fixed Issuer and no validator), or an
+	// Issuer without a JWKS, is a half-configured OIDC provider — flag it rather
+	// than silently dropping verification.
+	if !oauth2 {
+		hasIssuerCheck := cfg.Provider.Issuer != "" || cfg.IssuerValidator != nil
+		if hasIssuerCheck != (cfg.Provider.JWKSURL != "") {
+			return fmt.Errorf("OIDC provider needs both a JWKS URL and an issuer (fixed or IssuerValidator)")
+		}
 	}
 
 	// Every endpoint and the redirect must be https (loopback excepted), so a

--- a/auth/oauth/idtoken.go
+++ b/auth/oauth/idtoken.go
@@ -52,20 +52,37 @@ func (c *Client) VerifyIDToken(ctx context.Context, idToken, nonce string) (*IDC
 		return nil, fmt.Errorf("%w: no nonce supplied to verify against", ErrIDTokenInvalid)
 	}
 
+	opts := []gjwt.ParserOption{
+		gjwt.WithValidMethods(idTokenAlgs),
+		gjwt.WithAudience(c.cfg.ClientID),
+		gjwt.WithExpirationRequired(),
+		gjwt.WithIssuedAt(),
+	}
+	// Exact issuer match unless a validator is configured (multi-tenant), in
+	// which case the issuer is checked by the predicate after parsing.
+	if c.cfg.IssuerValidator == nil {
+		opts = append(opts, gjwt.WithIssuer(c.cfg.Provider.Issuer))
+	}
+
 	var claims gjwt.MapClaims
 	_, err := gjwt.ParseWithClaims(idToken, &claims,
 		func(t *gjwt.Token) (any, error) {
 			kid, _ := t.Header["kid"].(string)
 			return c.jwks.key(ctx, kid)
 		},
-		gjwt.WithValidMethods(idTokenAlgs),
-		gjwt.WithIssuer(c.cfg.Provider.Issuer),
-		gjwt.WithAudience(c.cfg.ClientID),
-		gjwt.WithExpirationRequired(),
-		gjwt.WithIssuedAt(),
+		opts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrIDTokenInvalid, err)
+	}
+
+	// Custom issuer validation (multi-tenant): the iss claim must be approved by
+	// the configured predicate.
+	if c.cfg.IssuerValidator != nil {
+		iss, _ := claims["iss"].(string)
+		if iss == "" || !c.cfg.IssuerValidator(iss) {
+			return nil, fmt.Errorf("%w: issuer %q rejected", ErrIDTokenInvalid, iss)
+		}
 	}
 
 	// Bind the token to this login: the nonce must match the one we issued.

--- a/auth/oauth/oauth_hardening_test.go
+++ b/auth/oauth/oauth_hardening_test.go
@@ -16,6 +16,61 @@ import (
 	"github.com/Glyndor/authcore/auth/oauth"
 )
 
+func TestVerifyIDToken_issuerValidatorMultiTenant(t *testing.T) {
+	key := mustRSA(t)
+	srv := jwksServer(t, &key.PublicKey)
+	defer srv.Close()
+
+	tenantIss := "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0"
+	mk := func(validator func(string) bool) *oauth.Client {
+		c, err := oauth.New(fakeProvider{}, oauth.Config{
+			ClientID:    testClientID,
+			RedirectURL: "https://app.example/cb",
+			Provider: oauth.Provider{
+				AuthURL: srv.URL + "/a", TokenURL: srv.URL + "/t", JWKSURL: srv.URL,
+				// no fixed Issuer — the validator handles it
+			},
+			IssuerValidator: validator,
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return c
+	}
+
+	// A token whose dynamic per-tenant issuer the validator approves verifies,
+	// even though no fixed Provider.Issuer matches it.
+	tok := signIDToken(t, key, testKID, validClaims(tenantIss, "n"))
+	ok := mk(func(iss string) bool { return iss == tenantIss })
+	if _, err := ok.VerifyIDToken(context.Background(), tok, "n"); err != nil {
+		t.Errorf("validator-approved issuer should verify, got %v", err)
+	}
+
+	// A validator that rejects the issuer fails closed.
+	reject := mk(func(string) bool { return false })
+	if _, err := reject.VerifyIDToken(context.Background(), tok, "n"); err == nil {
+		t.Error("validator-rejected issuer must be refused")
+	}
+}
+
+func TestAzureMultiTenantIssuer(t *testing.T) {
+	accept := oauth.AzureMultiTenantIssuer()
+	good := "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0"
+	if !accept(good) {
+		t.Errorf("expected %q to be accepted", good)
+	}
+	for _, bad := range []string{
+		"https://accounts.google.com",
+		"https://login.microsoftonline.com/common/v2.0",
+		"https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v1.0",
+		"http://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0",
+	} {
+		if accept(bad) {
+			t.Errorf("expected %q to be rejected", bad)
+		}
+	}
+}
+
 func TestVerifyIDToken_ecOffCurveAndBadCurveRejected(t *testing.T) {
 	signKey := mustRSA(t)
 	ec, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/auth/oauth/presets.go
+++ b/auth/oauth/presets.go
@@ -1,6 +1,30 @@
 package oauth
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
+
+// azureV2Issuer matches an Azure AD v2.0 issuer for any tenant:
+// https://login.microsoftonline.com/<tenant-guid>/v2.0
+var azureV2Issuer = regexp.MustCompile(`^https://login\.microsoftonline\.com/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/v2\.0$`)
+
+// AzureMultiTenantIssuer returns an IssuerValidator that accepts any Azure AD
+// v2.0 issuer, i.e. tokens from any tenant. Use it with the Microsoft "common"
+// or "organizations" endpoints, where each user's token carries their own
+// tenant id in "iss" and no fixed issuer string can match:
+//
+//	cfg := oauth.Config{
+//	    ClientID: id, ClientSecret: secret, RedirectURL: cb,
+//	    Provider:        oauth.Microsoft("common"),
+//	    IssuerValidator: oauth.AzureMultiTenantIssuer(),
+//	}
+//
+// This trusts users from EVERY Azure tenant. To restrict to specific tenants,
+// also check the "tid" claim via IDClaims.Raw against your allowlist.
+func AzureMultiTenantIssuer() func(issuer string) bool {
+	return azureV2Issuer.MatchString
+}
 
 // Google returns the Provider endpoints for Google's OIDC service.
 //
@@ -50,9 +74,10 @@ func Discord() Provider {
 // "contoso.onmicrosoft.com"). Do NOT pass the multi-tenant aliases "common",
 // "organizations", or "consumers": a real ID token's "iss" carries the
 // signed-in user's own tenant GUID, never the alias, and VerifyIDToken enforces
-// an exact issuer match — so an alias-based config rejects every token. Verifying
-// across arbitrary tenants needs per-tenant issuer validation, which exact-match
-// does not provide and which is not currently supported; pin a single tenant here.
+// an exact issuer match — so an alias-based config rejects every token. To
+// accept users from any tenant, pass Microsoft("common") and set
+// Config.IssuerValidator to AzureMultiTenantIssuer() (which approves any Azure
+// v2.0 per-tenant issuer); otherwise pin a single tenant here.
 func Microsoft(tenant string) Provider {
 	base := fmt.Sprintf("https://login.microsoftonline.com/%s", tenant)
 	return Provider{

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -57,6 +57,27 @@ mod, _ := oauth.New(auth, oauth.Config{ClientID: id, ClientSecret: secret, Redir
 Discovery enforces that the document's issuer matches the one you asked for, so
 a substituted document cannot redirect the client to attacker endpoints.
 
+### Multi-tenant providers (Azure AD common)
+
+By default the ID token's `iss` must match `Provider.Issuer` exactly. A
+multi-tenant provider gives each user a token whose issuer carries their own
+tenant id, so no fixed string matches. Set `Config.IssuerValidator` to accept
+the issuer by predicate instead:
+
+```go
+cfg := oauth.Config{
+    ClientID: id, ClientSecret: secret, RedirectURL: cb,
+    Provider:        oauth.Microsoft("common"),
+    IssuerValidator: oauth.AzureMultiTenantIssuer(), // any Azure v2.0 tenant
+}
+```
+
+`AzureMultiTenantIssuer()` accepts any `https://login.microsoftonline.com/<tenant>/v2.0`
+issuer. It trusts users from **every** tenant — to restrict to specific tenants,
+also check the `tid` claim via `IDClaims.Raw` against your allowlist. The
+predicate replaces only the issuer check; signature, audience, expiry and nonce
+are still enforced.
+
 Or hand-write the four endpoints if you prefer:
 
 ```go


### PR DESCRIPTION
Release v1.11.0 — multi-tenant OIDC. No breaking changes.

- **auth/oauth: `Config.IssuerValidator` (#174).** An optional predicate that replaces the exact `iss` match, so a multi-tenant provider (Azure AD common/organizations) whose tokens carry a per-tenant issuer can be verified. Nil by default — exact match unchanged. `AzureMultiTenantIssuer()` accepts any Azure v2.0 per-tenant issuer; pair with a `tid` allowlist to restrict tenants. Signature/audience/expiry/nonce still enforced.
