### PR TITLE
test: close the sweep across the remaining modules

### DIFF
--- a/auth/email/email_test.go
+++ b/auth/email/email_test.go
@@ -428,3 +428,44 @@ func TestVerifyDomain_dnsFailureCachesNegativeBriefly(t *testing.T) {
 		t.Errorf("negative DNS failure TTL should be ≤30 s, got %v", time.Until(entry.expiresAt))
 	}
 }
+
+// TestValidate_tooLong above builds a ~249-character local part, so it is
+// refused by the 64-character local-part rule and never reaches the total
+// length check — deleting the 254 guard leaves it green. A total over 254 has
+// to be assembled from parts that are each individually legal.
+func TestValidate_tooLongWithEveryPartIndividuallyLegal(t *testing.T) {
+	local := strings.Repeat("a", 60) // under the 64 limit
+	label := strings.Repeat("b", 60) // under the 63-byte DNS label limit
+	domain := label + "." + label + "." + label + "." + label + ".com"
+	address := local + "@" + domain
+
+	if len(address) <= 254 {
+		t.Fatalf("fixture is only %d characters, it has to exceed 254 to test anything", len(address))
+	}
+	if len(local) > 64 {
+		t.Fatal("fixture's local part breaks its own premise")
+	}
+
+	err := validate(address)
+	if !errors.Is(err, ErrInvalidEmail) {
+		t.Fatalf("an address over 254 characters must be refused, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "254") {
+		t.Fatalf("refused for the wrong reason — the length guard is not what caught it: %v", err)
+	}
+}
+
+// The companion: the same shape just under the limit has to be accepted, or
+// the test above would pass for any address at all.
+func TestValidate_acceptsALongButLegalAddress(t *testing.T) {
+	local := strings.Repeat("a", 60)
+	label := strings.Repeat("b", 60)
+	address := local + "@" + label + "." + label + ".com"
+
+	if len(address) > 254 {
+		t.Fatalf("fixture is %d characters, it has to stay under 254", len(address))
+	}
+	if err := validate(address); err != nil {
+		t.Fatalf("a long but legal address must be accepted: %v", err)
+	}
+}

--- a/internal/keymanager/generate_paths_internal_test.go
+++ b/internal/keymanager/generate_paths_internal_test.go
@@ -1,0 +1,106 @@
+package keymanager
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// If the public key cannot be written after the private one already has been,
+// the private key is removed again — otherwise the next start finds a
+// half-populated directory and refuses to run at all. The cleanup is
+// unreachable through New, because checkKeyDirConsistency rejects a partial
+// directory before generation is ever attempted, so it is driven directly.
+//
+// A directory standing where the file should go makes the write fail on every
+// platform without needing permission games.
+func TestGenerateAndSaveEd25519_removesThePrivateKeyIfThePublicWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	privPath := filepath.Join(dir, filePrivateKey)
+	pubPath := filepath.Join(dir, filePublicKey)
+	if err := os.Mkdir(pubPath, 0700); err != nil {
+		t.Fatalf("plant a directory at the public key path: %v", err)
+	}
+
+	_, _, err := generateAndSaveEd25519(privPath, pubPath)
+	if err == nil {
+		t.Fatal("the generation must fail when the public key cannot be written")
+	}
+	if _, err := os.Stat(privPath); !os.IsNotExist(err) {
+		t.Fatalf("the private key must not survive a failed pair write, stat gave: %v", err)
+	}
+}
+
+func TestGenerateAndSaveEd25519_failsWhenThePrivateKeyCannotBeWritten(t *testing.T) {
+	dir := t.TempDir()
+	privPath := filepath.Join(dir, filePrivateKey)
+	if err := os.Mkdir(privPath, 0700); err != nil {
+		t.Fatalf("plant a directory at the private key path: %v", err)
+	}
+
+	if _, _, err := generateAndSaveEd25519(privPath, filepath.Join(dir, filePublicKey)); err == nil {
+		t.Fatal("the generation must fail when the private key cannot be written")
+	}
+}
+
+func TestGenerateAndSaveRefreshSecret_failsWhenItCannotBeWritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, fileRefreshSecret)
+	if err := os.Mkdir(path, 0700); err != nil {
+		t.Fatalf("plant a directory at the secret path: %v", err)
+	}
+
+	if _, err := generateAndSaveRefreshSecret(path); err == nil {
+		t.Fatal("the generation must fail when the secret cannot be written")
+	}
+}
+
+// A descriptor that cannot be read at all is not the same as one that is
+// absent: absent means the pre-marker layout and is adopted, while unreadable
+// means the loader cannot tell what wrote the directory and must fail closed.
+func TestNew_refusesAnUnreadableDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := New(dir, testLoggerInternal{t}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	path := filepath.Join(dir, fileMetadata)
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove descriptor: %v", err)
+	}
+	if err := os.Mkdir(path, 0700); err != nil {
+		t.Fatalf("plant a directory at the descriptor path: %v", err)
+	}
+
+	if _, err := New(dir, testLoggerInternal{t}); err == nil {
+		t.Fatal("an unreadable descriptor must fail closed, not be treated as absent")
+	}
+}
+
+// KeyID is exported for the JWT module to index rotated keys by the same
+// derivation. Its own package never called it, so it read as 0% while being
+// exercised from next door — asserted here so the number stops lying.
+func TestKeyID_matchesTheManagersOwnDerivation(t *testing.T) {
+	dir := t.TempDir()
+	km, err := New(dir, testLoggerInternal{t})
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	if got := KeyID(km.PublicKey()); got != km.KeyID() {
+		t.Fatalf("KeyID(pub) = %q, want the manager's own %q", got, km.KeyID())
+	}
+
+	other, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if KeyID(other) == km.KeyID() {
+		t.Fatal("two different keys must not share an id")
+	}
+}
+
+type testLoggerInternal struct{ t *testing.T }
+
+func (l testLoggerInternal) Info(msg string, args ...any) { l.t.Logf("[INFO] "+msg, args...) }
+func (l testLoggerInternal) Warn(msg string, args ...any) { l.t.Logf("[WARN] "+msg, args...) }


