### PR TITLE
test(oauth): exercise the guards that survived being deleted

### DIFF
--- a/auth/oauth/jwks_bounds_internal_test.go
+++ b/auth/oauth/jwks_bounds_internal_test.go
@@ -1,0 +1,107 @@
+package oauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// The bounds in parseJWK reject key material a hostile or broken JWKS document
+// can otherwise hand the verifier: an undersized RSA modulus that is cheap to
+// factor, an oversized one that turns every verification into a CPU sink, and
+// EC coordinates outside the field. Every one of them survived being deleted
+// with the suite green, because the end-to-end tests build only well-formed
+// keys — so they are driven here directly.
+
+func b64(i *big.Int) string { return base64.RawURLEncoding.EncodeToString(i.Bytes()) }
+
+func rsaJWK(t *testing.T, bits int) jwk {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		t.Fatalf("generate %d-bit RSA key: %v", bits, err)
+	}
+	return jwk{Kty: "RSA", N: b64(k.N), E: b64(big.NewInt(int64(k.E)))}
+}
+
+func TestParseJWK_rejectsAnUndersizedRSAModulus(t *testing.T) {
+	// 1024 bits is generatable and plausible-looking, and well under the floor.
+	_, err := parseJWK(rsaJWK(t, 1024))
+	if err == nil {
+		t.Fatal("a 1024-bit RSA key must be refused")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+func TestParseJWK_acceptsAnRSAKeyAtTheFloor(t *testing.T) {
+	if _, err := parseJWK(rsaJWK(t, 2048)); err != nil {
+		t.Fatalf("2048 bits is the floor and must be accepted, got: %v", err)
+	}
+}
+
+func TestParseJWK_rejectsAnOversizedRSAModulus(t *testing.T) {
+	// Generating a >16384-bit key takes minutes, so the modulus is synthesised
+	// directly: parseJWK only measures its bit length.
+	huge := new(big.Int).Lsh(big.NewInt(1), 16385)
+	_, err := parseJWK(jwk{Kty: "RSA", N: b64(huge), E: b64(big.NewInt(65537))})
+	if err == nil {
+		t.Fatal("a 16385-bit modulus must be refused — every verification would be a modexp on it")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+func TestParseJWK_rejectsECCoordinatesOutsideTheField(t *testing.T) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate P-256 key: %v", err)
+	}
+	// One coordinate longer than the curve's field size: on curve arithmetic it
+	// is meaningless, and it is what the length bound exists to catch.
+	oversized := new(big.Int).Lsh(big.NewInt(1), 8*33)
+
+	_, err = parseJWK(jwk{Kty: "EC", Crv: "P-256", X: b64(oversized), Y: b64(k.Y)})
+	if err == nil {
+		t.Fatal("an x coordinate wider than the field must be refused")
+	}
+}
+
+func TestParseJWK_supportsEveryCurveItClaims(t *testing.T) {
+	// The provider chooses the curve, so all three advertised ones have to work
+	// — only P-256 was exercised before.
+	for name, curve := range map[string]elliptic.Curve{
+		"P-256": elliptic.P256(),
+		"P-384": elliptic.P384(),
+		"P-521": elliptic.P521(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			k, err := ecdsa.GenerateKey(curve, rand.Reader)
+			if err != nil {
+				t.Fatalf("generate %s key: %v", name, err)
+			}
+			got, err := parseJWK(jwk{Kty: "EC", Crv: name, X: b64(k.X), Y: b64(k.Y)})
+			if err != nil {
+				t.Fatalf("%s must be supported, got: %v", name, err)
+			}
+			pub, ok := got.(*ecdsa.PublicKey)
+			if !ok || pub.Curve != curve {
+				t.Fatalf("%s parsed into the wrong key type or curve: %T", name, got)
+			}
+		})
+	}
+}
+
+func TestParseJWK_rejectsAnUnknownCurve(t *testing.T) {
+	_, err := parseJWK(jwk{Kty: "EC", Crv: "P-999", X: b64(big.NewInt(1)), Y: b64(big.NewInt(1))})
+	if err == nil {
+		t.Fatal("an unknown curve must be refused rather than defaulted")
+	}
+}

--- a/auth/oauth/oauth_hardening_test.go
+++ b/auth/oauth/oauth_hardening_test.go
@@ -299,3 +299,25 @@ func TestVerifyIDToken_encUseKeySkipped(t *testing.T) {
 		t.Error("an enc-use key must not verify a token signature")
 	}
 }
