### PR TITLE
feat(keymanager): record the on-disk key layout version

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,7 +23,8 @@ type Config struct {
 	Logger Logger
 
 	// KeysDir is the directory where authcore creates and stores cryptographic
-	// key files (ed25519_private.pem, ed25519_public.pem, refresh_secret.key).
+	// key files (ed25519_private.pem, ed25519_public.pem, refresh_secret.key),
+	// alongside a metadata.json recording the on-disk layout version.
 	//
 	// Defaults to ".authcore" relative to the current working directory.
 	// Use an absolute path in containerised or restricted environments.

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -7,11 +7,49 @@ On first run authcore creates `KeysDir` (default `.authcore`) and generates:
 | `ed25519_private.pem` | PKCS#8 PEM | `0600` | Signing key |
 | `ed25519_public.pem` | PKIX PEM | `0644` | Verification key |
 | `refresh_secret.key` | 32-byte hex | `0600` | HMAC-SHA256 key for refresh token hashing |
+| `metadata.json` | JSON | `0600` | Records which on-disk layout wrote the directory |
 | `.gitignore` | `*` | `0600` | Prevents accidental commits |
 
 On subsequent starts the files are loaded and the key pair is validated for
 consistency. If only one PEM file is present, `New()` returns `ErrKeyManager` —
 delete both to regenerate.
+
+## The layout marker
+
+`metadata.json` holds no key material — a format version, when the keys were
+first written, and the id of the current signing key:
+
+```json
+{
+  "format": 1,
+  "created": "2026-07-27T02:41:09Z",
+  "key_id": "3f9a1c07d5b2e846"
+}
+```
+
+It exists so that a release which changes the on-disk format can **migrate what
+is already there** rather than regenerate it. Regenerating would invalidate
+every refresh-token and API-key hash you have stored, logging out all of your
+users — which authcore treats as a defect, not an acceptable breaking change.
+
+What that means in practice:
+
+- A directory created **before this file existed** carries no marker. It is
+  adopted in place on the next start: the marker is written, the keys are not
+  touched. Nothing is required of you.
+- A directory reporting a **newer** format than the running build understands is
+  **refused**, keys untouched. Upgrade authcore rather than downgrading the
+  directory.
+- A **corrupt** marker is also refused, because a loader that cannot tell what
+  wrote the keys must not guess at them. The file holds no secret, so deleting
+  it is safe and makes the next start re-adopt the existing keys — the error
+  says so.
+- If the marker **cannot be written** (a read-only mounted secret, for example)
+  authcore logs a warning and carries on. It is bookkeeping; it never blocks
+  startup.
+
+The recorded `key_id` follows the keys: rotate them by replacing the PEM files
+and the marker is updated on the next start.
 
 ## Containers & multiple replicas
 

--- a/internal/keymanager/format.go
+++ b/internal/keymanager/format.go
@@ -1,0 +1,140 @@
+package keymanager
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// currentFormat is the version of the on-disk layout this build writes and
+// understands. Bump it only when the meaning of an existing file changes —
+// adding a new file that older versions simply ignore does not need a bump.
+const currentFormat = 1
+
+// fileMetadata records which layout wrote the key directory.
+//
+// The library allows breaking changes and ships them forward, and it persists
+// key material on disk, so a release that changes the on-disk format has to
+// migrate what is already there rather than regenerate it: regenerating
+// invalidates every refresh-token and API-key hash the consumer has stored,
+// which logs out all of their users. That migration is only possible if the
+// loader can tell what wrote the directory, which is what this file is for.
+const fileMetadata = "metadata.json"
+
+// metadata is the content of fileMetadata. It holds no secret — KeyID is
+// derived from the public key and already travels in every JWT header — but it
+// is written 0600 anyway, since nothing outside authcore reads it.
+type metadata struct {
+	// Format is the on-disk layout version. A directory written by a newer
+	// authcore carries a higher number and is refused rather than guessed at.
+	Format int `json:"format"`
+	// Created is when the key material was first written, RFC 3339. For a
+	// directory adopted from the pre-metadata layout it is the modification
+	// time of the private key, which is the closest honest answer available.
+	Created string `json:"created"`
+	// KeyID identifies the signing key that was live when this file was last
+	// written. It is informational: it lets an operator see which key a
+	// directory holds without parsing the PEM.
+	KeyID string `json:"key_id"`
+}
+
+// errFormatFromFuture reports a directory written by a newer authcore.
+var errFormatFromFuture = errors.New("key directory was written by a newer version of authcore")
+
+// readMetadata loads the descriptor from dir.
+//
+// A missing file is not an error: it means the pre-metadata layout, and the
+// caller adopts it. Anything else — unreadable, malformed, or a format this
+// build does not understand — is fatal, because the whole point of the marker
+// is to stop a loader from guessing at key material it may not understand.
+func readMetadata(dir string) (*metadata, error) {
+	path := filepath.Join(dir, fileMetadata)
+
+	data, err := readCapped(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // pre-metadata layout
+		}
+		return nil, fmt.Errorf("read %q: %w", path, err)
+	}
+
+	var m metadata
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf(
+			"parse %q: %w; the file describes the key layout and holds no key material, "+
+				"so deleting it is safe and makes authcore re-adopt the existing keys",
+			path, err,
+		)
+	}
+
+	if m.Format > currentFormat {
+		return nil, fmt.Errorf(
+			"%w: %q reports format %d, this build understands %d; upgrade authcore rather than downgrading the directory",
+			errFormatFromFuture, path, m.Format, currentFormat,
+		)
+	}
+	if m.Format < 1 {
+		return nil, fmt.Errorf("%q reports an invalid format %d", path, m.Format)
+	}
+
+	return &m, nil
+}
+
+// syncMetadata brings the descriptor in line with the keys that were just
+// loaded or generated: it writes one for a directory that has none (adopting
+// the pre-metadata layout in place, without touching the keys), and refreshes
+// the recorded key id when the signing key has been rotated underneath.
+//
+// A write failure is reported to the log, never returned. A read-only KeysDir
+// is a supported deployment — a mounted secret — and the descriptor is
+// bookkeeping, so failing to write it must not stop a service from starting.
+func syncMetadata(dir string, existing *metadata, keyID string, log logger) {
+	switch {
+	case existing == nil:
+		m := metadata{
+			Format:  currentFormat,
+			Created: creationTime(dir),
+			KeyID:   keyID,
+		}
+		if err := writeMetadata(dir, m); err != nil {
+			log.Warn("authcore/keymanager: could not write %s in %q (continuing): %v", fileMetadata, dir, err)
+			return
+		}
+		log.Info("authcore/keymanager: recorded on-disk format %d for %s", currentFormat, dir)
+
+	case existing.KeyID != keyID:
+		// The signing key changed since the descriptor was written — a manual
+		// rotation, or keys restored from elsewhere. Follow the keys.
+		m := *existing
+		m.KeyID = keyID
+		if err := writeMetadata(dir, m); err != nil {
+			log.Warn("authcore/keymanager: could not update %s in %q (continuing): %v", fileMetadata, dir, err)
+			return
+		}
+		log.Info("authcore/keymanager: signing key changed, %s now records key id %s", fileMetadata, keyID)
+	}
+}
+
+// writeMetadata serialises m into dir.
+func writeMetadata(dir string, m metadata) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", fileMetadata, err)
+	}
+	return os.WriteFile(filepath.Join(dir, fileMetadata), append(data, '\n'), 0600)
+}
+
+// creationTime dates the key material. The private key's modification time is
+// when it was written, which for a directory adopted from the pre-metadata
+// layout beats stamping "now" onto keys that may be months old, and for a
+// freshly generated one is already now. The fallback covers a private key that
+// cannot be stat'ed.
+func creationTime(dir string) string {
+	if fi, err := os.Stat(filepath.Join(dir, filePrivateKey)); err == nil {
+		return fi.ModTime().UTC().Format(time.RFC3339)
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}

--- a/internal/keymanager/format_internal_test.go
+++ b/internal/keymanager/format_internal_test.go
@@ -1,0 +1,76 @@
+package keymanager
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureLogger records what the key manager reports, so a test can assert on
+// the warning rather than only on the absence of a crash.
+type captureLogger struct{ warnings []string }
+
+func (l *captureLogger) Info(string, ...any) {}
+func (l *captureLogger) Warn(msg string, args ...any) {
+	l.warnings = append(l.warnings, msg)
+	_ = args
+}
+
+// Being unable to write the descriptor must never stop a service from
+// starting: it is bookkeeping, and a read-only KeysDir — a mounted secret — is
+// a supported deployment. syncMetadata therefore reports and returns instead of
+// propagating, which this pins by making the write fail for real.
+//
+// Note the permission-bit version of this scenario is not reachable through
+// New: it chmods the directory back to 0700 before writing anything, so a mode
+// of 0500 does not survive. The genuine case is a filesystem that refuses the
+// write, which is what a missing directory reproduces portably.
+func TestSyncMetadata_writeFailureIsNotFatal(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	log := &captureLogger{}
+
+	syncMetadata(missing, nil, "abcdef0123456789", log)
+
+	if len(log.warnings) != 1 {
+		t.Fatalf("expected exactly one warning, got %d: %v", len(log.warnings), log.warnings)
+	}
+	if !strings.Contains(log.warnings[0], "continuing") {
+		t.Errorf("the warning should say startup continues, got: %q", log.warnings[0])
+	}
+	if _, err := os.Stat(filepath.Join(missing, fileMetadata)); !os.IsNotExist(err) {
+		t.Errorf("no descriptor should exist after a failed write, stat gave: %v", err)
+	}
+}
+
+// The same non-fatal handling applies to refreshing a descriptor whose key has
+// been rotated underneath it.
+func TestSyncMetadata_rotationWriteFailureIsNotFatal(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	log := &captureLogger{}
+	existing := &metadata{Format: currentFormat, Created: "2026-01-01T00:00:00Z", KeyID: "0000000000000000"}
+
+	syncMetadata(missing, existing, "abcdef0123456789", log)
+
+	if len(log.warnings) != 1 {
+		t.Fatalf("expected exactly one warning, got %d: %v", len(log.warnings), log.warnings)
+	}
+	if !strings.Contains(log.warnings[0], "continuing") {
+		t.Errorf("the warning should say startup continues, got: %q", log.warnings[0])
+	}
+}
+
+// A directory already carrying an up-to-date descriptor is left alone — no
+// write, so nothing to fail.
+func TestSyncMetadata_upToDateDescriptorIsNotRewritten(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	log := &captureLogger{}
+	keyID := "abcdef0123456789"
+	existing := &metadata{Format: currentFormat, Created: "2026-01-01T00:00:00Z", KeyID: keyID}
+
+	syncMetadata(missing, existing, keyID, log)
+
+	if len(log.warnings) != 0 {
+		t.Errorf("an up-to-date descriptor should not be written at all, got warnings: %v", log.warnings)
+	}
+}

--- a/internal/keymanager/format_test.go
+++ b/internal/keymanager/format_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -280,5 +281,39 @@ func TestNew_recordsARotatedKeyID(t *testing.T) {
 	}
 	if got := readMetadataFile(t, dir).KeyID; got != rotated.KeyID() {
 		t.Errorf("descriptor key_id = %q, want the rotated %q", got, rotated.KeyID())
+	}
+}
+
+// End to end now that the directory mode survives: a KeysDir the operator has
+// closed to 0500 holds its keys, cannot take the descriptor, and still starts.
+// This became testable through New only once it stopped chmodding the
+// directory back to 0700 (#222) — before that the mode never reached the write.
+func TestNew_readOnlyDirectoryStillLoads(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits do not apply on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory write permissions")
+	}
+
+	dir, keyID := preMetadataDir(t)
+	before := snapshotKeys(t, dir)
+
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("restrict directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	km, err := keymanager.New(dir, testLogger{t})
+	if err != nil {
+		t.Fatalf("a read-only key directory must still load, got: %v", err)
+	}
+	if km.KeyID() != keyID {
+		t.Errorf("key id = %q, want %q", km.KeyID(), keyID)
+	}
+	assertKeysUnchanged(t, dir, before)
+
+	if _, err := os.Stat(filepath.Join(dir, metadataFile)); !os.IsNotExist(err) {
+		t.Errorf("the descriptor should not exist after an impossible write, stat gave: %v", err)
 	}
 }