### PR DESCRIPTION
Fourth and last pass of #229, over `auth/email`, `auth/username`, `internal/keymanager` and the injected-material path in `keystore`.

**Sixteen guards mutated, fifteen already covered.** That is the first pass that came back mostly clean, and it is worth saying plainly rather than presenting the one finding as though the module were riddled. `auth/username` and the key-material validation in `internal/keymanager` — private and public key lengths, the pair matching, the refresh-secret length, the partial-directory refusal — all detected their own deletion.

### The one survivor

`auth/email`'s 254-character total length. `TestValidate_tooLong` built a 249-character local part, so the 64-character local-part rule refused it first and the total was never measured. Same shape as the size-cap tests in #227 and the PHC bounds in #234: **the fixture violated more than one rule, and an earlier guard fired.**

An address that reaches it has to be assembled from parts that are each individually legal — a 60-character local part and 60-character DNS labels — with a companion test asserting the same shape just under the limit is accepted. Without that second assertion the first would be satisfied by any rejection at all, which is the whole failure mode being fixed.

### Loader gaps in `internal/keymanager`

- **The cleanup that removes a freshly written private key when the public write fails** was the largest single gap in the package, at 55.6%. It is unreachable through `New` — `checkKeyDirConsistency` refuses a partial directory before generation is attempted — so it is driven directly, and asserts *the private key does not survive* rather than that an error came back. Planting a directory where a file should go makes the write fail on any platform, with no permission games.
- **An unreadable descriptor is now distinguished from an absent one.** Absent means the pre-marker layout and is adopted in place; unreadable means the loader cannot tell what wrote the directory and has to fail closed. Those are opposite behaviours from one missing file.
- **`KeyID` had been reading as 0%** while being exercised from the JWT module next door. It has its own assertion now, so the number stops lying.

### Measured

| package | before | now |
|---|---|---|
| `internal/keymanager` | 88.9% | **92.0%** |
| `auth/email` | 90.9% | **91.9%** |
| total | 92.3% | **92.9%** |

**Every package is over 90% for the first time**, which settles the substantive half of #218 — no package is hiding under the aggregate any more. The policy question there, whether the gate should be per-package, is unaffected and still open.

`go vet`, `golangci-lint` (0 issues) and `go test -race ./...` pass. Each new test was confirmed by deleting the control it names and watching it fail.
