### PR TITLE
release: v1.11.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,15 @@ updates:
       prefix: "build"
       include: "scope"
 
-  # The examples are standalone Go modules (own go.mod + local replace), so the
-  # root entry above does not see them. Track them too — otherwise an example
+  # The examples are standalone Go modules with their own go.mod, so the root
+  # entry above does not see them. Track them too — otherwise an example
   # dependency drifts and accumulates advisories unmonitored.
+  #
+  # Grouped, because there are nine of them and they move together. Since the
+  # examples stopped using a `replace` and started requiring the published
+  # version (#213), every release makes authcore itself a dependency that has
+  # drifted in all nine at once: v1.11.6 produced ten separate pull requests
+  # that all said the same thing. One group is one review.
   - package-ecosystem: "gomod"
     directories:
       - "/examples/*"
@@ -24,6 +30,10 @@ updates:
     labels:
       - "type:deps"
     open-pull-requests-limit: 10
+    groups:
+      examples:
+        patterns:
+          - "*"
     commit-message:
       prefix: "build"
       include: "scope"

--- a/auth/email/email_test.go
+++ b/auth/email/email_test.go
@@ -428,3 +428,44 @@ func TestVerifyDomain_dnsFailureCachesNegativeBriefly(t *testing.T) {
 		t.Errorf("negative DNS failure TTL should be ≤30 s, got %v", time.Until(entry.expiresAt))
 	}
 }
+
+// TestValidate_tooLong above builds a ~249-character local part, so it is
+// refused by the 64-character local-part rule and never reaches the total
+// length check — deleting the 254 guard leaves it green. A total over 254 has
+// to be assembled from parts that are each individually legal.
+func TestValidate_tooLongWithEveryPartIndividuallyLegal(t *testing.T) {
+	local := strings.Repeat("a", 60) // under the 64 limit
+	label := strings.Repeat("b", 60) // under the 63-byte DNS label limit
+	domain := label + "." + label + "." + label + "." + label + ".com"
+	address := local + "@" + domain
+
+	if len(address) <= 254 {
+		t.Fatalf("fixture is only %d characters, it has to exceed 254 to test anything", len(address))
+	}
+	if len(local) > 64 {
+		t.Fatal("fixture's local part breaks its own premise")
+	}
+
+	err := validate(address)
+	if !errors.Is(err, ErrInvalidEmail) {
+		t.Fatalf("an address over 254 characters must be refused, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "254") {
+		t.Fatalf("refused for the wrong reason — the length guard is not what caught it: %v", err)
+	}
+}
+
+// The companion: the same shape just under the limit has to be accepted, or
+// the test above would pass for any address at all.
+func TestValidate_acceptsALongButLegalAddress(t *testing.T) {
+	local := strings.Repeat("a", 60)
+	label := strings.Repeat("b", 60)
+	address := local + "@" + label + "." + label + ".com"
+
+	if len(address) > 254 {
+		t.Fatalf("fixture is %d characters, it has to stay under 254", len(address))
+	}
+	if err := validate(address); err != nil {
+		t.Fatalf("a long but legal address must be accepted: %v", err)
+	}
+}

--- a/internal/keymanager/generate_paths_internal_test.go
+++ b/internal/keymanager/generate_paths_internal_test.go
@@ -1,0 +1,106 @@
+package keymanager
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// If the public key cannot be written after the private one already has been,
+// the private key is removed again — otherwise the next start finds a
+// half-populated directory and refuses to run at all. The cleanup is
+// unreachable through New, because checkKeyDirConsistency rejects a partial
+// directory before generation is ever attempted, so it is driven directly.
+//
+// A directory standing where the file should go makes the write fail on every
+// platform without needing permission games.
+func TestGenerateAndSaveEd25519_removesThePrivateKeyIfThePublicWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	privPath := filepath.Join(dir, filePrivateKey)
+	pubPath := filepath.Join(dir, filePublicKey)
+	if err := os.Mkdir(pubPath, 0700); err != nil {
+		t.Fatalf("plant a directory at the public key path: %v", err)
+	}
+
+	_, _, err := generateAndSaveEd25519(privPath, pubPath)
+	if err == nil {
+		t.Fatal("the generation must fail when the public key cannot be written")
+	}
+	if _, err := os.Stat(privPath); !os.IsNotExist(err) {
+		t.Fatalf("the private key must not survive a failed pair write, stat gave: %v", err)
+	}
+}
+
+func TestGenerateAndSaveEd25519_failsWhenThePrivateKeyCannotBeWritten(t *testing.T) {
+	dir := t.TempDir()
+	privPath := filepath.Join(dir, filePrivateKey)
+	if err := os.Mkdir(privPath, 0700); err != nil {
+		t.Fatalf("plant a directory at the private key path: %v", err)
+	}
+
+	if _, _, err := generateAndSaveEd25519(privPath, filepath.Join(dir, filePublicKey)); err == nil {
+		t.Fatal("the generation must fail when the private key cannot be written")
+	}
+}
+
+func TestGenerateAndSaveRefreshSecret_failsWhenItCannotBeWritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, fileRefreshSecret)
+	if err := os.Mkdir(path, 0700); err != nil {
+		t.Fatalf("plant a directory at the secret path: %v", err)
+	}
+
+	if _, err := generateAndSaveRefreshSecret(path); err == nil {
+		t.Fatal("the generation must fail when the secret cannot be written")
+	}
+}
+
+// A descriptor that cannot be read at all is not the same as one that is
+// absent: absent means the pre-marker layout and is adopted, while unreadable
+// means the loader cannot tell what wrote the directory and must fail closed.
+func TestNew_refusesAnUnreadableDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := New(dir, testLoggerInternal{t}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	path := filepath.Join(dir, fileMetadata)
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove descriptor: %v", err)
+	}
+	if err := os.Mkdir(path, 0700); err != nil {
+		t.Fatalf("plant a directory at the descriptor path: %v", err)
+	}
+
+	if _, err := New(dir, testLoggerInternal{t}); err == nil {
+		t.Fatal("an unreadable descriptor must fail closed, not be treated as absent")
+	}
+}
+
+// KeyID is exported for the JWT module to index rotated keys by the same
+// derivation. Its own package never called it, so it read as 0% while being
+// exercised from next door — asserted here so the number stops lying.
+func TestKeyID_matchesTheManagersOwnDerivation(t *testing.T) {
+	dir := t.TempDir()
+	km, err := New(dir, testLoggerInternal{t})
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	if got := KeyID(km.PublicKey()); got != km.KeyID() {
+		t.Fatalf("KeyID(pub) = %q, want the manager's own %q", got, km.KeyID())
+	}
+
+	other, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if KeyID(other) == km.KeyID() {
+		t.Fatal("two different keys must not share an id")
+	}
+}
+
+type testLoggerInternal struct{ t *testing.T }
+
+func (l testLoggerInternal) Info(msg string, args ...any) { l.t.Logf("[INFO] "+msg, args...) }
+func (l testLoggerInternal) Warn(msg string, args ...any) { l.t.Logf("[WARN] "+msg, args...) }


