### PR TITLE
ci: assert that the scheduled audit and fuzz are still firing

### DIFF
--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -15,20 +15,24 @@ on:
   push:
     branches: [main, develop]
 
+# A called workflow cannot elevate beyond what the caller grants, so the
+# actions: read the freshness job needs to query run history has to be granted
+# here too.
 permissions:
   contents: read
+  actions: read
 
 jobs:
   audit:
     name: audit freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@0c615b27eb8485554ac1506e4a0509e813444a47
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@86532aaf0963099b06b186a1a31381f72b0b7415
     with:
       workflow: audit.yml
       max-age-days: 15 # weekly cron, so two periods of slack
 
   fuzz:
     name: fuzz freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@0c615b27eb8485554ac1506e4a0509e813444a47
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@86532aaf0963099b06b186a1a31381f72b0b7415
     with:
       workflow: fuzz.yml
       max-age-days: 15 # weekly cron, so two periods of slack

--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -1,0 +1,34 @@
+name: Schedule freshness
+
+# The weekly audit and fuzz runs are the only guards here that can fail by
+# silence: a cron that stops firing emits nothing, and no alert reads exactly
+# like all clear. That is how this repository went four weeks without a
+# security scan in July 2026, and how GO-2026-5856 ended up being found by
+# hand instead of by the audit that exists for it.
+#
+# Asserting freshness from ordinary CI turns that absence into a red check on
+# everyday work.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: audit freshness
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@0c615b27eb8485554ac1506e4a0509e813444a47
+    with:
+      workflow: audit.yml
+      max-age-days: 15 # weekly cron, so two periods of slack
+
+  fuzz:
+    name: fuzz freshness
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@0c615b27eb8485554ac1506e4a0509e813444a47
+    with:
+      workflow: fuzz.yml
+      max-age-days: 15 # weekly cron, so two periods of slack

--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -25,14 +25,14 @@ permissions:
 jobs:
   audit:
     name: audit freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@86532aaf0963099b06b186a1a31381f72b0b7415
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
     with:
       workflow: audit.yml
       max-age-days: 15 # weekly cron, so two periods of slack
 
   fuzz:
     name: fuzz freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@86532aaf0963099b06b186a1a31381f72b0b7415
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
     with:
       workflow: fuzz.yml
       max-age-days: 15 # weekly cron, so two periods of slack


### PR DESCRIPTION
Part of #219.

Adds a caller for the new `schedule-freshness` reusable so that a cron which stops firing shows up as a red check on ordinary work instead of as nothing at all.

**I expect this to fail right now, and that is the proof.** The newest successful *scheduled* run of both `audit.yml` and `fuzz.yml` is 2026-06-29 — 28 days ago, well past the 15-day limit. Tonight's runs were `workflow_dispatch`, which deliberately does not count: the point is to measure the schedule, not that somebody pressed a button. So a red check here is the check working, reporting a real four-week gap that nothing else reported.

It goes green when the schedule actually fires. Both crons are Monday 06:00 and 07:00 UTC, and I toggled them off and on last night to re-register them, so tomorrow's run is the test of whether that worked. If it does not fire, this stops being a CI problem and becomes a support ticket — and this check is what will keep saying so instead of letting it slide for another month.

Pinned to the reusable's commit rather than a tag on purpose: `Glyndor/.github` is only tagged once a consumer has proved a workflow green, and this is that consumer. I move the pin to the release tag afterwards.