### PR TITLE
test(jwt): exercise the verification guards that survived deletion

### DIFF
--- a/auth/jwt/algconfusion_internal_test.go
+++ b/auth/jwt/algconfusion_internal_test.go
@@ -1,0 +1,123 @@
+package jwt
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+	"time"
+
+	gjwt "github.com/golang-jwt/jwt/v5"
+)
+
+// The attack: Ed25519 public keys are public by definition, so an attacker who
+// knows one can mint an HS256 token using those very bytes as the HMAC secret.
+// A verifier that hands the key to whichever method the token names verifies it
+// happily, and every token can be forged.
+//
+// This asserts the outcome, and it passes even with the alg check in
+// eddsaKeyFunc deleted — golang-jwt refuses the key on its own, because
+// ed25519.PublicKey is a named type that does not assert to []byte and its HMAC
+// verifier accepts nothing else. That second layer is real but incidental: it
+// holds only while the keyfunc returns ed25519.PublicKey, and a refactor to
+// return []byte(pub) would remove it silently. TestEddsaKeyFunc_rejectsANonEdDSAAlg
+// below is what pins the check itself.
+func TestVerifyAccessToken_refusesAnHS256TokenSignedWithThePublicKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "k1"
+	keys := map[string]ed25519.PublicKey{kid: pub}
+
+	now := time.Now()
+	claims := &accessClaims[map[string]any]{
+		RegisteredClaims: gjwt.RegisteredClaims{
+			Issuer:    "issuer",
+			Subject:   "0192f0c1-0000-7000-8000-000000000000",
+			Audience:  gjwt.ClaimStrings{"aud"},
+			IssuedAt:  gjwt.NewNumericDate(now.Add(-time.Minute)),
+			ExpiresAt: gjwt.NewNumericDate(now.Add(time.Hour)),
+			ID:        "jti",
+		},
+		Type: tokenTypeAccess,
+	}
+
+	// Sign with HMAC, keyed on the public key's raw bytes.
+	forged := gjwt.NewWithClaims(gjwt.SigningMethodHS256, claims)
+	forged.Header["kid"] = kid
+	tokenStr, err := forged.SignedString([]byte(pub))
+	if err != nil {
+		t.Fatalf("sign the forged token: %v", err)
+	}
+
+	got, err := verifyAccessToken[map[string]any](tokenStr, keys, now, "issuer", "aud", 0)
+	if err == nil {
+		t.Fatalf("an HS256 token keyed on the public key was accepted — any token can be forged; claims: %+v", got)
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Logf("rejected, though not as ErrTokenInvalid: %v", err)
+	}
+}
+
+// The alg check has to be asserted directly. mapJWTError collapses everything
+// into ErrTokenInvalid, so from outside there is no way to tell a token refused
+// for its algorithm from one refused for a bad signature — which is why
+// deleting the check leaves the end-to-end tests green.
+func TestEddsaKeyFunc_rejectsANonEdDSAAlg(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "k1"
+	fn := eddsaKeyFunc(map[string]ed25519.PublicKey{kid: pub})
+
+	for name, method := range map[string]gjwt.SigningMethod{
+		"HS256": gjwt.SigningMethodHS256,
+		"RS256": gjwt.SigningMethodRS256,
+		"none":  gjwt.SigningMethodNone,
+	} {
+		t.Run(name, func(t *testing.T) {
+			tok := gjwt.New(method)
+			tok.Header["kid"] = kid
+
+			key, err := fn(tok)
+			if err == nil {
+				t.Fatalf("alg %s must be refused before any key is handed out, got key %T", name, key)
+			}
+			if !strings.Contains(err.Error(), "unexpected alg") {
+				t.Fatalf("refused for the wrong reason: %v", err)
+			}
+			if key != nil {
+				t.Fatalf("no key may be returned alongside the rejection, got %T", key)
+			}
+		})
+	}
+}
+
+func TestEddsaKeyFunc_returnsTheKeyForEdDSA(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "k1"
+	fn := eddsaKeyFunc(map[string]ed25519.PublicKey{kid: pub})
+
+	tok := gjwt.New(gjwt.SigningMethodEdDSA)
+	tok.Header["kid"] = kid
+
+	key, err := fn(tok)
+	if err != nil {
+		t.Fatalf("EdDSA must be accepted: %v", err)
+	}
+	// The concrete type matters: it is what stops golang-jwt handing these
+	// bytes to an HMAC verifier. Returning []byte here would be a silent
+	// downgrade.
+	got, ok := key.(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("keyfunc must return ed25519.PublicKey, got %T", key)
+	}
+	if !got.Equal(pub) {
+		t.Fatal("keyfunc returned a different key")
+	}
+}

