### PR TITLE
ci: group the example dependency updates into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,15 @@ updates:
       prefix: "build"
       include: "scope"
 
-  # The examples are standalone Go modules (own go.mod + local replace), so the
-  # root entry above does not see them. Track them too — otherwise an example
+  # The examples are standalone Go modules with their own go.mod, so the root
+  # entry above does not see them. Track them too — otherwise an example
   # dependency drifts and accumulates advisories unmonitored.
+  #
+  # Grouped, because there are nine of them and they move together. Since the
+  # examples stopped using a `replace` and started requiring the published
+  # version (#213), every release makes authcore itself a dependency that has
+  # drifted in all nine at once: v1.11.6 produced ten separate pull requests
+  # that all said the same thing. One group is one review.
   - package-ecosystem: "gomod"
     directories:
       - "/examples/*"
@@ -24,6 +30,10 @@ updates:
     labels:
       - "type:deps"
     open-pull-requests-limit: 10
+    groups:
+      examples:
+        patterns:
+          - "*"
     commit-message:
       prefix: "build"
       include: "scope"


### PR DESCRIPTION
v1.11.6 produced **ten** pull requests that all said the same thing — #235 through #244, each bumping `github.com/Glyndor/authcore` in one example module, all of them already stale by one patch before anyone looked at them.

That cost is mine. Dropping the `replace` in #213 was right — it stopped the examples claiming versions that never applied (v1.1.1, v1.2.2, v1.9.0, v1.10.6, all masked by the replace) and gave anyone copying a directory out of the tree a `require` that means something. But it also made authcore a tracked dependency of all nine example modules, so every release drifts them in lockstep.

A group is what they were all along: they move together by construction. One group, one review, and the versions stay honest.

The root module keeps its own ungrouped entry. A bump there changes what a consumer actually resolves and deserves to be looked at on its own — which is exactly what happened with `x/crypto` 0.54.0 this week.

Validated the file parses and carries the group. The existing ten will close themselves once Dependabot regroups on its next daily run; I would rather let it do that than merge ten stale pull requests by hand.