--- a/internal/keymanager/format_test.go
+++ b/internal/keymanager/format_test.go
@@ -1,0 +1,284 @@
+package keymanager_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+const metadataFile = "metadata.json"
+
+// keyFiles are the files that hold actual key material. A migration may add,
+// describe or re-read them; it may never silently replace them.
+var keyFiles = []string{"ed25519_private.pem", "ed25519_public.pem", "refresh_secret.key"}
+
+// onDiskMetadata mirrors the descriptor for assertions. The production type is
+// unexported, and asserting against the JSON is the stronger check anyway: it
+// pins the wire format a future version has to keep reading.
+type onDiskMetadata struct {
+	Format  int    `json:"format"`
+	Created string `json:"created"`
+	KeyID   string `json:"key_id"`
+}
+
+// snapshotKeys returns the exact bytes of every key file, so a later comparison
+// proves the material survived rather than merely that loading succeeded.
+func snapshotKeys(t *testing.T, dir string) map[string][]byte {
+	t.Helper()
+	out := make(map[string][]byte, len(keyFiles))
+	for _, name := range keyFiles {
+		data, err := os.ReadFile(filepath.Join(dir, name)) // #nosec G304 -- test fixture path
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		out[name] = data
+	}
+	return out
+}
+
+func assertKeysUnchanged(t *testing.T, dir string, before map[string][]byte) {
+	t.Helper()
+	after := snapshotKeys(t, dir)
+	for name, want := range before {
+		if got := after[name]; string(got) != string(want) {
+			t.Fatalf("%s was rewritten; key material must survive untouched", name)
+		}
+	}
+}
+
+func readMetadataFile(t *testing.T, dir string) onDiskMetadata {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, metadataFile)) // #nosec G304 -- test fixture path
+	if err != nil {
+		t.Fatalf("read %s: %v", metadataFile, err)
+	}
+	var m onDiskMetadata
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse %s: %v", metadataFile, err)
+	}
+	return m
+}
+
+// preMetadataDir builds a key directory in the layout that shipped before
+// metadata.json existed: the three key files, no descriptor.
+func preMetadataDir(t *testing.T) (dir string, keyID string) {
+	t.Helper()
+	dir = t.TempDir()
+	km, err := keymanager.New(dir, testLogger{t})
+	if err != nil {
+		t.Fatalf("seed keymanager.New(): %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, metadataFile)); err != nil {
+		t.Fatalf("strip %s: %v", metadataFile, err)
+	}
+	return dir, km.KeyID()
+}
+
+func TestNew_writesMetadataForAFreshDirectory(t *testing.T) {
+	dir := t.TempDir()
+	km, err := keymanager.New(dir, testLogger{t})
+	if err != nil {
+		t.Fatalf("keymanager.New(): %v", err)
+	}
+
+	m := readMetadataFile(t, dir)
+	if m.Format != 1 {
+		t.Errorf("format = %d, want 1", m.Format)
+	}
+	if m.KeyID != km.KeyID() {
+		t.Errorf("key_id = %q, want %q", m.KeyID, km.KeyID())
+	}
+	if _, err := time.Parse(time.RFC3339, m.Created); err != nil {
+		t.Errorf("created = %q, not RFC 3339: %v", m.Created, err)
+	}
+}
+
+// The migration that has to exist from day one: a directory written before the
+// marker existed is adopted in place. The assertion is that the key material
+// survives byte for byte — an adoption that regenerated would invalidate every
+// stored refresh-token and API-key hash, logging out the consumer's users.
+func TestNew_adoptsPreMetadataDirectoryWithoutTouchingKeys(t *testing.T) {
+	dir, keyID := preMetadataDir(t)
+	before := snapshotKeys(t, dir)
+
+	km, err := keymanager.New(dir, testLogger{t})
+	if err != nil {
+		t.Fatalf("adopting a pre-metadata directory must succeed, got: %v", err)
+	}
+
+	assertKeysUnchanged(t, dir, before)
+
+	if km.KeyID() != keyID {
+		t.Errorf("key id changed on adoption: got %q, want %q", km.KeyID(), keyID)
+	}
+	m := readMetadataFile(t, dir)
+	if m.Format != 1 {
+		t.Errorf("adopted format = %d, want 1", m.Format)
+	}
+	if m.KeyID != keyID {
+		t.Errorf("adopted key_id = %q, want %q", m.KeyID, keyID)
+	}
+}
+
+// Adoption dates the material by the key's own mtime rather than stamping the
+// moment of the upgrade, so a directory that is months old does not claim to
+// have been created during the release that adopted it.
+func TestNew_adoptionDatesFromTheKeyNotTheUpgrade(t *testing.T) {
+	dir, _ := preMetadataDir(t)
+
+	old := time.Now().Add(-90 * 24 * time.Hour).UTC().Truncate(time.Second)
+	priv := filepath.Join(dir, "ed25519_private.pem")
+	if err := os.Chtimes(priv, old, old); err != nil {
+		t.Fatalf("backdate private key: %v", err)
+	}
+
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("keymanager.New(): %v", err)
+	}
+
+	got := readMetadataFile(t, dir).Created
+	if want := old.Format(time.RFC3339); got != want {
+		t.Errorf("created = %q, want the key's mtime %q", got, want)
+	}
+}
+
+// A directory from a newer authcore is refused while its files are still
+// untouched — the loader must not interpret material in a layout it does not
+// know, and must not "recover" by regenerating.
+func TestNew_refusesADirectoryFromTheFuture(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("seed keymanager.New(): %v", err)
+	}
+	before := snapshotKeys(t, dir)
+
+	future := onDiskMetadata{Format: 99, Created: time.Now().UTC().Format(time.RFC3339), KeyID: "deadbeefdeadbeef"}
+	data, err := json.Marshal(future)
+	if err != nil {
+		t.Fatalf("encode fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, metadataFile), data, 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	_, err = keymanager.New(dir, testLogger{t})
+	if err == nil {
+		t.Fatal("expected an error for a directory written by a newer authcore")
+	}
+	if !strings.Contains(err.Error(), "newer version") {
+		t.Errorf("error should name the cause, got: %v", err)
+	}
+	assertKeysUnchanged(t, dir, before)
+}
+
+// Corrupt bookkeeping fails closed rather than being silently rewritten, and
+// the error has to carry the escape: the file holds no key material, so
+// deleting it is safe and re-adopts the keys.
+func TestNew_refusesCorruptMetadataAndNamesTheEscape(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("seed keymanager.New(): %v", err)
+	}
+	before := snapshotKeys(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, metadataFile), []byte("{not json"), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	_, err := keymanager.New(dir, testLogger{t})
+	if err == nil {
+		t.Fatal("expected an error for unparseable metadata")
+	}
+	if !strings.Contains(err.Error(), "deleting it is safe") {
+		t.Errorf("error should tell the operator how to recover, got: %v", err)
+	}
+	assertKeysUnchanged(t, dir, before)
+
+	// And the escape has to actually work.
+	if err := os.Remove(filepath.Join(dir, metadataFile)); err != nil {
+		t.Fatalf("remove metadata: %v", err)
+	}
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("deleting the descriptor should re-adopt the keys, got: %v", err)
+	}
+	assertKeysUnchanged(t, dir, before)
+}
+
+// Loading an already-marked directory must not churn the file: a rewrite on
+// every start would be pointless disk traffic and would erase the original
+// creation date.
+func TestNew_doesNotRewriteAnUpToDateDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("seed keymanager.New(): %v", err)
+	}
+	path := filepath.Join(dir, metadataFile)
+	first, err := os.ReadFile(path) // #nosec G304 -- test fixture path
+	if err != nil {
+		t.Fatalf("read %s: %v", metadataFile, err)
+	}
+	stamp := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(path, stamp, stamp); err != nil {
+		t.Fatalf("backdate %s: %v", metadataFile, err)
+	}
+
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("keymanager.New(): %v", err)
+	}
+
+	second, err := os.ReadFile(path) // #nosec G304 -- test fixture path
+	if err != nil {
+		t.Fatalf("re-read %s: %v", metadataFile, err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("descriptor content changed on a plain reload:\nbefore %s\nafter  %s", first, second)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", metadataFile, err)
+	}
+	if !fi.ModTime().Equal(stamp) {
+		t.Error("descriptor was rewritten on a plain reload; it should only be written when something changed")
+	}
+}
+
+// Rotating the signing key by swapping the files is supported, so the
+// descriptor follows the keys rather than fighting them.
+func TestNew_recordsARotatedKeyID(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("seed keymanager.New(): %v", err)
+	}
+
+	// A second, independent directory supplies a fresh pair to rotate in.
+	other := t.TempDir()
+	rotated, err := keymanager.New(other, testLogger{t})
+	if err != nil {
+		t.Fatalf("seed replacement pair: %v", err)
+	}
+	for _, name := range []string{"ed25519_private.pem", "ed25519_public.pem"} {
+		data, err := os.ReadFile(filepath.Join(other, name)) // #nosec G304 -- test fixture path
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0600); err != nil {
+			t.Fatalf("rotate %s: %v", name, err)
+		}
+	}
+
+	km, err := keymanager.New(dir, testLogger{t})
+	if err != nil {
+		t.Fatalf("keymanager.New() after rotation: %v", err)
+	}
+	if km.KeyID() != rotated.KeyID() {
+		t.Fatalf("loaded key id = %q, want the rotated %q", km.KeyID(), rotated.KeyID())
+	}
+	if got := readMetadataFile(t, dir).KeyID; got != rotated.KeyID() {
+		t.Errorf("descriptor key_id = %q, want the rotated %q", got, rotated.KeyID())
+	}
+}

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -8,9 +8,18 @@
 //	ed25519_private.pem  — Ed25519 private key, PKCS#8 PEM, mode 0600
 //	ed25519_public.pem   — Ed25519 public key,  PKIX  PEM, mode 0644
 //	refresh_secret.key   — 32-byte HMAC-SHA256 secret, hex-encoded, mode 0600
