### PR TITLE
ci: label the freshness pin with its release

### DIFF
--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -25,14 +25,14 @@ permissions:
 jobs:
   audit:
     name: audit freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2 # v1.11.0
     with:
       workflow: audit.yml
       max-age-days: 15 # weekly cron, so two periods of slack
 
   fuzz:
     name: fuzz freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2 # v1.11.0
     with:
       workflow: fuzz.yml
       max-age-days: 15 # weekly cron, so two periods of slack


### PR DESCRIPTION
Closes #219.

The pin already pointed at the commit that became `v1.11.0` — it was pinned to the merge of Glyndor/.github#105 while the reusable was still waiting for a consumer to prove it green, which #226 then did. This adds the version comment beside it.

The SHA is what makes the pin safe. The comment is what makes it visible: without a version to compare against, Dependabot never proposes a bump and the pin quietly rots. That is the difference between a reusable this repository happens to call and one the organisation can adopt.

### Where #219 stands

| | |
|---|---|
| Crons re-registered | `Security audit` and `Fuzz` both fired on 2026-07-27 — 09:55 and 10:30 UTC, against crons set for 06:00 and 07:00. Nearly four hours late, which is normal for GitHub and worth remembering before calling one dead. |
| First ever green | `audit.yml` had **never** completed a scheduled run successfully; its only previous cron-triggered run, on 2026-06-29, is the one that failed. |
| Guard proven both ways | It reported the real 27-day gap while the schedules were dark, and `Within the 15-day limit` once they resumed. |

Closing #219 on the authcore side. **What is not done is the rollout**: epistle, unitpm, glyndor.net, apt and podup all carry schedules and none of them has a freshness check. That is org work and needs its own issue rather than living in this one.