### PR TITLE
ci: keep the org reusable pins out of Dependabot's hands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,9 @@ updates:
       - "type:deps"
       - "type:ci"
     open-pull-requests-limit: 10
+    ignore:
+      # The org reusable workflows move on my schedule, not Dependabot's: a bump
+      # changes what the whole CI matrix does, so I adopt a new version when I
+      # have measured it, not when a bot notices the tag. Third-party actions
+      # (checkout, setup-go) are NOT ignored — those I do want proposed.
+      - dependency-name: "Glyndor/.github/*"


### PR DESCRIPTION
I want the `Glyndor/.github` reusable pins to move on my schedule, not Dependabot's. A bump there changes what every job in the CI matrix does, so I adopt a new version after I have measured it — not because a bot saw a new tag.

- Added an `ignore` for `Glyndor/.github/*` to the `github-actions` entry.
- Third-party actions (`actions/checkout`, `actions/setup-go`) are deliberately **not** ignored — those I do want proposed automatically.

Context: this repo's Dependabot version updates are currently switched off at the repository level, so the config file has been inert since June. I am turning that back on, and this entry lands first so the first run does not open a `v1.6.0 → v1.10.1` reusable bump I would only close.