### PR TITLE
fix(deps): require go 1.26.5 to close the crypto/tls ECH leak

### DIFF
--- a/examples/apikey/go.mod
+++ b/examples/apikey/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/apikey
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Glyndor/authcore v1.11.3
 

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/basic
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Glyndor/authcore v1.11.3
 

--- a/examples/email/go.mod
+++ b/examples/email/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/email
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Glyndor/authcore v1.11.3
 

--- a/examples/fiber/go.mod
+++ b/examples/fiber/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/fiber
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Glyndor/authcore v1.11.3

--- a/examples/gin/go.mod
+++ b/examples/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/gin
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Glyndor/authcore v1.11.3

--- a/examples/go.work
+++ b/examples/go.work
@@ -15,7 +15,7 @@
 // them against the versions gin and fiber elevate rather than the ones authcore
 // declares. One level down, the library is tested as a consumer gets it.
 
-go 1.26.4
+go 1.26.5
 
 use (
 	../

--- a/examples/jwt/go.mod
+++ b/examples/jwt/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/jwt
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Glyndor/authcore v1.11.3
 

--- a/examples/oauth/go.mod
+++ b/examples/oauth/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/oauth
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Glyndor/authcore v1.11.3
 

--- a/examples/password/go.mod
+++ b/examples/password/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/password
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Glyndor/authcore v1.11.3
 

--- a/examples/username/go.mod
+++ b/examples/username/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/username
 
-go 1.26.4
+go 1.26.5
 
 require github.com/Glyndor/authcore v1.11.3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
Closes #215.

`govulncheck` flagged GO-2026-5856 (Encrypted Client Hello privacy leak in `crypto/tls`) as reachable from `oauth.Client.Exchange` — the token exchange and the JWKS fetch both go out over TLS. Raising the `go` directive to 1.26.5 is the remediation: the directive is the floor toolchain selection honours, so it is what puts a consumer on a patched standard library.

Reach is narrow and I would rather state it than dress it up: ECH is only used when the TLS config carries an ECH config list, and `newSafeHTTPClient` never sets one, so it takes a consumer passing their own `Config.HTTPClient` with ECH configured. A privacy leak in a path this library owns, not an authentication break.

### What I measured, on go1.26.5

| Check | Before | After |
|---|---|---|
| `govulncheck ./...` | 1 vulnerability my code calls (GO-2026-5856), 1 more latent (GO-2026-4970, `os`) | **No vulnerabilities found** |
| `go test -race ./...` | — | 9/9 packages pass |
| Nine examples, `go build && go vet` | — | pass |

The toolchain selected 1.26.5 on its own once the directive moved, which is the mechanism this change relies on.

### One entry stays, deliberately

`GO-2026-5932` against `golang.org/x/crypto@v0.54.0` still shows as a vulnerability in a module I require but do not call. It is the advisory that `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design — `Fixed in: N/A`, applying to every version of the module since 0, so it is not a regression from the recent v0.54.0 bump, and nothing here imports `openpgp`. There is nothing to action; I am recording it so the next scan does not re-open the question.
