### PR TITLE
fix(keymanager): tighten the key directory, never loosen it

### DIFF
--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -77,9 +77,13 @@ func New(dir string, log logger) (*KeyManager, error) {
 
 	// MkdirAll does not tighten a directory that already exists, so a pre-created
 	// or volume-mounted KeysDir could sit at a looser mode (e.g. 0755). Tighten
-	// it to owner-only. A failure here is not fatal — the private key and refresh
-	// secret are still written 0600 — so warn rather than abort.
-	if err := os.Chmod(dir, dirMode); err != nil {
+	// it to owner-only — but only ever tighten. An operator who hands over a
+	// stricter directory (0500 for a read-only mounted secret) means it, and
+	// widening the permissions on the directory that holds the private key would
+	// be the opposite of what this exists for. A failure here is not fatal — the
+	// private key and refresh secret are still written 0600 — so warn rather than
+	// abort.
+	if err := tightenDirMode(dir); err != nil {
 		log.Warn("authcore/keymanager: could not tighten key directory %q to %o: %v", dir, dirMode, err)
 	}
 
@@ -167,6 +171,25 @@ func (km *KeyManager) KeyID() string {
 // Dir returns the absolute path of the key directory.
 func (km *KeyManager) Dir() string {
 	return km.dir
+}
+
+// tightenDirMode removes any permission bit outside dirMode from dir, and
+// leaves a directory that is already at or below dirMode untouched.
+//
+// Chmodding unconditionally would also *raise* a stricter mode to 0700, which
+// is why the current mode is read first: 0755 becomes 0700, while 0500 stays
+// 0500. On a platform without Unix permission bits the mode carries no group
+// or world bits to strip, so this is a no-op there.
+func tightenDirMode(dir string) error {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	mode := fi.Mode().Perm()
+	if mode&^dirMode == 0 {
+		return nil // already at least this strict
+	}
+	return os.Chmod(dir, mode&dirMode)
 }
 
 // ensureGitignore writes a catch-all .gitignore inside dir if one does

--- a/internal/keymanager/mode_test.go
+++ b/internal/keymanager/mode_test.go
@@ -1,0 +1,70 @@
+package keymanager_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/Glyndor/authcore/internal/keymanager"
+)
+
+// seededDir returns a key directory that already holds its key material.
+func seededDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("seed keymanager.New(): %v", err)
+	}
+	return dir
+}
+
+func modeOf(t *testing.T, dir string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	return fi.Mode().Perm()
+}
+
+// An operator who hands authcore a deliberately tighter KeysDir keeps it. This
+// directory holds the Ed25519 private key and the refresh secret, so widening
+// its permissions unasked is the opposite of what the tightening exists for.
+func TestNew_doesNotLoosenARestrictiveKeysDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits do not apply on Windows")
+	}
+	dir := seededDir(t)
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("restrict directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("keymanager.New(): %v", err)
+	}
+
+	if got := modeOf(t, dir); got != 0500 {
+		t.Errorf("key directory mode = %04o, want 0500 left alone", got)
+	}
+}
+
+// The tightening the comment exists for still has to happen: a volume-mounted
+// or pre-created directory that arrives world-readable is closed to the owner.
+func TestNew_tightensAnOpenKeysDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits do not apply on Windows")
+	}
+	dir := seededDir(t)
+	if err := os.Chmod(dir, 0755); err != nil {
+		t.Fatalf("loosen directory: %v", err)
+	}
+
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("keymanager.New(): %v", err)
+	}
+
+	if got := modeOf(t, dir); got != 0700 {
+		t.Errorf("key directory mode = %04o, want 0700 after tightening", got)
+	}
+}


### PR DESCRIPTION
Closes #222.

`New` chmodded `KeysDir` to `0700` unconditionally. The comment above it says the point is to tighten a directory that arrives too open — but with no read of the current mode it also *widened* a stricter one, so a directory handed over at `0500` came back `0700` after the first start. `docs/key-management.md` tells people to mount that directory read-only, and it holds the Ed25519 private key and the refresh secret, so granting write back unasked is the opposite of what the code claims.

`tightenDirMode` now reads the mode and only clears bits: `0755` -> `0700`, `0500` stays `0500`.

### Measured, go1.26.5

The observable effect is the directory mode, so both directions are asserted — a fix that just deleted the chmod would pass the first test while silently dropping the tightening the code exists for.

| | Before | After |
|---|---|---|
| Directory at `0500` | becomes `0700` | stays `0500` |
| Directory at `0755` | becomes `0700` | becomes `0700` |

The first row is a failing test on `develop`, which is how I confirmed the bug is real rather than a reading of the source.

`go build`, `go vet`, `golangci-lint` (0 issues) and `go test -race ./...` all pass.

### Mutation testing, including two that did not bite

| Mutation | Result |
|---|---|
| Remove the `tightenDirMode` call | tightening test fails, as expected |
| Remove only the early return | **still passes** |
| Change only `chmod(dir, mode&dirMode)` back to `chmod(dir, dirMode)` | **still passes** |
| Remove both | loosening test fails, as expected |

The two that survive are worth stating rather than hiding: the early return and the mask each independently prevent the loosening, so neither alone is load-bearing. I only trusted the test once the mutation that removes both — which is exactly the code as it stands on `develop` — turned it red.

### Relationship to #221

Same package, different change, so it is a separate branch off `develop`. Whichever merges second may need a trivial rebase; the hunks are in different parts of `New`.
