### PR TITLE
release: v1.11.6

### DIFF
--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -25,14 +25,14 @@ permissions:
 jobs:
   audit:
     name: audit freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2 # v1.11.0
     with:
       workflow: audit.yml
       max-age-days: 15 # weekly cron, so two periods of slack
 
   fuzz:
     name: fuzz freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2 # v1.11.0
     with:
       workflow: fuzz.yml
       max-age-days: 15 # weekly cron, so two periods of slack

--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -1,0 +1,38 @@
+name: Schedule freshness
+
+# The weekly audit and fuzz runs are the only guards here that can fail by
+# silence: a cron that stops firing emits nothing, and no alert reads exactly
+# like all clear. That is how this repository went four weeks without a
+# security scan in July 2026, and how GO-2026-5856 ended up being found by
+# hand instead of by the audit that exists for it.
+#
+# Asserting freshness from ordinary CI turns that absence into a red check on
+# everyday work.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+# A called workflow cannot elevate beyond what the caller grants, so the
+# actions: read the freshness job needs to query run history has to be granted
+# here too.
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  audit:
+    name: audit freshness
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
+    with:
+      workflow: audit.yml
+      max-age-days: 15 # weekly cron, so two periods of slack
+
+  fuzz:
+    name: fuzz freshness
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2
+    with:
+      workflow: fuzz.yml
+      max-age-days: 15 # weekly cron, so two periods of slack

--- a/auth/jwt/algconfusion_internal_test.go
+++ b/auth/jwt/algconfusion_internal_test.go
@@ -1,0 +1,123 @@
+package jwt
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+	"time"
+
+	gjwt "github.com/golang-jwt/jwt/v5"
+)
+
+// The attack: Ed25519 public keys are public by definition, so an attacker who
+// knows one can mint an HS256 token using those very bytes as the HMAC secret.
+// A verifier that hands the key to whichever method the token names verifies it
+// happily, and every token can be forged.
+//
+// This asserts the outcome, and it passes even with the alg check in
+// eddsaKeyFunc deleted — golang-jwt refuses the key on its own, because
+// ed25519.PublicKey is a named type that does not assert to []byte and its HMAC
+// verifier accepts nothing else. That second layer is real but incidental: it
+// holds only while the keyfunc returns ed25519.PublicKey, and a refactor to
+// return []byte(pub) would remove it silently. TestEddsaKeyFunc_rejectsANonEdDSAAlg
+// below is what pins the check itself.
+func TestVerifyAccessToken_refusesAnHS256TokenSignedWithThePublicKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "k1"
+	keys := map[string]ed25519.PublicKey{kid: pub}
+
+	now := time.Now()
+	claims := &accessClaims[map[string]any]{
+		RegisteredClaims: gjwt.RegisteredClaims{
+			Issuer:    "issuer",
+			Subject:   "0192f0c1-0000-7000-8000-000000000000",
+			Audience:  gjwt.ClaimStrings{"aud"},
+			IssuedAt:  gjwt.NewNumericDate(now.Add(-time.Minute)),
+			ExpiresAt: gjwt.NewNumericDate(now.Add(time.Hour)),
+			ID:        "jti",
+		},
+		Type: tokenTypeAccess,
+	}
+
+	// Sign with HMAC, keyed on the public key's raw bytes.
+	forged := gjwt.NewWithClaims(gjwt.SigningMethodHS256, claims)
+	forged.Header["kid"] = kid
+	tokenStr, err := forged.SignedString([]byte(pub))
+	if err != nil {
+		t.Fatalf("sign the forged token: %v", err)
+	}
+
+	got, err := verifyAccessToken[map[string]any](tokenStr, keys, now, "issuer", "aud", 0)
+	if err == nil {
+		t.Fatalf("an HS256 token keyed on the public key was accepted — any token can be forged; claims: %+v", got)
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Logf("rejected, though not as ErrTokenInvalid: %v", err)
+	}
+}
+
+// The alg check has to be asserted directly. mapJWTError collapses everything
+// into ErrTokenInvalid, so from outside there is no way to tell a token refused
+// for its algorithm from one refused for a bad signature — which is why
+// deleting the check leaves the end-to-end tests green.
+func TestEddsaKeyFunc_rejectsANonEdDSAAlg(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "k1"
+	fn := eddsaKeyFunc(map[string]ed25519.PublicKey{kid: pub})
+
+	for name, method := range map[string]gjwt.SigningMethod{
+		"HS256": gjwt.SigningMethodHS256,
+		"RS256": gjwt.SigningMethodRS256,
+		"none":  gjwt.SigningMethodNone,
+	} {
+		t.Run(name, func(t *testing.T) {
+			tok := gjwt.New(method)
+			tok.Header["kid"] = kid
+
+			key, err := fn(tok)
+			if err == nil {
+				t.Fatalf("alg %s must be refused before any key is handed out, got key %T", name, key)
+			}
+			if !strings.Contains(err.Error(), "unexpected alg") {
+				t.Fatalf("refused for the wrong reason: %v", err)
+			}
+			if key != nil {
+				t.Fatalf("no key may be returned alongside the rejection, got %T", key)
+			}
+		})
+	}
+}
+
+func TestEddsaKeyFunc_returnsTheKeyForEdDSA(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "k1"
+	fn := eddsaKeyFunc(map[string]ed25519.PublicKey{kid: pub})
+
+	tok := gjwt.New(gjwt.SigningMethodEdDSA)
+	tok.Header["kid"] = kid
+
+	key, err := fn(tok)
+	if err != nil {
+		t.Fatalf("EdDSA must be accepted: %v", err)
+	}
+	// The concrete type matters: it is what stops golang-jwt handing these
+	// bytes to an HMAC verifier. Returning []byte here would be a silent
+	// downgrade.
+	got, ok := key.(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("keyfunc must return ed25519.PublicKey, got %T", key)
+	}
+	if !got.Equal(pub) {
+		t.Fatal("keyfunc returned a different key")
+	}
+}

