### PR TITLE
ci: give Dependabot commits explicit conventional types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     labels:
       - "type:deps"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+      include: "scope"
 
   # The examples are standalone Go modules (own go.mod + local replace), so the
   # root entry above does not see them. Track them too — otherwise an example
@@ -21,6 +24,9 @@ updates:
     labels:
       - "type:deps"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,3 +37,6 @@ updates:
       - "type:deps"
       - "type:ci"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
Dependabot picked its own commit type, which drifted between ecosystems. Pinned: `build` for the module bumps, `ci` for the workflow ones, scope included — the same shape as the other Go repositories.

Landing on `main` rather than riding a release: Dependabot version updates stopped running on this repository at the end of June (last update pull request 2026-06-28, same day the config was last touched), and Insights → Dependabot still reports "version updates aren't configured yet". They only re-register when the config file itself changes on the default branch — measured across the org, confirmed on `Glyndor/apt#65`.