### PR TITLE
fix(oauth): SSRF-safe redirects, JWKS burst-collapse, id_token cap

### DIFF
--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -264,6 +264,12 @@ func validate(address string) error {
 // Results are cached per domain for the duration of the DNS TTL, capped at
 // [DefaultCacheTTL], to avoid repeated lookups for the same domain.
 //
+// The cache and the single-flight de-duplication bound repeated and concurrent
+// lookups for the SAME domain, but each uncached distinct domain still costs one
+// outbound DNS query — a flood of unique domains is not bounded here. Rate-limit
+// the endpoint that calls VerifyDomain (registration) so an attacker cannot turn
+// it into a DNS-amplification vector.
+//
 // On success it returns nil.
 // On failure it returns one of:
 //

--- a/auth/oauth/config.go
+++ b/auth/oauth/config.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -78,9 +79,55 @@ func applyDefaults(cfg Config) Config {
 		cfg.Scopes = defaultScopes
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = &http.Client{Timeout: 10 * time.Second}
+		cfg.HTTPClient = newSafeHTTPClient()
 	}
 	return cfg
+}
+
+// newSafeHTTPClient is the default HTTP client for the OAuth fetches. Its
+// CheckRedirect closes the SSRF / credential-exfiltration vectors that bare
+// redirect-following opens (see safeRedirect). A caller who supplies their own
+// HTTPClient owns this policy.
+func newSafeHTTPClient() *http.Client {
+	return &http.Client{Timeout: 10 * time.Second, CheckRedirect: safeRedirect}
+}
+
+// safeRedirect is the redirect policy for every OAuth fetch (token, JWKS,
+// userinfo, discovery). It refuses:
+//   - more than a few hops,
+//   - a downgrade to plaintext http,
+//   - a redirect to a loopback / link-local / private host (SSRF to cloud
+//     metadata or internal services),
+//   - a cross-origin redirect — the token POST replays the client secret on a
+//     307/308, so it must never leave the configured host; legitimate OAuth
+//     endpoints do not redirect across hosts.
+func safeRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 5 {
+		return fmt.Errorf("too many redirects")
+	}
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing redirect to non-https %q", req.URL.Redacted())
+	}
+	if isPrivateHost(req.URL.Hostname()) {
+		return fmt.Errorf("refusing redirect to private host %q", req.URL.Hostname())
+	}
+	if prev := via[len(via)-1]; req.URL.Host != prev.URL.Host {
+		return fmt.Errorf("refusing cross-origin redirect to %q", req.URL.Host)
+	}
+	return nil
+}
+
+// isPrivateHost reports whether host is an IP literal in a loopback, private,
+// link-local, or unspecified range. Hostnames (non-literals) return false — the
+// scheme and cross-origin checks still apply, and the initial endpoint was
+// https-validated.
+func isPrivateHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
 // validateConfig returns an error if cfg is missing anything required.