+//	metadata.json        — on-disk layout version, mode 0600
 //
 // On subsequent calls the existing files are loaded and validated; no new
 // material is generated unless a file is missing.
+//
+// metadata.json records which layout wrote the directory, so a future release
+// that changes the on-disk format can migrate what is there instead of
+// regenerating it — regenerating would invalidate every refresh-token and
+// API-key hash the consumer has stored, logging out all of their users. A
+// directory written before this file existed carries no marker; it is adopted
+// in place, keys untouched. A directory reporting a newer format is refused
+// rather than parsed on a guess.
 //
 // Key-file loading is size-capped at 4 KiB. A healthy Ed25519 PEM is ~200
 // bytes and a hex-encoded HMAC secret is 65 bytes, so the cap leaves
@@ -94,6 +103,14 @@ func New(dir string, log logger) (*KeyManager, error) {
 		log.Warn("authcore/keymanager: could not write .gitignore in %q (continuing): %v", dir, err)
 	}
 
+	// Read the layout marker before anything is parsed or generated: a directory
+	// written by a newer authcore must be refused while its files are still
+	// untouched, not after a loader from this build has interpreted them.
+	meta, err := readMetadata(dir)
+	if err != nil {
+		return nil, err
+	}
+
 	// Fail closed on a partially-populated directory before generating anything,
 	// so a missing refresh secret beside an existing key pair is reported rather
 	// than silently regenerated (which would invalidate stored refresh hashes).