--- a/auth/jwt/parseroptions_internal_test.go
+++ b/auth/jwt/parseroptions_internal_test.go
@@ -1,0 +1,156 @@
+package jwt
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	gjwt "github.com/golang-jwt/jwt/v5"
+)
+
+// The parser options are the whole of the claim validation — there is no
+// hand-written check for exp, iss or aud, so deleting an option silently
+// removes a control. Each of these survived being deleted with the suite green,
+// because every other test builds a well-formed token.
+
+const (
+	optIssuer   = "issuer.example"
+	optAudience = "aud.example"
+	optSubject  = "0192f0c1-0000-7000-8000-000000000000"
+)
+
+type signer struct {
+	priv ed25519.PrivateKey
+	keys map[string]ed25519.PublicKey
+}
+
+func newSigner(t *testing.T) signer {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return signer{priv: priv, keys: map[string]ed25519.PublicKey{"k1": pub}}
+}
+
+// sign builds an access token from a claim set the caller can bend.
+func (s signer) sign(t *testing.T, mutate func(*gjwt.RegisteredClaims)) string {
+	t.Helper()
+	now := time.Now()
+	reg := gjwt.RegisteredClaims{
+		Issuer:    optIssuer,
+		Subject:   optSubject,
+		Audience:  gjwt.ClaimStrings{optAudience},
+		IssuedAt:  gjwt.NewNumericDate(now.Add(-time.Minute)),
+		ExpiresAt: gjwt.NewNumericDate(now.Add(time.Hour)),
+		ID:        "jti",
+	}
+	mutate(&reg)
+	str, err := signToken(&accessClaims[map[string]any]{RegisteredClaims: reg, Type: tokenTypeAccess}, s.priv, "k1")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return str
+}
+
+func (s signer) verify(t *testing.T, tokenStr string) error {
+	t.Helper()
+	_, err := verifyAccessToken[map[string]any](tokenStr, s.keys, time.Now(), optIssuer, optAudience, 0)
+	return err
+}
+
+// A token with no exp never expires. WithExpirationRequired is the only thing
+// that refuses one.
+func TestVerifyAccessToken_refusesATokenWithNoExpiry(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) { c.ExpiresAt = nil })
+
+	if err := s.verify(t, tok); err == nil {
+		t.Fatal("a token with no exp claim must be refused — it would never expire")
+	}
+}
+
+func TestVerifyAccessToken_refusesAnExpiredToken(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) {
+		c.ExpiresAt = gjwt.NewNumericDate(time.Now().Add(-time.Hour))
+	})
+
+	err := s.verify(t, tok)
+	if !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("want ErrTokenExpired, got: %v", err)
+	}
+}
+
+// Issuer and audience are what stop a token minted by the same key for a
+// different service being replayed here.
+func TestVerifyAccessToken_refusesAnotherServicesIssuer(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) { c.Issuer = "other.example" })
+
+	if err := s.verify(t, tok); err == nil {
+		t.Fatal("a token issued by another service must be refused")
+	}
+}
+
+func TestVerifyAccessToken_refusesAnotherServicesAudience(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) { c.Audience = gjwt.ClaimStrings{"other.example"} })
+
+	if err := s.verify(t, tok); err == nil {
+		t.Fatal("a token addressed to another audience must be refused")
+	}
+}
+
+// The length cap refuses an oversized token before any parsing, so a hostile
+// caller cannot make the parser chew through megabytes.
+//
+// The oversized token has to be otherwise *valid*. My first version passed a
+// string of filler, which the parser rejects as malformed whether or not the
+// cap exists — so deleting the cap left the test green. Padding a properly
+// signed token past the limit is what makes the cap the only thing that can
+// refuse it.
+func (s signer) oversizedButValid(t *testing.T) string {
+	t.Helper()
+	now := time.Now()
+	tok, err := signToken(&accessClaims[map[string]any]{
+		RegisteredClaims: gjwt.RegisteredClaims{
+			Issuer:    optIssuer,
+			Subject:   optSubject,
+			Audience:  gjwt.ClaimStrings{optAudience},
+			IssuedAt:  gjwt.NewNumericDate(now.Add(-time.Minute)),
+			ExpiresAt: gjwt.NewNumericDate(now.Add(time.Hour)),
+			ID:        "jti",
+		},
+		Type:  tokenTypeAccess,
+		Extra: map[string]any{"padding": strings.Repeat("a", maxTokenLen)},
+	}, s.priv, "k1")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if len(tok) <= maxTokenLen {
+		t.Fatalf("fixture is only %d bytes, needs to exceed %d", len(tok), maxTokenLen)
+	}
+	return tok
+}
+
+func TestVerifyAccessToken_refusesAnOversizedToken(t *testing.T) {
+	s := newSigner(t)
+
+	err := s.verify(t, s.oversizedButValid(t))
+	if !errors.Is(err, ErrTokenMalformed) {
+		t.Fatalf("want ErrTokenMalformed for a valid token over %d bytes, got: %v", maxTokenLen, err)
+	}
+}
+
+func TestVerifyRefreshToken_refusesAnOversizedToken(t *testing.T) {
+	s := newSigner(t)
+
+	_, err := verifyRefreshToken(s.oversizedButValid(t), s.keys, time.Now(), optIssuer, optAudience, 0)
+	if !errors.Is(err, ErrTokenMalformed) {
+		t.Fatalf("want ErrTokenMalformed for a valid token over %d bytes, got: %v", maxTokenLen, err)
+	}
+}


