### PR TITLE
fix(deps): require go 1.26.6 to close four reachable stdlib vulnerabilities

### DIFF
--- a/examples/apikey/go.mod
+++ b/examples/apikey/go.mod
@@ -1,5 +1,5 @@
 module github.com/Glyndor/authcore/examples/apikey
 
-go 1.26.5
+go 1.26.6
 
 require github.com/Glyndor/authcore v1.11.6

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,5 +1,5 @@
 module github.com/Glyndor/authcore/examples/basic
 
-go 1.26.5
+go 1.26.6
 
 require github.com/Glyndor/authcore v1.11.6

--- a/examples/email/go.mod
+++ b/examples/email/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/email
 
-go 1.26.5
+go 1.26.6
 
 require github.com/Glyndor/authcore v1.11.6
 

--- a/examples/fiber/go.mod
+++ b/examples/fiber/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/fiber
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Glyndor/authcore v1.11.6

--- a/examples/gin/go.mod
+++ b/examples/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/gin
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Glyndor/authcore v1.11.6

--- a/examples/go.work
+++ b/examples/go.work
@@ -15,7 +15,7 @@
 // them against the versions gin and fiber elevate rather than the ones authcore
 // declares. One level down, the library is tested as a consumer gets it.
 
-go 1.26.5
+go 1.26.6
 
 use (
 	../

--- a/examples/jwt/go.mod
+++ b/examples/jwt/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/jwt
 
-go 1.26.5
+go 1.26.6
 
 require github.com/Glyndor/authcore v1.11.6
 

--- a/examples/oauth/go.mod
+++ b/examples/oauth/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/oauth
 
-go 1.26.5
+go 1.26.6
 
 require github.com/Glyndor/authcore v1.11.6
 

--- a/examples/password/go.mod
+++ b/examples/password/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore/examples/password
 
-go 1.26.5
+go 1.26.6
 
 require github.com/Glyndor/authcore v1.11.6
 

--- a/examples/username/go.mod
+++ b/examples/username/go.mod
@@ -1,5 +1,5 @@
 module github.com/Glyndor/authcore/examples/username
 
-go 1.26.5
+go 1.26.6
 
 require github.com/Glyndor/authcore v1.11.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Glyndor/authcore
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
Closes #327.

`govulncheck` has been red on the scheduled `audit.yml` run since 2026-08-17, reporting four standard library vulnerabilities my code calls. All four are fixed in go 1.26.6 while the directive declared 1.26.5, so raising it is the whole remediation: the directive is the floor toolchain selection honours, which is what puts a consumer on a patched standard library. Same shape as #216 and #172, both of which shipped as PATCH releases.

Eleven files, one line each: the root module, the nine example modules, and `examples/go.work`. The examples move with the root because `examples.yml` reads `go-version-file` per example, so leaving them behind would run their CI on a floor the library no longer declares.

### What I measured

| Check | go 1.26.5 | go 1.26.6 |
|---|---|---|
| `govulncheck ./...` | exit 3, 4 vulnerabilities my code calls | exit 0, **No vulnerabilities found** |
| `go test -race ./...` | | 9/9 packages pass |
| Nine examples, `go build && go vet` | | 9/9 pass, one package each |

The 1.26.5 column is a control run rather than the CI log: I put the directive back, re-ran, read the same four advisories, then restored 1.26.6. Without that column a clean scan proves only that the scan ran.

The toolchain selected 1.26.6 on its own once the directive moved, and `go env GOWORK` is still empty at the repository root, so the library is tested against the versions it declares rather than the ones gin and fiber elevate.

### What this leaves alone

`GO-2026-5932` against `golang.org/x/crypto` still shows as a vulnerability in a module I require but do not call. It is the standing advisory that `x/crypto/openpgp` is unmaintained and unsafe by design, `Fixed in: N/A`, applying to every version of the module since 0. Nothing here imports `openpgp`.

### After this merges

`audit.yml` goes green on its next Monday run, which clears `audit freshness / schedule freshness` and takes the nine pin bumps (#316 to #324) out of `UNSTABLE`. v1.11.7 is what `go get` serves today, so this wants a PATCH release rather than riding along with the next one.