+
+// An ID token with no "sub" identifies nobody. Accepting one hands the consumer
+// an empty subject, which their storage layer is liable to treat as a real
+// account key. The guard that rejects it survived being deleted with the suite
+// green — every other test signs a token that has a subject.
+func TestVerifyIDToken_rejectsATokenWithNoSubject(t *testing.T) {
+	key := mustRSA(t)
+	srv := jwksServer(t, &key.PublicKey)
+	c := newClient(t, srv)
+
+	claims := validClaims(srv.URL, "n")
+	delete(claims, "sub")
+	tok := signIDToken(t, key, testKID, claims)
+
+	_, err := c.VerifyIDToken(context.Background(), tok, "n")
+	if err == nil {
+		t.Fatal("an ID token without a subject must be refused")
+	}
+	if !strings.Contains(err.Error(), "subject") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}

--- a/auth/oauth/redirect_internal_test.go
+++ b/auth/oauth/redirect_internal_test.go
@@ -1,0 +1,68 @@
+package oauth
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// safeRedirect applies four guards in order — hop count, https, private host,
+// same origin — and the first two make the last two unreachable from any test
+// that redirects between local servers: an httptest server is plaintext on a
+// loopback address, so the scheme and private-host guards fire long before the
+// hop count or the origin check can. That is why the end-to-end redirect test
+// stays green when either of those is deleted, and why they are exercised here
+// against the function directly instead.
+func req(t *testing.T, raw string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return &http.Request{URL: u, Host: u.Host}
+}
+
+func TestSafeRedirect(t *testing.T) {
+	const origin = "https://provider.example/token"
+
+	for name, tc := range map[string]struct {
+		to   string
+		hops int
+		want string // substring of the expected rejection, "" means allowed
+	}{
+		"same origin is allowed":         {to: "https://provider.example/token2", want: ""},
+		"cross-origin leaks the secret":  {to: "https://evil.example/steal", want: "cross-origin"},
+		"plaintext downgrade":            {to: "http://provider.example/token", want: "non-https"},
+		"cloud metadata endpoint":        {to: "https://169.254.169.254/latest", want: "private host"},
+		"loopback":                       {to: "https://127.0.0.1/token", want: "private host"},
+		"private range":                  {to: "https://10.0.0.5/token", want: "private host"},
+		"too many hops on the same host": {to: "https://provider.example/token", hops: 5, want: "too many redirects"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			hops := tc.hops
+			if hops == 0 {
+				hops = 1
+			}
+			via := make([]*http.Request, hops)
+			for i := range via {
+				via[i] = req(t, origin)
+			}
+
+			err := safeRedirect(req(t, tc.to), via)
+
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("redirect to %q should be allowed, got: %v", tc.to, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("redirect to %q must be refused", tc.to)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("redirect to %q refused for the wrong reason: want %q, got: %v", tc.to, tc.want, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
First pass of the sweep in #229, scoped to `auth/oauth`.

I did not read the tests looking for weak ones — I deleted each security control in turn and checked whether anything went red. Five survived:

| Control | Before | After |
|---|---|---|
| Redirect hop limit (`len(via) >= 5`) | survives deletion | detected |
| Cross-origin redirect (the token POST replays the client secret) | survives deletion | detected |
| RSA modulus bounds (2048–16384) | survives deletion | detected |
| EC coordinates outside the field | survives deletion | detected |
| ID token with no `sub` | survives deletion | detected |

Every one had been added deliberately as hardening. None was being executed.

### Why the redirect ones could never have been caught end to end

`safeRedirect` applies four guards in order — hop count, https, private host, same origin. Any test that redirects between local servers dies at the second or third, because an `httptest` server is plaintext on a loopback address. The last two were structurally unreachable through `Exchange`, so `TestExchange_refusesUnsafeRedirect` stayed green with either deleted, and more integration tests would not have helped. They are driven against the function directly now, each case asserting its own rejection reason rather than accepting any error.

**I nearly shipped a worse version of this.** My first attempt replaced the redirect test with one pointing at a live second server, on the theory that the original passed only because `evil.example` does not resolve. It passed with the cross-origin check deleted too — the plaintext guard fired first. Same trap as #227: an assertion satisfied by whichever failure arrives first. That is what sent me to the unit-level test.

### The rest

`parseJWK` gets direct tests for the modulus floor and ceiling, an EC coordinate wider than the field, an unknown curve, and — new — **P-384 and P-521, which the module advertises and had never once parsed**. The empty-subject case signs a token with `sub` removed; accepting one hands the consumer an empty subject, which their storage is liable to treat as a real account key.

### Measured

`go vet`, `golangci-lint` (0 issues) and `go test -race ./...` pass. `auth/oauth` coverage 87.7% -> 90.2%, which clears the gate it was under in #218.

Every new test was confirmed by deleting the control it names and watching it fail. That is the only reason to believe any of them.
