### PR TITLE
ci: bump shared reusables to v1.18.1 and add the pin guards

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   audit:
-    uses: Glyndor/.github/.github/workflows/go-audit.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/go-audit.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       # G104 (errcheck on logger Output) and G306 (public-key 0644) are justified
       # in code with //nolint:gosec; standalone gosec ignores those pragmas.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   go:
-    uses: Glyndor/.github/.github/workflows/go-ci.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/go-ci.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       coverage-threshold: 90
       # Every package clears this today, which is exactly when a floor is
@@ -19,3 +19,11 @@ jobs:
       # internal/keymanager at 85.7% — the two with the most attack surface —
       # while a fully covered clock helper paid for them.
       per-package-coverage-threshold: 90
+
+  pin-policy:
+    uses: Glyndor/.github/.github/workflows/pin-policy-reusable.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+
+  dependabot-freshness:
+    uses: Glyndor/.github/.github/workflows/dependabot-freshness.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
+    with:
+      max-age-days: 15

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   dco:
-    uses: Glyndor/.github/.github/workflows/dco.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/dco.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   fuzz:
-    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/go-fuzz.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       fuzztime: "60s"
       targets: >-

--- a/.github/workflows/line-limit.yml
+++ b/.github/workflows/line-limit.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   line-limit:
-    uses: Glyndor/.github/.github/workflows/line-limit.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/line-limit.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -8,4 +8,4 @@ permissions: {}
 
 jobs:
   develop-only:
-    uses: Glyndor/.github/.github/workflows/main-guard.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/main-guard.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1

--- a/.github/workflows/schedule-freshness.yml
+++ b/.github/workflows/schedule-freshness.yml
@@ -25,14 +25,14 @@ permissions:
 jobs:
   audit:
     name: audit freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       workflow: audit.yml
       max-age-days: 15 # weekly cron, so two periods of slack
 
   fuzz:
     name: fuzz freshness
-    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@045903bf83a58651f119bc7d952aa45242b897c5 # v1.12.0
+    uses: Glyndor/.github/.github/workflows/schedule-freshness.yml@d4bbc5b6ec0c351ca4cb17d948ceaad818da4078 # v1.18.1
     with:
       workflow: fuzz.yml
       max-age-days: 15 # weekly cron, so two periods of slack


### PR DESCRIPTION
I bumped every Glyndor/.github reusable in this repo from v1.12.0 to v1.18.1 (SHA `d4bbc5b6ec0c351ca4cb17d948ceaad818da4078`):

| caller | was | now |
|---|---|---|
| `ci.yml` (go-ci) | v1.12.0 | v1.18.1 |
| `audit.yml` (go-audit) | v1.12.0 | v1.18.1 |
| `fuzz.yml` (go-fuzz) | v1.12.0 | v1.18.1 |
| `dco.yml` | v1.12.0 | v1.18.1 |
| `line-limit.yml` | v1.12.0 | v1.18.1 |
| `main-guard.yml` | v1.12.0 | v1.18.1 |
| `schedule-freshness.yml` (x2) | v1.12.0 | v1.18.1 |

The trailing comments now point at a real tag, which is what lets Dependabot resolve and bump them later.

I also added the two guard jobs to `ci.yml` so the pins do not go stale again:

* **pin-policy** — fails the PR if any pin's SHA is no longer the surface tagged by the latest Glyndor/.github release.
* **dependabot-freshness** — fails the PR if Dependabot has not opened a PR in the last 15 days. Dependabot has silently died here before with a valid config, and silence is otherwise indistinguishable from "nothing to update".

Both jobs inherit the file-level `permissions: contents: read`; I did not add per-job permissions blocks.

Verified locally with:

```sh
grep -rn 'Glyndor/\.github/\.github/workflows/' .github/workflows/ | grep -v 'd4bbc5b6ec0c351ca4cb17d948ceaad818da4078' || echo "OK: all pins current"
grep -rn 'Glyndor/\.github' .github/workflows/ | grep -v '# v1.18.1' || echo "OK: all comments correct"
grep -c 'pin-policy-reusable\|dependabot-freshness' .github/workflows/ci.yml
python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" .github/workflows/*.yml && echo "OK: yaml parses"
```