--- a/auth/jwt/parseroptions_internal_test.go
+++ b/auth/jwt/parseroptions_internal_test.go
@@ -1,0 +1,156 @@
+package jwt
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	gjwt "github.com/golang-jwt/jwt/v5"
+)
+
+// The parser options are the whole of the claim validation — there is no
+// hand-written check for exp, iss or aud, so deleting an option silently
+// removes a control. Each of these survived being deleted with the suite green,
+// because every other test builds a well-formed token.
+
+const (
+	optIssuer   = "issuer.example"
+	optAudience = "aud.example"
+	optSubject  = "0192f0c1-0000-7000-8000-000000000000"
+)
+
+type signer struct {
+	priv ed25519.PrivateKey
+	keys map[string]ed25519.PublicKey
+}
+
+func newSigner(t *testing.T) signer {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return signer{priv: priv, keys: map[string]ed25519.PublicKey{"k1": pub}}
+}
+
+// sign builds an access token from a claim set the caller can bend.
+func (s signer) sign(t *testing.T, mutate func(*gjwt.RegisteredClaims)) string {
+	t.Helper()
+	now := time.Now()
+	reg := gjwt.RegisteredClaims{
+		Issuer:    optIssuer,
+		Subject:   optSubject,
+		Audience:  gjwt.ClaimStrings{optAudience},
+		IssuedAt:  gjwt.NewNumericDate(now.Add(-time.Minute)),
+		ExpiresAt: gjwt.NewNumericDate(now.Add(time.Hour)),
+		ID:        "jti",
+	}
+	mutate(&reg)
+	str, err := signToken(&accessClaims[map[string]any]{RegisteredClaims: reg, Type: tokenTypeAccess}, s.priv, "k1")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return str
+}
+
+func (s signer) verify(t *testing.T, tokenStr string) error {
+	t.Helper()
+	_, err := verifyAccessToken[map[string]any](tokenStr, s.keys, time.Now(), optIssuer, optAudience, 0)
+	return err
+}
+
+// A token with no exp never expires. WithExpirationRequired is the only thing
+// that refuses one.
+func TestVerifyAccessToken_refusesATokenWithNoExpiry(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) { c.ExpiresAt = nil })
+
+	if err := s.verify(t, tok); err == nil {
+		t.Fatal("a token with no exp claim must be refused — it would never expire")
+	}
+}
+
+func TestVerifyAccessToken_refusesAnExpiredToken(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) {
+		c.ExpiresAt = gjwt.NewNumericDate(time.Now().Add(-time.Hour))
+	})
+
+	err := s.verify(t, tok)
+	if !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("want ErrTokenExpired, got: %v", err)
+	}
+}
+
+// Issuer and audience are what stop a token minted by the same key for a
+// different service being replayed here.
+func TestVerifyAccessToken_refusesAnotherServicesIssuer(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) { c.Issuer = "other.example" })
+
+	if err := s.verify(t, tok); err == nil {
+		t.Fatal("a token issued by another service must be refused")
+	}
+}
+
+func TestVerifyAccessToken_refusesAnotherServicesAudience(t *testing.T) {
+	s := newSigner(t)
+	tok := s.sign(t, func(c *gjwt.RegisteredClaims) { c.Audience = gjwt.ClaimStrings{"other.example"} })
+
+	if err := s.verify(t, tok); err == nil {
+		t.Fatal("a token addressed to another audience must be refused")
+	}
+}
+
+// The length cap refuses an oversized token before any parsing, so a hostile
+// caller cannot make the parser chew through megabytes.
+//
+// The oversized token has to be otherwise *valid*. My first version passed a
+// string of filler, which the parser rejects as malformed whether or not the
+// cap exists — so deleting the cap left the test green. Padding a properly
+// signed token past the limit is what makes the cap the only thing that can
+// refuse it.
+func (s signer) oversizedButValid(t *testing.T) string {
+	t.Helper()
+	now := time.Now()
+	tok, err := signToken(&accessClaims[map[string]any]{
+		RegisteredClaims: gjwt.RegisteredClaims{
+			Issuer:    optIssuer,
+			Subject:   optSubject,
+			Audience:  gjwt.ClaimStrings{optAudience},
+			IssuedAt:  gjwt.NewNumericDate(now.Add(-time.Minute)),
+			ExpiresAt: gjwt.NewNumericDate(now.Add(time.Hour)),
+			ID:        "jti",
+		},
+		Type:  tokenTypeAccess,
+		Extra: map[string]any{"padding": strings.Repeat("a", maxTokenLen)},
+	}, s.priv, "k1")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if len(tok) <= maxTokenLen {
+		t.Fatalf("fixture is only %d bytes, needs to exceed %d", len(tok), maxTokenLen)
+	}
+	return tok
+}
+
+func TestVerifyAccessToken_refusesAnOversizedToken(t *testing.T) {
+	s := newSigner(t)
+
+	err := s.verify(t, s.oversizedButValid(t))
+	if !errors.Is(err, ErrTokenMalformed) {
+		t.Fatalf("want ErrTokenMalformed for a valid token over %d bytes, got: %v", maxTokenLen, err)
+	}
+}
+
+func TestVerifyRefreshToken_refusesAnOversizedToken(t *testing.T) {
+	s := newSigner(t)
+
+	_, err := verifyRefreshToken(s.oversizedButValid(t), s.keys, time.Now(), optIssuer, optAudience, 0)
+	if !errors.Is(err, ErrTokenMalformed) {
+		t.Fatalf("want ErrTokenMalformed for a valid token over %d bytes, got: %v", maxTokenLen, err)
+	}
+}

