### PR TITLE
release: v1.11.2

### DIFF
--- a/examples/oauth/go.mod
+++ b/examples/oauth/go.mod
@@ -4,6 +4,9 @@ go 1.26.4
 
 require github.com/Glyndor/authcore v1.9.0
 
-require github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+require (
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+)
 
 replace github.com/Glyndor/authcore => ../../

--- a/examples/oauth/go.sum
+++ b/examples/oauth/go.sum
@@ -1,2 +1,4 @@
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=


### PR DESCRIPTION
Release v1.11.2 — fix the oauth example build.

The v1.11.1 JWKS burst-collapse added golang.org/x/sync/singleflight to auth/oauth; the standalone examples/oauth module lacked that transitive dependency in its go.sum, breaking the Examples CI. go mod tidy on the example fixes it. Library code unchanged. (#189)
