### PR TITLE
chore: bring develop to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     labels:
       - "type:deps"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+      include: "scope"
 
   # The examples are standalone Go modules (own go.mod + local replace), so the
   # root entry above does not see them. Track them too — otherwise an example
@@ -21,6 +24,9 @@ updates:
     labels:
       - "type:deps"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,9 +37,6 @@ updates:
       - "type:deps"
       - "type:ci"
     open-pull-requests-limit: 10
-    ignore:
-      # The org reusable workflows move on my schedule, not Dependabot's: a bump
-      # changes what the whole CI matrix does, so I adopt a new version when I
-      # have measured it, not when a bot notices the tag. Third-party actions
-      # (checkout, setup-go) are NOT ignored — those I do want proposed.
-      - dependency-name: "Glyndor/.github/*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,9 @@ updates:
       - "type:deps"
       - "type:ci"
     open-pull-requests-limit: 10
+    ignore:
+      # The org reusable workflows move on my schedule, not Dependabot's: a bump
+      # changes what the whole CI matrix does, so I adopt a new version when I
+      # have measured it, not when a bot notices the tag. Third-party actions
+      # (checkout, setup-go) are NOT ignored — those I do want proposed.
+      - dependency-name: "Glyndor/.github/*"

--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,21 @@
+MIT License
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2026 Glyndor
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-   1. Definitions.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 Glyndor
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ module is independent and safe by default.
 [![CI](https://github.com/Glyndor/authcore/actions/workflows/ci.yml/badge.svg)](https://github.com/Glyndor/authcore/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Glyndor/authcore.svg)](https://pkg.go.dev/github.com/Glyndor/authcore)
 
-License: Apache-2.0.
+License: MIT.
 
 ---
 
@@ -99,4 +99,4 @@ Full API reference on [pkg.go.dev](https://pkg.go.dev/github.com/Glyndor/authcor
 
 ## License
 
-[Apache-2.0](LICENSE) — report vulnerabilities privately via the **Security** tab, never in a public issue.
+[MIT](LICENSE) — report vulnerabilities privately via the **Security** tab, never in a public issue.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
-<div align="center">
+# authcore
 
-# 🛡️ authcore
-
-**Auth is the code you only get wrong once. authcore does the dangerous parts for you.**
-
-Argon2id passwords · EdDSA tokens · refresh rotation · API keys · social login
-(OIDC + OAuth2) · email + username validation — all secure by default, timing-safe,
-zero-config, in pure Go. No database. No framework. No crypto PhD. Apache-2.0.
+Go authentication library: Argon2id password hashing, EdDSA access/refresh
+tokens with rotation, opaque API keys, OIDC/OAuth2 social login, and
+email/username validation. No database and no framework required — each
+module is independent and safe by default.
 
 [![CI](https://github.com/Glyndor/authcore/actions/workflows/ci.yml/badge.svg)](https://github.com/Glyndor/authcore/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Glyndor/authcore.svg)](https://pkg.go.dev/github.com/Glyndor/authcore)
 
-[**Install**](#-install) · [**Quick start**](#-quick-start) · [**Why**](#-why) · [**Modules**](#-modules) · [**Examples**](examples/) · [**Docs**](docs/)
-
-</div>
+License: Apache-2.0.
 
 ---
 
@@ -31,7 +26,7 @@ ok,   _ := pwd.Verify(attempt, hash)         // constant-time, always
 pair, _ := tokens.CreateTokens(userID, claims) // EdDSA-signed access + refresh
 ```
 
-## 📦 Install
+## Install
 
 ```bash
 go get github.com/Glyndor/authcore
@@ -40,7 +35,7 @@ go get github.com/Glyndor/authcore
 Requires **Go 1.26+**. On first run, Ed25519 keys + an HMAC secret are generated
 under `./.authcore/` — point `KeysDir` at a secrets volume in production.
 
-## 🚀 Quick start
+## Quick start
 
 ```go
 // One-time setup at startup. Keys are created on first run.
@@ -65,21 +60,14 @@ if ok, _ := pwd.Verify("Str0ng-P@ssword!", hash); ok {
 > Full, runnable versions live in [`examples/`](examples/) — `go run ./examples/jwt/`.
 > Wiring into a real HTTP stack: [Fiber](examples/fiber/) · [Gin](examples/gin/).
 
-## ⚡ Why
+## Design
 
-Roll your own and own every footgun. Run a full identity platform for a login
-form. Or reach for authcore — **the dangerous primitives, done right, in-process**.
+authcore is an in-process library, not a hosted identity platform: it ships no
+database and no HTTP server of its own, generates and manages its own signing
+keys on first run, and each module (password, jwt, apikey, oauth, email,
+username) can be used independently.
 
-| | Roll your own | Full IdP (Ory, Keycloak) | **authcore** |
-|---|:---:|:---:|:---:|
-| Time to first login | Hours – days | Hours (+ ops) | **~5 minutes** |
-| Argon2id · EdDSA · timing-safe | Manual, easy to slip | ✅ | ✅ **by default** |
-| Automatic key management | Manual | ✅ | ✅ |
-| Database / HTTP server | You build it | Theirs (locked in) | **Bring your own** |
-| Extra service to run | No | **Yes** | No |
-| You own the data model | ✅ | ❌ | ✅ |
-
-## 🔐 Modules
+## Modules
 
 Pick only what you need — each is independent, testable, and safe by default.
 
@@ -100,7 +88,7 @@ flowchart LR
     M -->|hash · sign · verify| App
 ```
 
-## 📖 Docs
+## Docs
 
 **New here? Start with the [Secure login recipe](docs/secure-login.md)** — the
 step-by-step flow that turns these primitives into a login an auditor accepts.


### PR DESCRIPTION
Bringing develop to main so the license and the Dependabot config are the ones on the default branch. **No tag, no release** — this is a branch sync.

Why it matters beyond tidiness: Dependabot reads its config from the **default branch**, and its registration only comes back when that file changes there. As long as main carries the old copy, this repository keeps getting no update pull requests at all.

What rides along:

- ci: let Dependabot propose the org reusable bumps again (#198)
- ci: keep the org reusable pins out of Dependabot's hands (#196)
- chore: relicense from Apache-2.0 to MIT (#195)
- docs: remove advertising-style content from the README (#192)