--- a/auth/oauth/jwks_bounds_internal_test.go
+++ b/auth/oauth/jwks_bounds_internal_test.go
@@ -1,0 +1,107 @@
+package oauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// The bounds in parseJWK reject key material a hostile or broken JWKS document
+// can otherwise hand the verifier: an undersized RSA modulus that is cheap to
+// factor, an oversized one that turns every verification into a CPU sink, and
+// EC coordinates outside the field. Every one of them survived being deleted
+// with the suite green, because the end-to-end tests build only well-formed
+// keys — so they are driven here directly.
+
+func b64(i *big.Int) string { return base64.RawURLEncoding.EncodeToString(i.Bytes()) }
+
+func rsaJWK(t *testing.T, bits int) jwk {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		t.Fatalf("generate %d-bit RSA key: %v", bits, err)
+	}
+	return jwk{Kty: "RSA", N: b64(k.N), E: b64(big.NewInt(int64(k.E)))}
+}
+
+func TestParseJWK_rejectsAnUndersizedRSAModulus(t *testing.T) {
+	// 1024 bits is generatable and plausible-looking, and well under the floor.
+	_, err := parseJWK(rsaJWK(t, 1024))
+	if err == nil {
+		t.Fatal("a 1024-bit RSA key must be refused")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+func TestParseJWK_acceptsAnRSAKeyAtTheFloor(t *testing.T) {
+	if _, err := parseJWK(rsaJWK(t, 2048)); err != nil {
+		t.Fatalf("2048 bits is the floor and must be accepted, got: %v", err)
+	}
+}
+
+func TestParseJWK_rejectsAnOversizedRSAModulus(t *testing.T) {
+	// Generating a >16384-bit key takes minutes, so the modulus is synthesised
+	// directly: parseJWK only measures its bit length.
+	huge := new(big.Int).Lsh(big.NewInt(1), 16385)
+	_, err := parseJWK(jwk{Kty: "RSA", N: b64(huge), E: b64(big.NewInt(65537))})
+	if err == nil {
+		t.Fatal("a 16385-bit modulus must be refused — every verification would be a modexp on it")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+func TestParseJWK_rejectsECCoordinatesOutsideTheField(t *testing.T) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate P-256 key: %v", err)
+	}
+	// One coordinate longer than the curve's field size: on curve arithmetic it
+	// is meaningless, and it is what the length bound exists to catch.
+	oversized := new(big.Int).Lsh(big.NewInt(1), 8*33)
+
+	_, err = parseJWK(jwk{Kty: "EC", Crv: "P-256", X: b64(oversized), Y: b64(k.Y)})
+	if err == nil {
+		t.Fatal("an x coordinate wider than the field must be refused")
+	}
+}
+
+func TestParseJWK_supportsEveryCurveItClaims(t *testing.T) {
+	// The provider chooses the curve, so all three advertised ones have to work
+	// — only P-256 was exercised before.
+	for name, curve := range map[string]elliptic.Curve{
+		"P-256": elliptic.P256(),
+		"P-384": elliptic.P384(),
+		"P-521": elliptic.P521(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			k, err := ecdsa.GenerateKey(curve, rand.Reader)
+			if err != nil {
+				t.Fatalf("generate %s key: %v", name, err)
+			}
+			got, err := parseJWK(jwk{Kty: "EC", Crv: name, X: b64(k.X), Y: b64(k.Y)})
+			if err != nil {
+				t.Fatalf("%s must be supported, got: %v", name, err)
+			}
+			pub, ok := got.(*ecdsa.PublicKey)
+			if !ok || pub.Curve != curve {
+				t.Fatalf("%s parsed into the wrong key type or curve: %T", name, got)
+			}
+		})
+	}
+}
+
+func TestParseJWK_rejectsAnUnknownCurve(t *testing.T) {
+	_, err := parseJWK(jwk{Kty: "EC", Crv: "P-999", X: b64(big.NewInt(1)), Y: b64(big.NewInt(1))})
+	if err == nil {
+		t.Fatal("an unknown curve must be refused rather than defaulted")
+	}
+}

--- a/auth/oauth/oauth_hardening_test.go
+++ b/auth/oauth/oauth_hardening_test.go
@@ -299,3 +299,25 @@ func TestVerifyIDToken_encUseKeySkipped(t *testing.T) {
 		t.Error("an enc-use key must not verify a token signature")
 	}
 }