@@ -111,12 +128,19 @@ func New(dir string, log logger) (*KeyManager, error) {
 		return nil, fmt.Errorf("refresh secret: %w", err)
 	}
 
+	keyID := computeKeyID(pub)
+
+	// Record the layout last, once the keys it describes are known good. A
+	// directory from before this file existed is adopted in place here — the
+	// key material is never rewritten, only described.
+	syncMetadata(dir, meta, keyID, log)
+
 	return &KeyManager{
 		dir:           dir,
 		privateKey:    priv,
 		publicKey:     pub,
 		refreshSecret: secret,
-		keyID:         computeKeyID(pub),
+		keyID:         keyID,
 	}, nil
 }
 


### PR DESCRIPTION
Closes #220.

The key directory carried three files and nothing saying what wrote them, which made this project's own migrate-forward rule unenforceable: with no marker, a future format change could only guess from the shape of a file or regenerate — and regenerating invalidates every refresh-token and API-key hash a consumer has stored, logging out all of their users.

`metadata.json` now records the format version, when the material was first written, and the live signing key's id. No secret in it; the key id already travels in every JWT header.

```json
{
  "format": 1,
  "created": "2026-07-27T02:41:09Z",
  "key_id": "3f9a1c07d5b2e846"
}
```

### The decisions, so they are easy to argue with