### PR DESCRIPTION
Second pass of #229, in the module with the widest blast radius. Same method: delete each control, see whether anything goes red.

| Control | Before | After |
|---|---|---|
| EdDSA algorithm check (`eddsaKeyFunc`) | survives deletion | detected |
| `WithExpirationRequired` | survives deletion | detected |
| `WithIssuer` | survives deletion | detected |
| `WithAudience` | survives deletion | detected |
| 8 KiB length cap, access path | survives deletion | detected |
| 8 KiB length cap, refresh path | survives deletion | detected |
| Refresh token accepted as access | already detected | — |
| Unknown `kid` falling back to another key | already detected | — |

Claim validation here is entirely parser options — there is no hand-written check for `exp`, `iss` or `aud` — so removing an option removes a control with nothing to notice, and every existing test builds a well-formed token. **Without `WithExpirationRequired` a token carrying no `exp` is accepted, and it never expires.** Without the issuer and audience options, a token minted by the same key for a different service verifies here: the cross-service reuse those lines say they defend against.

### The algorithm check needed a different kind of test

`mapJWTError` collapses everything into `ErrTokenInvalid`, so from outside there is no way to distinguish a token refused for its algorithm from one refused for its signature. Deleting the check cannot change any observable behaviour of the public API, which is exactly why no test could catch it. It is asserted against `eddsaKeyFunc` directly now — HS256, RS256 and `none` — including that no key is handed back alongside the rejection.

**And a correction I would rather state than bury.** I expected the end-to-end forgery to work with the check deleted: an HS256 token keyed on the Ed25519 public key, which is public by definition. It does not. golang-jwt's HMAC verifier refuses any key that is not literally `[]byte`, and `ed25519.PublicKey` is a named type that does not assert to it — measured, not assumed:

```
ed25519.PublicKey asserts to []byte: false
HS256.Verify with ed25519.PublicKey: key is of invalid type: HMAC verify expects []byte
```

So the alg check is defence in depth rather than the only thing between the library and forgery, and the comment above it overstates slightly. That second layer is real but incidental — it holds only while the keyfunc returns `ed25519.PublicKey`, and a refactor to `[]byte(pub)` would remove it silently. There is now a test pinning the concrete return type, and it catches that refactor.

### The length cap took two attempts

My first version fed the verifier a string of filler. The parser rejects that as malformed with or without the cap, so it stayed green under mutation — the same trap as #227 and as my first redirect test in #232, for the third time tonight. Padding a *properly signed* token past the limit makes the cap the only thing that can refuse it.

### Measured

`go vet`, `golangci-lint` (0 issues), `go test -race ./...` all pass. `auth/jwt` 94.4% -> 95.0%, module total 92.3%. Every new test was confirmed by deleting the control it names and watching it fail.