+
+// An ID token with no "sub" identifies nobody. Accepting one hands the consumer
+// an empty subject, which their storage layer is liable to treat as a real
+// account key. The guard that rejects it survived being deleted with the suite
+// green — every other test signs a token that has a subject.
+func TestVerifyIDToken_rejectsATokenWithNoSubject(t *testing.T) {
+	key := mustRSA(t)
+	srv := jwksServer(t, &key.PublicKey)
+	c := newClient(t, srv)
+
+	claims := validClaims(srv.URL, "n")
+	delete(claims, "sub")
+	tok := signIDToken(t, key, testKID, claims)
+
+	_, err := c.VerifyIDToken(context.Background(), tok, "n")
+	if err == nil {
+		t.Fatal("an ID token without a subject must be refused")
+	}
+	if !strings.Contains(err.Error(), "subject") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}

--- a/auth/oauth/redirect_internal_test.go
+++ b/auth/oauth/redirect_internal_test.go
@@ -1,0 +1,68 @@
+package oauth
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// safeRedirect applies four guards in order — hop count, https, private host,
+// same origin — and the first two make the last two unreachable from any test
+// that redirects between local servers: an httptest server is plaintext on a
+// loopback address, so the scheme and private-host guards fire long before the
+// hop count or the origin check can. That is why the end-to-end redirect test
+// stays green when either of those is deleted, and why they are exercised here
+// against the function directly instead.
+func req(t *testing.T, raw string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return &http.Request{URL: u, Host: u.Host}
+}
+
+func TestSafeRedirect(t *testing.T) {
+	const origin = "https://provider.example/token"
+
+	for name, tc := range map[string]struct {
+		to   string
+		hops int
+		want string // substring of the expected rejection, "" means allowed
+	}{
+		"same origin is allowed":         {to: "https://provider.example/token2", want: ""},
+		"cross-origin leaks the secret":  {to: "https://evil.example/steal", want: "cross-origin"},
+		"plaintext downgrade":            {to: "http://provider.example/token", want: "non-https"},
+		"cloud metadata endpoint":        {to: "https://169.254.169.254/latest", want: "private host"},
+		"loopback":                       {to: "https://127.0.0.1/token", want: "private host"},
+		"private range":                  {to: "https://10.0.0.5/token", want: "private host"},
+		"too many hops on the same host": {to: "https://provider.example/token", hops: 5, want: "too many redirects"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			hops := tc.hops
+			if hops == 0 {
+				hops = 1
+			}
+			via := make([]*http.Request, hops)
+			for i := range via {
+				via[i] = req(t, origin)
+			}
+
+			err := safeRedirect(req(t, tc.to), via)
+
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("redirect to %q should be allowed, got: %v", tc.to, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("redirect to %q must be refused", tc.to)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("redirect to %q refused for the wrong reason: want %q, got: %v", tc.to, tc.want, err)
+			}
+		})
+	}
+}

