### PR TITLE
ci: put every org reusable on v1.12.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/go-audit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/go-audit.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
     with:
       # G104 (errcheck on logger Output) and G306 (public-key 0644) are justified
       # in code with //nolint:gosec; standalone gosec ignores those pragmas.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   go:
-    uses: Glyndor/.github/.github/workflows/go-ci.yml@045903bf83a58651f119bc7d952aa45242b897c5
+    uses: Glyndor/.github/.github/workflows/go-ci.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
     with:
       coverage-threshold: 90
       # Every package clears this today, which is exactly when a floor is

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/dco.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   fuzz:
-    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@045903bf83a58651f119bc7d952aa45242b897c5
+    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
     with:
       fuzztime: "60s"
       targets: >-

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@7099f8a9c8be91fa1732fe2402268b338771233f # v1.10.1
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0

--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -25,14 +25,14 @@ permissions:
 jobs:
   audit:
     name: audit freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2 # v1.11.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
     with:
       workflow: audit.yml
       max-age-days: 15 # weekly cron, so two periods of slack
 
   fuzz:
     name: fuzz freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@41d31f18d3ed3bb1a8cbbc44c68030e4867488b2 # v1.11.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
     with:
       workflow: fuzz.yml
       max-age-days: 15 # weekly cron, so two periods of slack


### PR DESCRIPTION
Seven callers were spread across three versions:

| caller | was | now |
|---|---|---|
| `ci.yml`, `fuzz.yml` | raw commit, no version comment | `# v1.12.0` |
| `schedule-freshness.yml` | v1.11.0 | v1.12.0 |
| `dco.yml`, `go-audit.yml`, `line-limit.yml`, `main-guard.yml` | v1.10.1 | v1.12.0 |

`ci` and `fuzz` were pinned bare on purpose — Glyndor/.github#106 was waiting for a consumer to prove it green before being tagged, and #257 was that consumer. Now that v1.12.0 exists they get their comment back.

That comment is not decoration. Without a version beside the SHA, Dependabot has nothing to compare against, never proposes a bump, and the pin rots — which is exactly how four of these ended up two releases behind while nobody noticed.

Supersedes #250, #251, #252 and #254, which each moved one caller to v1.11.0.

Verified with `actionlint` across all seven workflows.