### PR TITLE
ci: enforce the coverage floor per package, and keep the fuzz corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ permissions:
 
 jobs:
   go:
-    uses: Glyndor/.github/.github/workflows/go-ci.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/go-ci.yml@045903bf83a58651f119bc7d952aa45242b897c5
     with:
       coverage-threshold: 90
+      # Every package clears this today, which is exactly when a floor is
+      # cheapest to adopt. The aggregate alone let auth/oauth sit at 87.7% and
+      # internal/keymanager at 85.7% — the two with the most attack surface —
+      # while a fully covered clock helper paid for them.
+      per-package-coverage-threshold: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       # cheapest to adopt. The aggregate alone let auth/oauth sit at 87.7% and
       # internal/keymanager at 85.7% — the two with the most attack surface —
       # while a fully covered clock helper paid for them.
-      per-package-coverage-threshold: 96
+      per-package-coverage-threshold: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
       # cheapest to adopt. The aggregate alone let auth/oauth sit at 87.7% and
       # internal/keymanager at 85.7% — the two with the most attack surface —
       # while a fully covered clock helper paid for them.
-      per-package-coverage-threshold: 90
+      per-package-coverage-threshold: 96

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   fuzz:
-    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@045903bf83a58651f119bc7d952aa45242b897c5
     with:
       fuzztime: "60s"
       targets: >-


### PR DESCRIPTION
Closes #218. Closes #225. Adopts both halves of Glyndor/.github#106, and is the consumer that proves them before that repository gets a tag.

### Per-package coverage floor

This module ran at 91% against a gate of 90 while `auth/oauth` sat at 87.7% and `internal/keymanager` at 85.7%. The two with the most attack surface were the two thinnest, and `internal/clock` at 100% was paying for them.

Every package clears 90 today, which is exactly when a floor is cheapest to adopt — it locks in a state that already holds rather than demanding new work:

| package | coverage |
|---|---|
| `auth/oauth` | 90.2% |
| `auth/email` | 91.9% |
| `internal/keymanager` | 92.0% |
| `auth/apikey` | 94.6% |
| `auth/jwt` | 95.0% |
| `auth/password` | 95.8% |
| `auth/username` | 97.5% |
| `authcore` | 98.1% |
| `internal/clock` | 100.0% |

The measurement that made this decidable: comparing isolated profiles against `-coverpkg=./...` moves those packages by +0.5 and +0.0, so the per-package numbers are honest rather than an artefact of helpers being exercised from a sibling package.

### The fuzz corpus survives between runs

It never did. `setup-go` restores `GOCACHE` — where Go keeps the corpus — but on a cache hit does not save it again, so every discovery died with the runner and the next week re-explored the same ground from the seeds.

Measured here before changing anything: a cold 60s run of `FuzzParseJWK` finds 219 new interesting inputs, 300s finds 293. **A single run saturates well before its budget**, so the budget was never the constraint — starting from zero every week was. `fuzztime` is deliberately unchanged.

The compounding will not be visible in this pull request; the first scheduled run after it merges seeds the cache, and the one after that is the first to start warm.

### Pinned by SHA

`Glyndor/.github` is only tagged once a consumer has proved a workflow green, and this is that consumer. The pin moves to the release tag afterwards.