--- a/auth/oauth/discovery.go
+++ b/auth/oauth/discovery.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 )
 
 const (
@@ -31,7 +30,7 @@ const (
 //	mod, _ := oauth.New(auth, oauth.Config{ClientID: id, RedirectURL: cb, Provider: p})
 func Discover(ctx context.Context, issuer string, httpClient *http.Client) (Provider, error) {
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
+		httpClient = newSafeHTTPClient()
 	}
 	// Never fetch discovery over plaintext — the whole trust chain (the jwks_uri
 	// the ID-token signature hangs on) comes from this document.

--- a/auth/oauth/idtoken.go
+++ b/auth/oauth/idtoken.go
@@ -37,6 +37,12 @@ type IDClaims struct {
 	Raw map[string]any
 }
 
+// maxIDTokenLen caps an ID token before parsing. Real ID tokens are a few KiB
+// (larger than an access token because of profile claims and an RSA signature);
+// 16 KiB is generous while refusing a multi-megabyte string that would force
+// base64+JSON work before the signature is checked.
+const maxIDTokenLen = 16 * 1024
+
 // VerifyIDToken validates an ID token and returns its claims.
 //
 // It verifies the signature against the provider's JWKS (asymmetric algorithms
@@ -50,6 +56,9 @@ type IDClaims struct {
 func (c *Client) VerifyIDToken(ctx context.Context, idToken, nonce string) (*IDClaims, error) {
 	if nonce == "" {
 		return nil, fmt.Errorf("%w: no nonce supplied to verify against", ErrIDTokenInvalid)
+	}
+	if len(idToken) > maxIDTokenLen {
+		return nil, fmt.Errorf("%w: token too large", ErrIDTokenInvalid)
 	}
 
 	opts := []gjwt.ParserOption{

--- a/auth/oauth/jwks.go
+++ b/auth/oauth/jwks.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -51,6 +53,8 @@ type jwksCache struct {
 	url  string
 	http *http.Client
 
+	group singleflight.Group // collapses concurrent refreshes into one outbound fetch
+
 	mu          sync.RWMutex
 	keys        map[string]crypto.PublicKey
 	expiresAt   time.Time
@@ -80,7 +84,10 @@ func (c *jwksCache) key(ctx context.Context, kid string) (crypto.PublicKey, erro
 		return nil, fmt.Errorf("%w: unknown kid %q", ErrJWKS, kid)
 	}
 
-	if err := c.refresh(ctx); err != nil {
+	// Collapse concurrent refreshes: a burst of tokens carrying distinct unknown
+	// kids triggers a single outbound JWKS fetch, not one per request.
+	_, err, _ := c.group.Do(c.url, func() (any, error) { return nil, c.refresh(ctx) })
+	if err != nil {
 		if ok {
 			return k, nil // serve the stale key rather than fail the login on a transient JWKS outage
 		}

--- a/auth/oauth/oauth_hardening_test.go
+++ b/auth/oauth/oauth_hardening_test.go
@@ -11,10 +11,88 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Glyndor/authcore/auth/oauth"
 )
+
+// tokenServerRedirectingTo returns a token endpoint that 307-redirects to loc.
+func tokenServerRedirectingTo(t *testing.T, loc string) *oauth.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, loc, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(srv.Close)
+	c, err := oauth.New(fakeProvider{}, oauth.Config{
+		ClientID:    testClientID,
+		RedirectURL: "https://app.example/cb",
+		Scopes:      []string{"read:user"},
+		Provider:    oauth.Provider{AuthURL: srv.URL + "/a", TokenURL: srv.URL + "/token", UserInfoURL: srv.URL + "/u"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestExchange_refusesUnsafeRedirect(t *testing.T) {
+	for name, loc := range map[string]string{
+		"cross-origin (leaks the secret)": "https://evil.example/steal",
+		"private metadata host (SSRF)":    "https://169.254.169.254/latest",
+		"plaintext downgrade":             "http://127.0.0.1/x",
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := tokenServerRedirectingTo(t, loc)
+			if _, err := c.Exchange(context.Background(), "code", "verifier"); err == nil {
+				t.Errorf("token exchange must refuse the redirect to %q", loc)
+			}
+		})
+	}
+}
+
+func TestJWKS_concurrentUnknownKidsCollapse(t *testing.T) {
+	key := mustRSA(t)
+	n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
+	doc := fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":%q,"n":%q,"e":%q}]}`, testKID, n, e)
+
+	var fetches int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&fetches, 1)
+		_, _ = w.Write([]byte(doc))
+	}))
+	defer srv.Close()
+	c := newClient(t, srv)
+
+	// A burst of tokens with distinct unknown kids must not fan out to one
+	// outbound JWKS fetch each — singleflight + the throttle collapse them.
+	var wg sync.WaitGroup
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tok := signIDToken(t, key, fmt.Sprintf("bogus-%d", i), validClaims(srv.URL, "n"))
+			_, _ = c.VerifyIDToken(context.Background(), tok, "n")
+		}(i)
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&fetches); got > 3 {
+		t.Errorf("burst of unknown kids caused %d JWKS fetches, want few", got)
+	}
+}
+
+func TestVerifyIDToken_oversizedRejected(t *testing.T) {
+	key := mustRSA(t)
+	srv := jwksServer(t, &key.PublicKey)
+	defer srv.Close()
+	c := newClient(t, srv)
+	if _, err := c.VerifyIDToken(context.Background(), strings.Repeat("a", 20000), "n"); err == nil {
+		t.Error("an oversized id token must be rejected before parsing")
+	}
+}
 
 func TestVerifyIDToken_issuerValidatorMultiTenant(t *testing.T) {
 	key := mustRSA(t)

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -84,6 +84,12 @@ To implement a fully custom source (KMS that signs without exposing the private
 key would need more than this), satisfy the one-method `KeyStore` interface
 yourself: `Load() (authcore.Keys, error)`.
 
+> [!NOTE]
+> The disk default stores the private key and refresh secret **unencrypted**
+> (owner-only `0600`, like an SSH key). For a high-assurance deployment, source
+> the material from a secret manager / KMS via a `KeyStore` instead of leaving it
+> in plaintext on disk.
+
 The `KeyID()` accessor returns a 16-character hex digest derived from the public
 key. It is embedded in every token's `kid` JOSE header. Verification selects the
 key by `kid` and rejects any token whose `kid` is not one the module accepts.

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -156,6 +156,10 @@ whatever the userinfo endpoint returns, so trust only the provider's stable id.
   are refused, closing the algorithm-confusion forgery.
 - **Issuer, audience, expiry, and nonce** are all enforced. A mismatch fails
   closed with `ErrIDTokenInvalid`.
+- **Safe redirects.** The default HTTP client refuses redirects that are
+  cross-origin (the token POST replays the client secret on a 307/308),
+  downgrade to `http`, or target a loopback / link-local / private host (SSRF).
+  If you set `Config.HTTPClient`, you own that policy.
 
 ## What is yours
 


### PR DESCRIPTION
From the routed injection + resilience reviews (closing the route loop).

- **(HIGH, SSRF / credential exfiltration) Safe redirects.** The OAuth HTTP clients followed redirects blindly: a 307/308 on the token endpoint re-POSTs `client_secret`+code+verifier to the redirect host, and GETs could be sent to `169.254.169.254` / `127.0.0.1` / RFC1918 (SSRF) or downgraded to `http`. A `CheckRedirect` now refuses cross-origin, https→http, and loopback/link-local/private hosts — on the default Exchange/JWKS/userinfo client and the Discover client. A caller-supplied `HTTPClient` owns its own policy.
- **(MAJOR) JWKS burst-collapse.** The once-per-minute throttle bounded the steady-state rate but not a concurrent burst (N simultaneous unknown kids each fired a fetch). `singleflight` now collapses concurrent refreshes to one outbound JWKS GET.
- **(minor) id_token cap.** `VerifyIDToken` rejects a token over 16 KiB before parsing, mirroring the jwt path.
- **(docs)** `VerifyDomain` warns that a unique-domain flood is unbounded (rate-limit the registration endpoint); key-management notes the disk default is plaintext at rest (use a KMS `KeyStore` for high assurance); oauth documents the redirect policy.

Tests: cross-origin/private/downgrade redirects refused, a 25-way unknown-kid burst collapses to ≤3 fetches, oversized id_token rejected. `go build`, `go vet`, `golangci-lint` (0 issues), the full suite with `-race`, and `govulncheck` (clean) all pass.

Closes #186