### PR DESCRIPTION
Release PR for v1.11.7.

### What changes for a consumer

Nothing — every commit is a test. Cut anyway so `main` does not drift behind `develop`, which is the state that left the MIT relicence undelivered for a day earlier this week.

### What it is

The last pass of the sweep in #229 (#248), over `auth/email`, `auth/username`, `internal/keymanager` and the injected key material. Sixteen guards mutated, fifteen already covered — the first pass to come back mostly clean.

The one survivor was `auth/email`'s 254-character address limit: its test built a 249-character local part, so the 64-character local-part rule refused it first and the total was never measured.

Also closed the loader gaps in `internal/keymanager` — most importantly the cleanup that removes a freshly written private key when the public write fails, which is unreachable through `New` because the consistency check refuses a partial directory before generation is attempted.

**Every package is over 90% for the first time**, which settles the substantive half of #218:

| package | now |
|---|---|
| `internal/keymanager` | 92.0% |
| `auth/oauth` | 90.2% |
| `auth/email` | 91.9% |
| `auth/jwt` | 95.0% |
| `auth/password` | 95.8% |
| `auth/apikey` | 94.6% |
| `auth/username` | 97.5% |
| `authcore` | 98.1% |
| `internal/clock` | 100.0% |
| **total** | **92.9%** |

### Verified on go1.26.5

`go build`, `go vet`, `golangci-lint` (0 issues), `go test -race ./...` across all nine packages. Every test added was confirmed by deleting the control it names and watching it fail.
