### PR TITLE
ci(examples): resolve the examples through a Go workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,13 @@
 
 # Compiled example binaries (each example is `package main`; `go build ./...`
 # drops a binary named after its directory). Extensionless, so list them.
+/examples/apikey/apikey
 /examples/basic/basic
 /examples/email/email
 /examples/fiber/fiber
 /examples/gin/gin
 /examples/jwt/jwt
+/examples/oauth/oauth
 /examples/password/password
 /examples/username/username
 
@@ -27,8 +29,14 @@ profile.cov
 # Dependency directories
 vendor/
 
-# Go workspace file
+# Go workspace files. A stray local workspace stays out of the tree, but
+# examples/go.work is committed — it is what lets the examples resolve authcore
+# from the checkout without a `replace`. The sum file stays ignored: it holds
+# only go.mod hashes the go command derives on demand, and committing it would
+# put yet another file in the tree that every root dependency bump has to
+# update, which is the coupling the workspace exists to remove.
 go.work
+!/examples/go.work
 go.work.sum
 
 # env file

--- a/examples/apikey/go.mod
+++ b/examples/apikey/go.mod
@@ -2,6 +2,5 @@ module github.com/Glyndor/authcore/examples/apikey
 
 go 1.26.4
 
-require github.com/Glyndor/authcore v1.10.6
+require github.com/Glyndor/authcore v1.11.3
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -2,6 +2,5 @@ module github.com/Glyndor/authcore/examples/basic
 
 go 1.26.4
 
-require github.com/Glyndor/authcore v1.2.2
+require github.com/Glyndor/authcore v1.11.3
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/email/go.mod
+++ b/examples/email/go.mod
@@ -2,7 +2,7 @@ module github.com/Glyndor/authcore/examples/email
 
 go 1.26.4
 
-require github.com/Glyndor/authcore v1.2.2
+require github.com/Glyndor/authcore v1.11.3
 
 require (
 	golang.org/x/net v0.56.0 // indirect
@@ -10,4 +10,3 @@ require (
 	golang.org/x/text v0.38.0 // indirect
 )
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/fiber/go.mod
+++ b/examples/fiber/go.mod
@@ -3,7 +3,7 @@ module github.com/Glyndor/authcore/examples/fiber
 go 1.26.4
 
 require (
-	github.com/Glyndor/authcore v1.1.1
+	github.com/Glyndor/authcore v1.11.3
 	github.com/gofiber/fiber/v3 v3.4.0
 )
 
@@ -26,4 +26,3 @@ require (
 	golang.org/x/text v0.38.0 // indirect
 )
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/gin/go.mod
+++ b/examples/gin/go.mod
@@ -3,7 +3,7 @@ module github.com/Glyndor/authcore/examples/gin
 go 1.26.4
 
 require (
-	github.com/Glyndor/authcore v1.1.1
+	github.com/Glyndor/authcore v1.11.3
 	github.com/gin-gonic/gin v1.12.0
 )
 
@@ -40,4 +40,3 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 )
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/go.work
+++ b/examples/go.work
@@ -1,0 +1,31 @@
+// The examples are standalone modules so that gin, fiber and friends never
+// reach a consumer's dependency graph through authcore's own go.mod. That split
+// used to be held together by a `replace` in every example, which forced each
+// one to carry hashes for the root module's requirements too — so a bump landing
+// in the root go.mod alone left all nine examples unbuildable until they were
+// tidied one by one.
+//
+// The workspace resolves authcore from the checkout instead, and satisfies the
+// external dependencies from the union of the member go.sum files, where the
+// bumped root hashes already are.
+//
+// It lives here rather than at the repository root deliberately: go.work is
+// discovered by walking up from the working directory, and a root-level
+// workspace would also capture the root module's own build and tests, resolving
+// them against the versions gin and fiber elevate rather than the ones authcore
+// declares. One level down, the library is tested as a consumer gets it.
+
+go 1.26.4
+
+use (
+	../
+	./apikey
+	./basic
+	./email
+	./fiber
+	./gin
+	./jwt
+	./oauth
+	./password
+	./username
+)

--- a/examples/jwt/go.mod
+++ b/examples/jwt/go.mod
@@ -2,8 +2,7 @@ module github.com/Glyndor/authcore/examples/jwt
 
 go 1.26.4
 
-require github.com/Glyndor/authcore v1.2.2
+require github.com/Glyndor/authcore v1.11.3
 
 require github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/oauth/go.mod
+++ b/examples/oauth/go.mod
@@ -2,11 +2,10 @@ module github.com/Glyndor/authcore/examples/oauth
 
 go 1.26.4
 
-require github.com/Glyndor/authcore v1.9.0
+require github.com/Glyndor/authcore v1.11.3
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 )
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/password/go.mod
+++ b/examples/password/go.mod
@@ -2,7 +2,7 @@ module github.com/Glyndor/authcore/examples/password
 
 go 1.26.4
 
-require github.com/Glyndor/authcore v1.2.2
+require github.com/Glyndor/authcore v1.11.3
 
 require (
 	golang.org/x/crypto v0.53.0 // indirect
@@ -10,4 +10,3 @@ require (
 	golang.org/x/text v0.38.0 // indirect
 )
 
-replace github.com/Glyndor/authcore => ../../

--- a/examples/username/go.mod
+++ b/examples/username/go.mod
@@ -2,6 +2,5 @@ module github.com/Glyndor/authcore/examples/username
 
 go 1.26.4
 
-require github.com/Glyndor/authcore v1.2.2
+require github.com/Glyndor/authcore v1.11.3
 
-replace github.com/Glyndor/authcore => ../../


### PR DESCRIPTION
Fixes the coupling described in #213: every root dependency bump turned all nine legs of `Examples` red, and left `go run ./examples/...` broken for anyone who cloned the repository.

A workspace at `examples/go.work` resolves authcore from the checkout and satisfies the external dependencies from the union of the member `go.sum` files, so the `replace` in each example is gone.

The workspace sits under `examples/` rather than at the repository root on purpose. `go.work` is discovered by walking up from the working directory, so a root-level one would also have captured the root module's own build and tests, resolving the library against the versions gin and fiber elevate instead of the ones it declares.

### What I measured

Toolchain go1.26.4, the same the `go.mod` pins.

| Check | Result |
|---|---|
| Reproduced the failure first, on #212's branch, `go build ./...` in `examples/gin` | `go: updates to go.mod needed` |
| All nine examples, `go build ./... && go vet ./...` on this branch | pass |
| **Same nine with #212's `x/net` 0.56.0 -> 0.57.0 cherry-picked on top** | **pass** — the case that is red today |
| `go env GOWORK` at the repository root | empty, so the root module stays outside the workspace |
| Root module, `go build ./... && go test ./...` | 9/9 packages pass |

The third row is the one that matters: it is the scenario blocking #209, #210, #211 and #212.

### Also in here

- `.gitignore` keeps ignoring a stray `go.work`, makes an exception for the committed one, and keeps `go.work.sum` ignored — it holds only go.mod hashes the go command derives on demand, and committing it would put one more file in the tree that every bump has to update, which is the coupling this removes.
- The examples pointed at five authcore versions that never applied (v1.1.1, v1.2.2, v1.9.0, v1.10.6), masked by the `replace`. They now name v1.11.3, which is what someone copying a directory out actually gets.
- The `apikey` and `oauth` example binaries were missing from `.gitignore`; building them locally surfaced that, so they are added.