--- a/auth/password/phc_bounds_internal_test.go
+++ b/auth/password/phc_bounds_internal_test.go
@@ -1,0 +1,105 @@
+package password
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// Verify derives the key with the parameters carried *inside the stored hash*,
+// not the module's own config — that is what keeps old hashes valid after the
+// work factors are tuned up. It also means a stored string decides how much
+// memory and time the verification costs, so the bounds in parsePHC are the
+// only thing standing between a hostile or corrupted row and a 16 GiB
+// allocation on the next login attempt.
+//
+// These assert at parsePHC rather than through Verify on purpose: parsePHC
+// rejects before argon2.IDKey is ever called, so the test proves the rejection
+// without asking the machine to attempt the allocation it is guarding against.
+
+// phc builds a PHC string with the given parameters and, crucially, a salt and
+// key of exactly the lengths parsePHC requires.
+//
+// That detail is the whole point. The bound tests that already existed used a
+// hand-written string with a four-byte salt — "$argon2id$v=19$m=4000000000,
+// t=3,p=2$c2FsdA$a2V5" — so parsePHC rejected them on the salt-length check
+// and never reached the parameter bounds. Every one of those bounds could be
+// deleted with the suite green.
+func phc(t *testing.T, algo string, version, memory, iterations, parallelism int) string {
+	t.Helper()
+	salt := base64.RawStdEncoding.EncodeToString(bytes.Repeat([]byte{0x01}, saltLen))
+	key := base64.RawStdEncoding.EncodeToString(bytes.Repeat([]byte{0x02}, keyLen))
+	return fmt.Sprintf("$%s$v=%d$m=%d,t=%d,p=%d$%s$%s", algo, version, memory, iterations, parallelism, salt, key)
+}
+
+func TestParsePHC_boundsAndLabels(t *testing.T) {
+	const okMem, okIter, okPar = minMemory, 3, 1
+
+	for name, tc := range map[string]struct {
+		hash string
+		want string
+	}{
+		"a different algorithm is not silently treated as argon2id": {
+			hash: phc(t, "argon2i", argon2.Version, okMem, okIter, okPar),
+			want: "argon2id",
+		},
+		"a different argon2 version is refused": {
+			hash: phc(t, "argon2id", argon2.Version+1, okMem, okIter, okPar),
+			want: "version",
+		},
+		"memory below the floor is refused": {
+			hash: phc(t, "argon2id", argon2.Version, minMemory-1, okIter, okPar),
+			want: "memory",
+		},
+		"memory above the ceiling is refused — it is what Verify would allocate": {
+			hash: phc(t, "argon2id", argon2.Version, maxMemory+1, okIter, okPar),
+			want: "memory",
+		},
+		"zero iterations is refused": {
+			hash: phc(t, "argon2id", argon2.Version, okMem, 0, okPar),
+			want: "iterations",
+		},
+		"iterations above the ceiling is refused — it is what Verify would spend": {
+			hash: phc(t, "argon2id", argon2.Version, okMem, maxIterations+1, okPar),
+			want: "iterations",
+		},
+		"zero parallelism is refused": {
+			hash: phc(t, "argon2id", argon2.Version, okMem, okIter, 0),
+			want: "parallelism",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, _, err := parsePHC(tc.hash)
+			if err == nil {
+				t.Fatal("this hash string must be refused before any key derivation")
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tc.want) {
+				t.Fatalf("refused for the wrong reason: want something about %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// The bounds must not reject what Hash itself produces — the fixture above is
+// only trustworthy if the real thing passes the same parser.
+func TestParsePHC_acceptsWhatHashProduces(t *testing.T) {
+	h, err := newMod(t).Hash("Correct-Horse-Battery-Staple-9")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if _, _, _, err := parsePHC(h); err != nil {
+		t.Fatalf("a hash this module produced must parse: %v", err)
+	}
+}
+
+// And the fixture itself has to be accepted when nothing is out of range,
+// otherwise the rejections above prove nothing.
+func TestParsePHC_acceptsTheFixtureWhenInRange(t *testing.T) {
+	if _, _, _, err := parsePHC(phc(t, "argon2id", argon2.Version, minMemory, 3, 1)); err != nil {
+		t.Fatalf("an in-range fixture must parse, or the bound tests are meaningless: %v", err)
+	}
+}

--- a/internal/keymanager/keymanager_test.go
+++ b/internal/keymanager/keymanager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/Glyndor/authcore/internal/keymanager"
@@ -30,60 +31,73 @@ func newKM(t *testing.T) *keymanager.KeyManager {
 
 // ----- generation -------------------------------------------------------------
 
+// seedValidDir returns a key directory holding a complete, valid set of key
+// files. The oversized-file tests start from one because New checks the
+// directory for consistency *before* it loads anything: a directory with two of
+// the three files is rejected as partially populated and never reaches the
+// capped reader at all.
+func seedValidDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := keymanager.New(dir, testLogger{t}); err != nil {
+		t.Fatalf("seed keymanager.New(): %v", err)
+	}
+	return dir
+}
+
+// assertSizeCapError fails unless err is the size-cap rejection. Asserting only
+// that some error came back is what let these tests pass for three releases
+// while never executing the cap they are named for.
+func assertSizeCapError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error for a file over the size cap, got nil")
+	}
+	if !strings.Contains(err.Error(), "cap") {
+		t.Fatalf("expected the size-cap error, got a different failure: %v", err)
+	}
+}
+
 func TestNew_oversizedKeyFileRejected(t *testing.T) {
 	// A valid Ed25519 PEM is ~200 bytes. An attacker-replaced key file
-	// several megabytes long would previously be loaded whole into
-	// memory before pem.Decode rejected it. The capped reader must
-	// surface a size error before the allocation.
-	dir := t.TempDir()
+	// several megabytes long would otherwise be loaded whole into memory
+	// before pem.Decode rejected it. The capped reader must surface a size
+	// error before the allocation.
+	dir := seedValidDir(t)
 	oversized := make([]byte, 100*1024) // 100 KiB, well above the 4 KiB cap
-	// Pair both key files so New() takes the "load existing" branch.
 	if err := os.WriteFile(filepath.Join(dir, "ed25519_private.pem"), oversized, 0600); err != nil {
-		t.Fatalf("seed oversized private key: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "ed25519_public.pem"), []byte("fake"), 0644); err != nil {
-		t.Fatalf("seed public key: %v", err)
+		t.Fatalf("replace private key with an oversized file: %v", err)
 	}
 
 	_, err := keymanager.New(dir, testLogger{t})
-	if err == nil {
-		t.Fatal("expected error when private key file exceeds size cap, got nil")
-	}
+	assertSizeCapError(t, err)
 }
 
 func TestNew_oversizedPublicKeyFileRejected(t *testing.T) {
 	// Regression guard for the public-key read path. Both key files must
 	// be size-capped; if only the private side is checked an attacker who
 	// can swap the public file still breaks startup.
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "ed25519_private.pem"), []byte("fake-but-small"), 0600); err != nil {
-		t.Fatalf("seed private key: %v", err)
-	}
+	dir := seedValidDir(t)
 	oversized := make([]byte, 100*1024)
 	if err := os.WriteFile(filepath.Join(dir, "ed25519_public.pem"), oversized, 0644); err != nil {
-		t.Fatalf("seed oversized public key: %v", err)
+		t.Fatalf("replace public key with an oversized file: %v", err)
 	}
 
 	_, err := keymanager.New(dir, testLogger{t})
-	if err == nil {
-		t.Fatal("expected error when public key file exceeds size cap, got nil")
-	}
+	assertSizeCapError(t, err)
 }
 
 func TestNew_oversizedRefreshSecretRejected(t *testing.T) {
 	// The refresh secret loader shares the same capped reader. A ~100 KiB
 	// secret file must be refused before it is hex-decoded.
-	dir := t.TempDir()
-	// Let the key-pair step succeed by letting New() generate fresh keys.
+	dir := seedValidDir(t)
 	oversized := make([]byte, 100*1024)
 	if err := os.WriteFile(filepath.Join(dir, "refresh_secret.key"), oversized, 0600); err != nil {
-		t.Fatalf("seed oversized refresh secret: %v", err)
+		t.Fatalf("replace refresh secret with an oversized file: %v", err)
 	}
 
 	_, err := keymanager.New(dir, testLogger{t})
-	if err == nil {
-		t.Fatal("expected error when refresh secret file exceeds size cap, got nil")
-	}
+	assertSizeCapError(t, err)
 }
 
 func TestNew_generatesAllFiles(t *testing.T) {


### PR DESCRIPTION
Release PR for v1.11.6.

### What changes for a consumer

Nothing. There is no code change in this release — every commit is a test or a CI caller. It is worth cutting anyway so `main` does not drift behind `develop`, which is the state that left the MIT relicense undelivered for a day earlier this week.

### What it is

A sweep for tests that pass for the wrong reason (#229), which found **sixteen security controls that could be deleted with the suite staying green**, across four modules:

- **`auth/jwt`** (#233) — the EdDSA algorithm check, `WithExpirationRequired`, `WithIssuer`, `WithAudience`, and the 8 KiB length cap on both the access and refresh paths. Without `WithExpirationRequired` a token carrying no `exp` is accepted, and it never expires.
- **`auth/oauth`** (#232) — the redirect hop limit, the cross-origin redirect check, the RSA modulus bounds, the EC coordinate bounds, and the rejection of an ID token with no `sub`. `P-384` and `P-521` had never been parsed, though the module advertises both.
- **`auth/password`** (#234) — the argon2id algorithm label, the version, and the memory, iteration and parallelism ranges. Tests for these already existed with the right names; their fixture had a four-byte salt, so `parsePHC` refused it on the length check and never reached the bounds. Those bounds are what stand between a stored hash and a multi-gigabyte allocation on the next login, because `Verify` derives the key with the parameters carried inside the hash.
- **`internal/keymanager`** (#228) — the 4 KiB key-file cap, whose three dedicated tests seeded a partial directory so the consistency check failed first.

Also here: the repository now asserts from ordinary CI that its scheduled `audit` and `fuzz` are still firing (#226, #219), using the new `schedule-freshness` reusable in `Glyndor/.github` v1.11.0.

### Verified on go1.26.5

`go build`, `go vet`, `golangci-lint` (0 issues), `go test -race ./...` across all nine packages, and `govulncheck` reporting no vulnerabilities. Coverage 92.3%, up from 91.0%: `auth/jwt` 95.0%, `auth/oauth` 90.2%, `internal/keymanager` 88.9%.

Every test added here was confirmed by deleting the control it names and watching it fail. Three of them needed a second attempt because the first version passed under mutation — the failure modes are recorded in the individual pull requests rather than smoothed over.