- **A separate file, not a PEM header.** People read those `.pem` files with `openssl`; putting authcore's bookkeeping inside them breaks that expectation.
- **Read before anything is parsed or generated.** A directory from a newer authcore is refused while its files are still untouched, rather than after this build has interpreted material in a layout it does not know.
- **A corrupt marker fails closed** — a loader that cannot tell what wrote the keys must not guess — but the error names the escape, because the file holds no key material: delete it and the next start re-adopts the keys. The test exercises that escape rather than trusting the sentence.
- **No marker means the pre-marker layout**, adopted in place. This is the one migration that has to exist from day one.
- **Adoption dates from the private key's mtime**, not from the moment of the upgrade, so a directory that is months old does not claim to have been created by the release that adopted it.
- **Writing is never fatal.** A read-only KeysDir is a supported deployment and this is bookkeeping.

### What I measured, go1.26.5

`go build`, `go vet`, `golangci-lint` (0 issues), and `go test -race ./...` all pass; `internal/keymanager` coverage moves 85.7% -> 87.5%.

The assertions are that key material *survives*, not that code ran, so I mutated the implementation to check the tests actually bite:

| Mutation | Expected | Result |
|---|---|---|
| Drop the newer-format guard | future-directory test fails | fails |
| Rewrite the descriptor on every load | no-churn test fails | fails |
| Always stamp `time.Now()` instead of the key mtime | adoption-date test fails | fails |
| Make a failed descriptor write fatal | write-failure test fails | fails |

That last one is worth a note, because my first version of the test did **not** catch it. I had written it as "chmod the directory to 0500 and expect startup to survive" — but `New` chmods the key directory back to `0700` before writing anything, so the permission bits never survive to the write, and the mutation sailed through green. The permission-bit scenario is unreachable through `New`; the real one is a filesystem that refuses the write, which a missing directory reproduces portably. The test is now white-box against `syncMetadata`, and it fails when the mutation lands. Worth knowing separately: **`New` will loosen a deliberately read-only-by-mode KeysDir to 0700**, which is not what the surrounding comments imply.

### Not in scope

`internal/keymanager` is still under the coverage gate at 87.5% — that is #218, unchanged by this beyond the small rise.
