### PR TITLE
feat(policy): open the policy layer in password, email and username

### DIFF
--- a/auth/email/config_test.go
+++ b/auth/email/config_test.go
@@ -1,0 +1,96 @@
+package email
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ---- New(p) reproduces today's behaviour ------------------------------------
+
+func TestNew_acceptsPlusAddressing(t *testing.T) {
+	// The zero Config{} - which is what New(p) uses - must NOT reject
+	// plus-addressing, because that is the existing behaviour callers
+	// depend on. Today the module is built with New(p); the change here is
+	// purely additive.
+	m := newMod(t)
+	if _, err := m.ValidateAndNormalize("user+tag@example.com"); err != nil {
+		t.Errorf("New(p) must accept plus-addressing by default, got %v", err)
+	}
+}
+
+// ---- NewWithConfig(p, Config{RejectPlusAddressing: true}) --------------------
+
+func TestNewWithConfig_rejectsPlusAddressing(t *testing.T) {
+	mod, err := NewWithConfig(fakeProvider{}, Config{RejectPlusAddressing: true})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+
+	_, err = mod.ValidateAndNormalize("user+tag@example.com")
+	if !errors.Is(err, ErrInvalidEmail) {
+		t.Fatalf("expected ErrInvalidEmail for plus-addressing, got %v", err)
+	}
+	if reason := errors.Unwrap(err); reason == nil || !strings.Contains(reason.Error(), "plus") {
+		t.Errorf("error reason must name the rule (plus-addressing), got %v", reason)
+	}
+}
+
+func TestNewWithConfig_rejectPlusStillPassesNormalAddresses(t *testing.T) {
+	// Turning plus-addressing rejection ON must not affect addresses that
+	// do not contain '+'. The whole point of the toggle is the
+	// plus-addressing rule specifically, not a stricter structural check.
+	mod, err := NewWithConfig(fakeProvider{}, Config{RejectPlusAddressing: true})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+
+	for _, addr := range []string{
+		"user@example.com",
+		"user.name@example.com",
+		"a@b.io",
+	} {
+		if _, err := mod.ValidateAndNormalize(addr); err != nil {
+			t.Errorf("ValidateAndNormalize(%q) = %v, want nil", addr, err)
+		}
+	}
+}
+
+func TestNewWithConfig_emptyConfigMatchesNew(t *testing.T) {
+	// Calling NewWithConfig with the zero Config{} must reproduce the
+	// behaviour of New(p). This is the additive guarantee: New keeps
+	// working, and zero-value Config{} in NewWithConfig does the same.
+	a, err := NewWithConfig(fakeProvider{}, Config{})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	b := newMod(t)
+
+	if _, err := a.ValidateAndNormalize("user+tag@example.com"); err != nil {
+		t.Errorf("zero Config{} must accept plus-addressing, got %v", err)
+	}
+	if _, err := b.ValidateAndNormalize("user+tag@example.com"); err != nil {
+		t.Errorf("New(p) must accept plus-addressing, got %v", err)
+	}
+}
+
+// ---- structural errors must surface before plus-addressing ------------------
+
+func TestNewWithConfig_plusAddressWithBadDomainStillReportsDomain(t *testing.T) {
+	// If the user passes a structurally invalid address that also contains
+	// a '+', they should see the structural error (more actionable), not
+	// the policy error. The policy check sits AFTER structural validation.
+	mod, err := NewWithConfig(fakeProvider{}, Config{RejectPlusAddressing: true})
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+
+	_, err = mod.ValidateAndNormalize("user+tag@example..com")
+	if !errors.Is(err, ErrInvalidEmail) {
+		t.Fatalf("expected ErrInvalidEmail, got %v", err)
+	}
+	reason := errors.Unwrap(err)
+	if reason == nil || strings.Contains(reason.Error(), "plus") {
+		t.Errorf("structural error must surface first; got %v", reason)
+	}
+}

--- a/auth/email/email.go
+++ b/auth/email/email.go
@@ -12,6 +12,12 @@
 // during normalisation, matching what DNS actually resolves. Store the
 // canonical ASCII form in your database so lookups are deterministic.
 //
+// Plus-addressing (`user+tag@example.com`) is accepted by default. A
+// deployment that treats `(local, domain)` as the unique account key can
+// opt in to [Config.RejectPlusAddressing] - this is a
+// [configurable policy field](../docs/configuration.md#the-principle),
+// not a security control. The structural rules above stay fixed.
+//
 // The single entry point is [Email.ValidateAndNormalize] — it normalizes
 // (lowercase + trim + punycode) and validates in one step, returning the
 // canonical form.
@@ -93,24 +99,57 @@ type cacheEntry struct {
 // concurrent use after construction. It owns no background goroutine and
 // needs no cleanup; like the other modules, you construct it and use it.
 type Email struct {
-	log      authcore.Logger
-	resolver *net.Resolver
-	cacheTTL time.Duration
-	mu       sync.RWMutex
-	cache    map[string]cacheEntry
-	group    singleflight.Group
+	log                  authcore.Logger
+	resolver             *net.Resolver
+	cacheTTL             time.Duration
+	mu                   sync.RWMutex
+	cache                map[string]cacheEntry
+	group                singleflight.Group
+	rejectPlusAddressing bool // when true, ValidateAndNormalize rejects '+' in the local part
 }
 
 // New creates an Email module using the provider's logger.
+// Equivalent to NewWithConfig(p, Config{}) - accepts the same plus-addressing
+// behaviour as the existing module always has.
 //
 //	emailMod, err := email.New(auth)
 //	if err != nil { ... }
 func New(p authcore.Provider) (*Email, error) {
+	return NewWithConfig(p, Config{})
+}
+
+// Config holds the email module's policy options.
+//
+// Today's behaviour is reproduced by the zero value, so callers that do not
+// need to override anything can keep using New(p). NewWithConfig is the
+// addition: it takes the policy explicitly.
+type Config struct {
+	// RejectPlusAddressing rejects addresses whose local part contains a
+	// '+'. When false (the default), plus-addressing is accepted - the same
+	// behaviour the module has always had.
+	//
+	// This is an account-uniqueness rule, not a security control. RFC 5233
+	// defines plus-addressing so that user+anything@example.com and
+	// user@example.com share one mailbox. Accepting it lets one mailbox own
+	// N accounts: if your product treats (local, domain) as the unique key,
+	// turn this on.
+	RejectPlusAddressing bool
+}
+
+// NewWithConfig creates an Email module with an explicit Config.
+//
+// The zero Config{} reproduces the behaviour of New(p) - today's default.
+//
+//	emailMod, err := email.NewWithConfig(auth, email.Config{
+//	    RejectPlusAddressing: true,
+//	})
+func NewWithConfig(p authcore.Provider, cfg Config) (*Email, error) {
 	e := &Email{
-		log:      p.Logger(),
-		resolver: net.DefaultResolver,
-		cacheTTL: DefaultCacheTTL,
-		cache:    make(map[string]cacheEntry),
+		log:                  p.Logger(),
+		resolver:             net.DefaultResolver,
+		cacheTTL:             DefaultCacheTTL,
+		cache:                make(map[string]cacheEntry),
+		rejectPlusAddressing: cfg.RejectPlusAddressing,
 	}
 	e.log.Info("email: module initialised")
 	return e, nil
@@ -161,6 +200,17 @@ func (e *Email) ValidateAndNormalize(address string) (string, error) {
 	normalized := normalize(address)
 	if err := validate(normalized); err != nil {
 		return "", err
+	}
+	// Plus-addressing is a policy rule applied AFTER structural validation,
+	// so that an address which is structurally invalid for other reasons is
+	// reported with the structural error first (more actionable for the
+	// caller). The check itself is a single byte scan against the already
+	// extracted local part: see ValidateAndNormalize implementation.
+	if e.rejectPlusAddressing {
+		atIdx := strings.LastIndexByte(normalized, '@')
+		if atIdx > 0 && strings.IndexByte(normalized[:atIdx], '+') >= 0 {
+			return "", &emailViolation{reason: fmt.Errorf("plus-addressing is not allowed")}
+		}
 	}
 	return normalized, nil
 }

--- a/auth/password/config.go
+++ b/auth/password/config.go
@@ -4,16 +4,32 @@ import "fmt"
 
 // Config holds the password module configuration.
 //
-// Only the Argon2id work parameters are tunable — Memory, Iterations, and
-// Parallelism. The algorithm (Argon2id), salt size (16 bytes), and key size
-// (32 bytes) are fixed to enforce consistent security across all deployments.
+// The configuration is split into two layers:
 //
-// Start from DefaultConfig and override only what your hardware supports:
+//   - The cryptographic work factor: Memory, Iterations, Parallelism.
+//     Tunable so each deployment can match its own hardware budget.
+//   - The policy layer: MinLength, MaxLength, RequireUpper, RequireLower,
+//     RequireDigit, RequireSymbol. These are a product rule (how forgiving
+//     your product wants to be), not cryptography - they exist so different
+//     installations can express different minimum-strength requirements
+//     while sharing the same Argon2id primitive. Defaults reproduce today's
+//     behaviour exactly.
+//
+// What stays fixed regardless of configuration:
+//
+//   - Algorithm: Argon2id (RFC 9106) - always
+//   - Salt: 16 random bytes per hash
+//   - Key length: 32 bytes (256-bit output)
+//   - Output format: PHC string (self-describing, portable)
+//   - Comparison: constant-time
+//
+// Start from DefaultConfig and override only what your installation needs:
 //
 //	cfg := password.DefaultConfig()
 //	cfg.Memory      = 128 * 1024  // 128 MiB — for a dedicated auth server
 //	cfg.Iterations  = 4
 //	cfg.Parallelism = 4           // match your guaranteed CPU core count
+//	cfg.MinLength   = 16          // stricter length floor for your product
 //	pwdMod, err := password.New(auth, cfg)
 type Config struct {
 	// Memory is the amount of memory used by Argon2id, in kibibytes.
@@ -30,23 +46,95 @@ type Config struct {
 	// Set this to the minimum number of CPU cores guaranteed to your service.
 	// Defaults to 2. Minimum 1.
 	Parallelism uint8
+
+	// MinLength is the minimum acceptable password length in runes.
+	// Defaults to 12. Minimum 8 (anything below that is a weakened default
+	// and is refused by validateConfig).
+	MinLength int
+
+	// MaxLength is the maximum acceptable password length in runes.
+	// Defaults to 64. Capped at 1024 - Argon2id hashes the whole input, so
+	// an unbounded maximum is a CPU denial-of-service: a single oversized
+	// input can pin a hashing thread for several seconds.
+	MaxLength int
+
+	// RequireUpper requires at least one uppercase letter (Unicode-aware).
+	// The pointer lets the caller express three states: nil means "keep
+	// today's default (true)"; an explicit *p = false turns the class off.
+	// A plain bool cannot distinguish "unset" from "deliberately false",
+	// which is exactly the ambiguity this Config avoids.
+	RequireUpper *bool
+
+	// RequireLower requires at least one lowercase letter (Unicode-aware).
+	// Pointer semantics: see RequireUpper.
+	RequireLower *bool
+
+	// RequireDigit requires at least one decimal digit.
+	// Pointer semantics: see RequireUpper.
+	RequireDigit *bool
+
+	// RequireSymbol requires at least one special character (anything that
+	// is not a letter or digit).
+	// Pointer semantics: see RequireUpper.
+	RequireSymbol *bool
 }
 
-// DefaultConfig returns a Config with OWASP-recommended Argon2id defaults.
+// DefaultConfig returns a Config with the library's recommended defaults.
 //
-// The defaults are calibrated for a server with at least 2 vCPUs and 4 GiB of
-// RAM. Each Hash call temporarily allocates Memory kibibytes (64 MiB) of RAM.
-// Tune Memory and Iterations upward on more capable hardware to strengthen the
-// work factor over time.
+// The cryptographic defaults are calibrated for a server with at least 2
+// vCPUs and 4 GiB of RAM. The policy defaults reproduce today's built-in
+// policy: 12–64 characters and one of each class (upper, lower, digit,
+// symbol). Each Hash call temporarily allocates Memory kibibytes (64 MiB)
+// of RAM. Tune Memory and Iterations upward on more capable hardware to
+// strengthen the work factor over time, and MinLength upward if your
+// product demands stricter passwords.
 func DefaultConfig() Config {
 	return Config{
 		Memory:      64 * 1024,
 		Iterations:  3,
 		Parallelism: 2,
+		MinLength:   12,
+		MaxLength:   64,
+		// Pointer to true: a nil means "keep today's behaviour", and today's
+		// behaviour is "require the class". An explicit false turns a class
+		// off - see RequireUpper on the Config type for the rationale.
+		RequireUpper:  ptr(true),
+		RequireLower:  ptr(true),
+		RequireDigit:  ptr(true),
+		RequireSymbol: ptr(true),
 	}
 }
 
+// ptr is a tiny helper so DefaultConfig can take the address of a true
+// literal without a temporary local. It is intentionally unexported.
+func ptr[T any](v T) *T { return &v }
+
+// Bool returns a pointer to v, for setting the *bool policy fields on Config.
+//
+// The policy fields are pointers so that leaving one unset ("keep today's
+// behaviour") is distinguishable from setting it to false ("turn this class
+// off"). A plain bool cannot express both. Without this helper the caller
+// needs a temporary local just to take its address, so the field is present
+// but awkward to reach:
+//
+//	off := false
+//	cfg.RequireSymbol = &off
+//
+// With it, turning a class off is one line:
+//
+//	cfg := password.DefaultConfig()
+//	cfg.RequireSymbol = password.Bool(false)  // no symbol required
+//	cfg.MinLength = 16                        // but a longer passphrase is
+//	pwdMod, err := password.New(auth, cfg)
+//
+// Passing true is the same as leaving the field nil, and is accepted so a
+// caller building a Config field by field can be explicit about every rule.
+func Bool(v bool) *bool { return &v }
+
 // applyDefaults fills zero-value fields with values from DefaultConfig.
+// For the *bool policy fields, nil is treated the same as unset and filled
+// with a pointer to true so that the rest of the package can read the value
+// through the pointer without nil checks.
 func applyDefaults(cfg Config) Config {
 	def := DefaultConfig()
 	if cfg.Memory == 0 {
@@ -58,6 +146,24 @@ func applyDefaults(cfg Config) Config {
 	if cfg.Parallelism == 0 {
 		cfg.Parallelism = def.Parallelism
 	}
+	if cfg.MinLength == 0 {
+		cfg.MinLength = def.MinLength
+	}
+	if cfg.MaxLength == 0 {
+		cfg.MaxLength = def.MaxLength
+	}
+	if cfg.RequireUpper == nil {
+		cfg.RequireUpper = def.RequireUpper
+	}
+	if cfg.RequireLower == nil {
+		cfg.RequireLower = def.RequireLower
+	}
+	if cfg.RequireDigit == nil {
+		cfg.RequireDigit = def.RequireDigit
+	}
+	if cfg.RequireSymbol == nil {
+		cfg.RequireSymbol = def.RequireSymbol
+	}
 	return cfg
 }
 
@@ -65,11 +171,25 @@ const (
 	minMemory     = 8 * 1024        // 8 MiB in KiB
 	maxMemory     = 4 * 1024 * 1024 // 4 GiB in KiB — prevents accidental DoS
 	maxIterations = 20              // beyond this, hashing takes tens of seconds
+
+	// minPolicyLength is the smallest value validateConfig will accept for
+	// MinLength. 8 is the modern floor below which brute-force windows
+	// collapse even on consumer GPUs; anything smaller is treated as a
+	// weakened default and refused, not silently allowed.
+	minPolicyLength = 8
+
+	// maxPolicyLength is the largest value validateConfig will accept for
+	// MaxLength. Argon2id hashes the entire input, so an unbounded maximum
+	// is a CPU denial-of-service: a single oversized input can pin a
+	// hashing thread for seconds. 1024 is generous for any reasonable
+	// passphrase while still bounded.
+	maxPolicyLength = 1024
 )
 
 // validateConfig returns an error if cfg contains invalid values.
 // applyDefaults is always called before validateConfig, so Iterations and
-// Parallelism are guaranteed to be ≥ 1 by the time this runs.
+// Parallelism are guaranteed to be ≥ 1 by the time this runs and the four
+// *bool policy fields are guaranteed to be non-nil.
 func validateConfig(cfg Config) error {
 	if cfg.Memory < minMemory {
 		return fmt.Errorf("memory must be at least %d KiB (8 MiB), got %d", minMemory, cfg.Memory)
@@ -79,6 +199,15 @@ func validateConfig(cfg Config) error {
 	}
 	if cfg.Iterations > maxIterations {
 		return fmt.Errorf("iterations must be at most %d, got %d", maxIterations, cfg.Iterations)
+	}
+	if cfg.MinLength < minPolicyLength {
+		return fmt.Errorf("min length must be at least %d, got %d", minPolicyLength, cfg.MinLength)
+	}
+	if cfg.MaxLength < cfg.MinLength {
+		return fmt.Errorf("max length (%d) must be at least min length (%d)", cfg.MaxLength, cfg.MinLength)
+	}
+	if cfg.MaxLength > maxPolicyLength {
+		return fmt.Errorf("max length must be at most %d, got %d", maxPolicyLength, cfg.MaxLength)
 	}
 	return nil
 }

--- a/auth/password/config_test.go
+++ b/auth/password/config_test.go
@@ -1,0 +1,303 @@
+package password
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fastMod returns a Password built with the cheapest valid Argon2id parameters
+// so Hash-based tests in this file do not spend seconds per call. The policy
+// fields of cfg are preserved verbatim.
+func fastMod(t *testing.T, cfg Config) *Password {
+	t.Helper()
+	cfg.Memory = 8 * 1024
+	cfg.Iterations = 1
+	cfg.Parallelism = 1
+	mod, err := New(fakeProvider{}, cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return mod
+}
+
+// ---- DefaultConfig reproduces today's policy exactly ------------------------
+
+func TestDefaultConfig_passwordPolicyLengths(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.MinLength != 12 {
+		t.Errorf("DefaultConfig().MinLength = %d, want 12", cfg.MinLength)
+	}
+	if cfg.MaxLength != 64 {
+		t.Errorf("DefaultConfig().MaxLength = %d, want 64", cfg.MaxLength)
+	}
+}
+
+func TestDefaultConfig_passwordPolicyRequiresAllClasses(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.RequireUpper == nil || *cfg.RequireUpper != true {
+		t.Error("DefaultConfig().RequireUpper must default to true (non-nil pointer to true)")
+	}
+	if cfg.RequireLower == nil || *cfg.RequireLower != true {
+		t.Error("DefaultConfig().RequireLower must default to true (non-nil pointer to true)")
+	}
+	if cfg.RequireDigit == nil || *cfg.RequireDigit != true {
+		t.Error("DefaultConfig().RequireDigit must default to true (non-nil pointer to true)")
+	}
+	if cfg.RequireSymbol == nil || *cfg.RequireSymbol != true {
+		t.Error("DefaultConfig().RequireSymbol must default to true (non-nil pointer to true)")
+	}
+}
+
+// TestDefaultConfig_passwordPolicyBoundaries covers the explicit boundary
+// cases for the default policy: 11 rejected, 12 accepted, 64 accepted,
+// 65 rejected. The "valid" seed (Aa1!) satisfies all four character classes
+// so each length is the only thing changing.
+func TestDefaultConfig_passwordPolicyBoundaries(t *testing.T) {
+	mod := fastMod(t, Config{}) // zero policy fields → applyDefaults fills defaults
+
+	base := "Aa1!"
+	eleven := base + strings.Repeat("a", 7)     // 11 chars: too short
+	twelve := base + strings.Repeat("a", 8)     // 12 chars: accepted (exactly MinLength)
+	sixtyfour := base + strings.Repeat("a", 60) // 64 chars: accepted (exactly MaxLength)
+	sixtyfive := base + strings.Repeat("a", 61) // 65 chars: too long
+
+	if err := mod.ValidatePolicy(eleven); err == nil {
+		t.Error("11-char password must be rejected under the default policy")
+	}
+	if err := mod.ValidatePolicy(twelve); err != nil {
+		t.Errorf("12-char password must be accepted under the default policy, got %v", err)
+	}
+	if err := mod.ValidatePolicy(sixtyfour); err != nil {
+		t.Errorf("64-char password must be accepted under the default policy, got %v", err)
+	}
+	if err := mod.ValidatePolicy(sixtyfive); err == nil {
+		t.Error("65-char password must be rejected under the default policy")
+	}
+}
+
+// ---- Configured MinLength is honoured and reported in the error --------------
+
+func TestConfig_minLengthChangesFloor(t *testing.T) {
+	// A password that passes the default (12 chars) must be rejected when
+	// MinLength is raised to 16, and the error message must report 16.
+	mod := fastMod(t, Config{MinLength: 16})
+
+	pwd := "Abcdefgh1!" // 10 chars, satisfies classes but below the new floor
+	if err := mod.ValidatePolicy(pwd); err == nil {
+		t.Fatal("a 10-character password must be rejected when MinLength=16")
+	} else if !strings.Contains(err.Error(), "16") {
+		t.Errorf("error message must report the configured MinLength (16), got %q", err.Error())
+	}
+}
+
+// ---- Configured *bool disables a class while leaving the others alone -------
+
+func TestConfig_requireSymbolFalseAcceptsNoSymbol(t *testing.T) {
+	// Three classes (upper, lower, digit) but no symbol. With RequireSymbol
+	// turned off, the password is accepted; with it on, it would be rejected.
+	no := false
+	mod := fastMod(t, Config{RequireSymbol: &no})
+
+	pwd := "Abcdefghijk1" // 12 chars, upper+lower+digit, no symbol
+	if err := mod.ValidatePolicy(pwd); err != nil {
+		t.Errorf("with RequireSymbol=false, a password with no symbol must be accepted, got %v", err)
+	}
+}
+
+func TestConfig_requireSymbolFalseStillEnforcesOtherClasses(t *testing.T) {
+	// With RequireSymbol turned off, a password that has no symbol but
+	// also lacks one of the OTHER three classes must still be rejected  -
+	// turning one class off must not silently turn the others off too.
+	no := false
+	mod := fastMod(t, Config{RequireSymbol: &no})
+
+	cases := map[string]string{
+		"no uppercase": "abcdefghijk1",
+		"no lowercase": "ABCDEFGHIJK1",
+		"no digit":     "Abcdefghijk!",
+	}
+	for name, pwd := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := mod.ValidatePolicy(pwd); err == nil {
+				t.Errorf("%s must still be rejected when only RequireSymbol is off", name)
+			}
+		})
+	}
+}
+
+// TestConfig_requireSymbolTrueRejectsNoSymbol is the negative direction:
+// leaving the default in place (or explicitly setting *bool = true) must
+// keep the old behaviour.
+func TestConfig_requireSymbolTrueRejectsNoSymbol(t *testing.T) {
+	yes := true
+	mod := fastMod(t, Config{RequireSymbol: &yes})
+
+	if err := mod.ValidatePolicy("Abcdefghijk1"); err == nil {
+		t.Error("with RequireSymbol=true, a password with no symbol must be rejected")
+	}
+}
+
+// ---- *bool pointer semantics: nil means "keep the default" ------------------
+
+func TestApplyDefaults_fillsNilRequirePointersToTrue(t *testing.T) {
+	cfg := applyDefaults(Config{Memory: 8 * 1024, Iterations: 1, Parallelism: 1})
+
+	want := true
+	for name, p := range map[string]**bool{
+		"RequireUpper":  &cfg.RequireUpper,
+		"RequireLower":  &cfg.RequireLower,
+		"RequireDigit":  &cfg.RequireDigit,
+		"RequireSymbol": &cfg.RequireSymbol,
+	} {
+		if p == nil {
+			t.Errorf("applyDefaults must fill %s with a non-nil pointer", name)
+			continue
+		}
+		if **p != want {
+			t.Errorf("applyDefaults must fill %s with a pointer to true, got %v", name, *p)
+		}
+	}
+}
+
+func TestApplyDefaults_preservesExplicitFalse(t *testing.T) {
+	no := false
+	cfg := applyDefaults(Config{
+		Memory:        8 * 1024,
+		Iterations:    1,
+		Parallelism:   1,
+		RequireUpper:  &no,
+		RequireLower:  &no,
+		RequireDigit:  &no,
+		RequireSymbol: &no,
+	})
+
+	want := false
+	for name, p := range map[string]**bool{
+		"RequireUpper":  &cfg.RequireUpper,
+		"RequireLower":  &cfg.RequireLower,
+		"RequireDigit":  &cfg.RequireDigit,
+		"RequireSymbol": &cfg.RequireSymbol,
+	} {
+		if p == nil {
+			t.Errorf("applyDefaults must not nil-out %s when caller passed an explicit pointer", name)
+			continue
+		}
+		if **p != want {
+			t.Errorf("applyDefaults must preserve explicit false for %s, got %v", name, *p)
+		}
+	}
+}
+
+func TestApplyDefaults_fillsZeroLengths(t *testing.T) {
+	cfg := applyDefaults(Config{Memory: 8 * 1024, Iterations: 1, Parallelism: 1})
+	if cfg.MinLength != 12 {
+		t.Errorf("applyDefaults MinLength = %d, want 12", cfg.MinLength)
+	}
+	if cfg.MaxLength != 64 {
+		t.Errorf("applyDefaults MaxLength = %d, want 64", cfg.MaxLength)
+	}
+}
+
+// ---- validateConfig refuses weakened or contradictory bounds ----------------
+
+func TestValidateConfig_rejectsMinLengthBelowFloor(t *testing.T) {
+	// 4 is below minPolicyLength (8); the validator must refuse instead of
+	// silently letting the caller ship a weakened default.
+	err := validateConfig(Config{
+		Memory:      8 * 1024,
+		Iterations:  1,
+		Parallelism: 1,
+		MinLength:   4,
+		MaxLength:   64,
+	})
+	if err == nil {
+		t.Fatal("validateConfig must reject MinLength below 8")
+	}
+	if !strings.Contains(err.Error(), "min length") {
+		t.Errorf("error must mention min length, got %v", err)
+	}
+}
+
+func TestValidateConfig_rejectsMaxLengthBelowMinLength(t *testing.T) {
+	// MaxLength smaller than MinLength is a contradiction: every input would
+	// be rejected for both reasons at once, so the validator must refuse.
+	err := validateConfig(Config{
+		Memory:      8 * 1024,
+		Iterations:  1,
+		Parallelism: 1,
+		MinLength:   16,
+		MaxLength:   12,
+	})
+	if err == nil {
+		t.Fatal("validateConfig must reject MaxLength below MinLength")
+	}
+	if !strings.Contains(err.Error(), "max length") {
+		t.Errorf("error must mention max length, got %v", err)
+	}
+}
+
+func TestValidateConfig_rejectsOversizedMaxLength(t *testing.T) {
+	// Above 1024 the bound becomes a CPU DoS: Argon2id hashes the whole input,
+	// so the validator must refuse anything beyond the configured ceiling.
+	err := validateConfig(Config{
+		Memory:      8 * 1024,
+		Iterations:  1,
+		Parallelism: 1,
+		MinLength:   12,
+		MaxLength:   1025,
+	})
+	if err == nil {
+		t.Fatal("validateConfig must reject MaxLength above 1024")
+	}
+}
+
+func TestNew_invalidPolicyConfigReturnsErrInvalidConfig(t *testing.T) {
+	// A weakened config that slips past validateConfig would be silently
+	// shipped in production. New must refuse it at construction time so the
+	// failure is loud and at startup, not at first user registration.
+	_, err := New(fakeProvider{}, Config{
+		Memory:      8 * 1024,
+		Iterations:  1,
+		Parallelism: 1,
+		MinLength:   4, // below the floor
+		MaxLength:   64,
+	})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("New() with MinLength=4 must return ErrInvalidConfig, got %v", err)
+	}
+}
+
+// TestBool_expressesBothStatesDistinctlyFromUnset pins the reason the policy
+// fields are pointers at all. Bool(false) must reach checkPolicy as an off
+// switch, while a nil field must keep the default on. A plain bool could not
+// tell those apart, so if this test ever passes with a non-pointer field the
+// distinction has been lost.
+func TestBool_expressesBothStatesDistinctlyFromUnset(t *testing.T) {
+	t.Parallel()
+
+	if got := Bool(false); got == nil || *got {
+		t.Fatalf("Bool(false) must point to false, got %v", got)
+	}
+	if got := Bool(true); got == nil || !*got {
+		t.Fatalf("Bool(true) must point to true, got %v", got)
+	}
+
+	// No symbol, and long enough to clear the default floor.
+	const noSymbol = "Passphrase123"
+
+	unset := applyDefaults(Config{})
+	if err := checkPolicy(noSymbol, unset); err == nil {
+		t.Error("a nil RequireSymbol must keep today's behaviour, which rejects a password with no symbol")
+	}
+
+	off := applyDefaults(Config{RequireSymbol: Bool(false)})
+	if err := checkPolicy(noSymbol, off); err != nil {
+		t.Errorf("RequireSymbol set to Bool(false) must accept a password with no symbol, got %v", err)
+	}
+
+	// Turning one class off must not turn the others off with it.
+	if err := checkPolicy("passphrase123", off); err == nil {
+		t.Error("RequireUpper must still apply when only RequireSymbol was turned off")
+	}
+}

--- a/auth/password/password.go
+++ b/auth/password/password.go
@@ -25,8 +25,12 @@
 //
 // # What is tunable
 //
-// Memory, Iterations, and Parallelism can be increased to match your hardware.
-// The algorithm and output format are never configurable — that's the point.
+// The cryptographic work factor (Memory, Iterations, Parallelism) and the
+// policy (MinLength, MaxLength, RequireUpper, RequireLower, RequireDigit,
+// RequireSymbol) can be raised or lowered to match your product. Defaults
+// reproduce the policy the library has always enforced - see
+// [Config]. The algorithm, salt size, key size, output format, and Unicode
+// NFC normalisation are never configurable - that's the point.
 //
 // # Full usage
 //
@@ -120,7 +124,7 @@ func New(p authcore.Provider, cfg ...Config) (*Password, error) {
 // Name returns the module's unique identifier. It implements authcore.Module.
 func (p *Password) Name() string { return "password" }
 
-// ValidatePolicy reports whether plaintext satisfies the built-in password policy.
+// ValidatePolicy reports whether plaintext satisfies the configured password policy.
 // Use this for fail-fast validation before calling Hash — for example, in an HTTP
 // handler to return a 400 before spending CPU on Argon2id.
 //
@@ -128,38 +132,39 @@ func (p *Password) Name() string { return "password" }
 // specific rule that was violated. The wrapped reason is safe to show the user:
 //
 //	if err := pwdMod.ValidatePolicy(req.Password); err != nil {
-//	    reason := errors.Unwrap(err).Error() // "must be at least 12 characters"
+//	    reason := errors.Unwrap(err).Error() // e.g. "must be at least 16 characters"
 //	    c.JSON(400, gin.H{"error": reason})
 //	}
 //
-// This check is identical to the one Hash performs internally.
+// This check is identical to the one Hash performs internally. The bounds and
+// required classes it enforces come from the module's Config (see
+// [Config.MinLength], [Config.MaxLength] and the [Config.RequireUpper] family),
+// so the message reflects what the caller actually configured.
 func (p *Password) ValidatePolicy(plaintext string) error {
-	if err := checkPolicy(norm.NFC.String(plaintext)); err != nil {
+	if err := checkPolicy(norm.NFC.String(plaintext), p.cfg); err != nil {
 		return &policyViolation{reason: err}
 	}
 	return nil
 }
 
-// checkPolicy validates plaintext against the built-in password policy.
+// checkPolicy validates plaintext against the policy encoded in cfg.
 // It runs in O(n) with a single pass and no memory allocations.
 //
 // Length is measured in Unicode characters (runes), not bytes, so a
 // multibyte passphrase is counted the way a user perceives it: a 4-character
 // CJK password is 4 characters, not 12 bytes.
 //
-// Rules:
-//   - Length between 12 and 64 characters.
-//   - At least one uppercase letter (Unicode-aware).
-//   - At least one lowercase letter (Unicode-aware).
-//   - At least one digit.
-//   - At least one special character (anything that is not a letter or digit).
-func checkPolicy(plaintext string) error {
+// The cfg argument must already have its *bool policy fields resolved
+// (applyDefaults guarantees non-nil), so this function reads them through
+// the pointer without nil checks. The error messages quote cfg.MinLength
+// and cfg.MaxLength, so the caller sees the bound they actually configured.
+func checkPolicy(plaintext string, cfg Config) error {
 	count := utf8.RuneCountInString(plaintext)
-	if count < 12 {
-		return fmt.Errorf("must be at least 12 characters")
+	if count < cfg.MinLength {
+		return fmt.Errorf("must be at least %d characters", cfg.MinLength)
 	}
-	if count > 64 {
-		return fmt.Errorf("must be at most 64 characters")
+	if count > cfg.MaxLength {
+		return fmt.Errorf("must be at most %d characters", cfg.MaxLength)
 	}
 
 	var hasUpper, hasLower, hasDigit, hasSpecial bool
@@ -177,13 +182,13 @@ func checkPolicy(plaintext string) error {
 	}
 
 	switch {
-	case !hasUpper:
+	case *cfg.RequireUpper && !hasUpper:
 		return fmt.Errorf("must contain at least one uppercase letter")
-	case !hasLower:
+	case *cfg.RequireLower && !hasLower:
 		return fmt.Errorf("must contain at least one lowercase letter")
-	case !hasDigit:
+	case *cfg.RequireDigit && !hasDigit:
 		return fmt.Errorf("must contain at least one digit")
-	case !hasSpecial:
+	case *cfg.RequireSymbol && !hasSpecial:
 		return fmt.Errorf("must contain at least one special character")
 	}
 	return nil
@@ -216,7 +221,7 @@ func (p *Password) Hash(plaintext string) (string, error) {
 	plaintext = norm.NFC.String(plaintext)
 
 	// Validate before hashing — fail fast before spending ~64 MiB of RAM on Argon2id.
-	if err := checkPolicy(plaintext); err != nil {
+	if err := checkPolicy(plaintext, p.cfg); err != nil {
 		return "", &policyViolation{reason: err}
 	}
 

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -290,25 +290,26 @@ func TestHash_strongPasswordSucceeds(t *testing.T) {
 // ---- checkPolicy() ----------------------------------------------------------
 
 func TestCheckPolicy_boundaryLengths(t *testing.T) {
-	base := "Aa1!" // 4-char valid seed — pad to reach target length
+	base := "Aa1!"         // 4-char valid seed - pad to reach target length
+	cfg := DefaultConfig() // 12..64, all classes required
 
 	exactly12 := base + strings.Repeat("a", 8)
-	if err := checkPolicy(exactly12); err != nil {
+	if err := checkPolicy(exactly12, cfg); err != nil {
 		t.Errorf("12-char password rejected: %v", err)
 	}
 
 	exactly64 := base + strings.Repeat("a", 60)
-	if err := checkPolicy(exactly64); err != nil {
+	if err := checkPolicy(exactly64, cfg); err != nil {
 		t.Errorf("64-char password rejected: %v", err)
 	}
 
 	tooShort := base + strings.Repeat("a", 7) // 11 chars
-	if checkPolicy(tooShort) == nil {
+	if checkPolicy(tooShort, cfg) == nil {
 		t.Error("11-char password should be rejected")
 	}
 
 	tooLong := base + strings.Repeat("a", 61) // 65 chars
-	if checkPolicy(tooLong) == nil {
+	if checkPolicy(tooLong, cfg) == nil {
 		t.Error("65-char password should be rejected")
 	}
 }

--- a/auth/username/config.go
+++ b/auth/username/config.go
@@ -1,17 +1,148 @@
 package username
 
-// minLength and maxLength are fixed by the library.
-// They are not configurable — this is a deliberate security standard,
-// not an oversight. A username shorter than 3 characters is ambiguous;
-// longer than 32 is impractical and increases attack surface on user-facing forms.
+import "fmt"
+
+// minLength and maxLength are the library's default length bounds, applied
+// when the caller's Config leaves MinLength or MaxLength at the zero value.
+// They are a product default - a caller may raise or lower them to fit the
+// installation. What is NOT configurable here, because it is the security
+// layer, is the character set [a-z0-9_-] (the homoglyph control) and the
+// normalization (lowercase + trim). Both stay fixed; widening the character
+// set to Unicode is exactly what enables impersonation, so it is closed.
 const (
 	minLength = 3
 	maxLength = 32
 )
 
-// defaultReservedNames is the built-in set of names that cannot be registered.
-// These cover infrastructure roles, common attack targets, and names that would
-// confuse users into believing they are interacting with the service itself.
+// upperMaxLength is the absolute ceiling a caller is allowed to set for
+// MaxLength. 255 is generous for any reasonable username while still keeping
+// storage and lookup columns bounded; anything beyond is almost certainly a
+// mistake.
+const upperMaxLength = 255
+
+// Config holds the username module's policy options.
+//
+// Today's behaviour is reproduced by the zero value, so callers that do not
+// need to override anything can keep using New(p). NewWithConfig is the
+// addition: it takes the policy explicitly.
+type Config struct {
+	// MinLength is the minimum acceptable username length in bytes.
+	// Defaults to 3. Minimum 1; values below that are rejected by
+	// validateConfig.
+	MinLength int
+
+	// MaxLength is the maximum acceptable username length in bytes.
+	// Defaults to 32. Capped at 255.
+	MaxLength int
+
+	// ExtraReservedNames adds entries to the built-in reserved-names list.
+	// Comparison happens after normalization (lowercase + trim), so the
+	// values here are stored in their canonical form.
+	ExtraReservedNames []string
+
+	// AllowReservedNames removes entries from the reserved-names set. The
+	// built-in blocklist includes names like "support", "info", "test",
+	// "home" - a deployment that runs a real "support" account lists it
+	// here so the account can be registered. Names are compared after
+	// normalization, so values here are stored in canonical form.
+	AllowReservedNames []string
+}
+
+// DefaultConfig returns a Config that reproduces today's built-in behaviour:
+// 3..32 characters, the built-in reserved list, no additions or removals.
+func DefaultConfig() Config {
+	return Config{
+		MinLength: minLength,
+		MaxLength: maxLength,
+	}
+}
+
+// applyDefaults fills zero-value fields with values from DefaultConfig and
+// normalizes the two name lists (lowercase + trim) so the rest of the
+// package can compare against a single canonical form. The reserved set
+// itself is built once at construction time by reservedSet.
+func applyDefaults(cfg Config) Config {
+	def := DefaultConfig()
+	if cfg.MinLength == 0 {
+		cfg.MinLength = def.MinLength
+	}
+	if cfg.MaxLength == 0 {
+		cfg.MaxLength = def.MaxLength
+	}
+	cfg.ExtraReservedNames = normalizeNameList(cfg.ExtraReservedNames)
+	cfg.AllowReservedNames = normalizeNameList(cfg.AllowReservedNames)
+	return cfg
+}
+
+// validateConfig refuses values that are themselves invalid or that would
+// make every username fail. The reserved-name lists are not validated here:
+// unknown names are simply added or removed as configured.
+//
+// The returned error wraps ErrInvalidConfig so errors.Is(err, ErrInvalidConfig)
+// reports the failure as the documented sentinel, while errors.Unwrap returns
+// the specific reason for programmatic handling.
+func validateConfig(cfg Config) error {
+	switch {
+	case cfg.MinLength < 1:
+		return &configViolation{reason: fmt.Errorf("min length must be at least 1, got %d", cfg.MinLength)}
+	case cfg.MaxLength < cfg.MinLength:
+		return &configViolation{reason: fmt.Errorf("max length (%d) must be at least min length (%d)", cfg.MaxLength, cfg.MinLength)}
+	case cfg.MaxLength > upperMaxLength:
+		return &configViolation{reason: fmt.Errorf("max length must be at most %d, got %d", upperMaxLength, cfg.MaxLength)}
+	}
+	return nil
+}
+
+// reservedSet builds the final reserved-name lookup set from the configured
+// additions and removals applied to the built-in list. Names already present
+// in ExtraReservedNames are deduped against the built-in list. The result is
+// normalised (lowercase + trimmed) so lookups can use the same form
+// normalize() produces for the input.
+func reservedSet(cfg Config) map[string]struct{} {
+	// Start with the built-in blocklist.
+	set := make(map[string]struct{}, len(defaultReservedNames)+len(cfg.ExtraReservedNames))
+	for _, name := range defaultReservedNames {
+		set[name] = struct{}{}
+	}
+
+	// Additions. Already normalized; duplicates against the built-in list
+	// collapse harmlessly into the same map slot.
+	for _, name := range cfg.ExtraReservedNames {
+		set[name] = struct{}{}
+	}
+
+	// Removals. Removing a name that was never reserved is a no-op.
+	for _, name := range cfg.AllowReservedNames {
+		delete(set, name)
+	}
+
+	return set
+}
+
+// normalizeNameList lowercases and trims every entry. Empty entries are
+// dropped so the caller cannot accidentally inject a name that matches
+// every input - the normalize() function applied to user input never
+// produces the empty string (the validator rejects empty inputs upstream),
+// but a misconfigured []string{"  "} would otherwise wedge the set.
+func normalizeNameList(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, raw := range names {
+		n := normalize(raw)
+		if n == "" {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// defaultReservedNames is the built-in set of names that cannot be
+// registered by default. These cover infrastructure roles, common attack
+// targets, and names that would confuse users into believing they are
+// interacting with the service itself.
+//
+// A deployment that needs one of these names - for example, a company that
+// runs a real "support" account - passes it in Config.AllowReservedNames.
 var defaultReservedNames = []string{
 	// Infrastructure and system accounts
 	"admin", "administrator", "root", "superuser", "system",

--- a/auth/username/config_test.go
+++ b/auth/username/config_test.go
@@ -1,0 +1,176 @@
+package username
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// modWith builds a Username with the requested Config, using the cheapest
+// valid setup. cfg is passed verbatim; the production code is responsible
+// for filling defaults and validating bounds.
+func modWith(t *testing.T, cfg Config) *Username {
+	t.Helper()
+	m, err := NewWithConfig(fakeProvider{}, cfg)
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	return m
+}
+
+// ---- AllowReservedNames unblocks a built-in reserved name -------------------
+
+func TestNewWithConfig_allowReservedNamesAreUnblocked(t *testing.T) {
+	// "support" is in the built-in reserved list. New(p) refuses it; a
+	// deployment that runs a real "support" account needs to be able to
+	// register it. AllowReservedNames is the toggle.
+	mod := modWith(t, Config{AllowReservedNames: []string{"support"}})
+
+	if _, err := mod.ValidateAndNormalize("support"); err != nil {
+		t.Errorf("with AllowReservedNames=[support], 'support' must be accepted, got %v", err)
+	}
+}
+
+func TestNew_p_rejectsSupportByDefault(t *testing.T) {
+	// The negative direction: with no AllowReservedNames override the
+	// built-in blocklist still applies. This is what the previous test
+	// is supposed to have flipped.
+	_, err := newMod(t).ValidateAndNormalize("support")
+	if !errors.Is(err, ErrInvalidUsername) {
+		t.Errorf("New(p) must still reject 'support' by default, got %v", err)
+	}
+}
+
+// ---- ExtraReservedNames adds to the blocklist --------------------------------
+
+func TestNewWithConfig_extraReservedNamesAreBlocked(t *testing.T) {
+	// "founder" is not in the built-in list. Adding it to ExtraReservedNames
+	// must cause ValidateAndNormalize to reject it.
+	mod := modWith(t, Config{ExtraReservedNames: []string{"founder"}})
+
+	if _, err := mod.ValidateAndNormalize("founder"); !errors.Is(err, ErrInvalidUsername) {
+		t.Errorf("a name listed in ExtraReservedNames must be rejected, got %v", err)
+	}
+}
+
+func TestNewWithConfig_extraReservedNamesNormalized(t *testing.T) {
+	// The comparison happens after normalize() (lowercase + trim), so the
+	// caller can pass names in any case or with surrounding whitespace.
+	// "  FOUNDER  " must end up matching "founder" in the lookup set.
+	mod := modWith(t, Config{ExtraReservedNames: []string{"  FOUNDER  "}})
+
+	if _, err := mod.ValidateAndNormalize("founder"); !errors.Is(err, ErrInvalidUsername) {
+		t.Errorf("normalized ExtraReservedNames entry must reject the lowercased input, got %v", err)
+	}
+}
+
+// ---- MinLength changes the lower bound and reports it in the error ----------
+
+func TestNewWithConfig_minLengthRejectsShortName(t *testing.T) {
+	// MinLength: 5 must reject a 4-character name AND report the new
+	// floor in the error message ("at least 5 characters").
+	mod := modWith(t, Config{MinLength: 5})
+
+	_, err := mod.ValidateAndNormalize("abcd")
+	if !errors.Is(err, ErrInvalidUsername) {
+		t.Fatalf("expected ErrInvalidUsername for a 4-character name when MinLength=5, got %v", err)
+	}
+	if reason := errors.Unwrap(err); reason == nil || !strings.Contains(reason.Error(), "5") {
+		t.Errorf("error reason must report the configured MinLength (5), got %v", reason)
+	}
+}
+
+func TestNewWithConfig_minLengthAcceptsBoundary(t *testing.T) {
+	// Exactly the floor must be accepted. The test for "below the floor"
+	// would also pass with a buggy "<= instead of <", so the boundary
+	// test is what proves it is right.
+	mod := modWith(t, Config{MinLength: 5})
+
+	if _, err := mod.ValidateAndNormalize("abcde"); err != nil {
+		t.Errorf("a name at exactly MinLength=5 must be accepted, got %v", err)
+	}
+}
+
+// ---- MaxLength changes the upper bound --------------------------------------
+
+func TestNewWithConfig_maxLengthRejectsLongName(t *testing.T) {
+	mod := modWith(t, Config{MaxLength: 5})
+
+	_, err := mod.ValidateAndNormalize(strings.Repeat("a", 6))
+	if !errors.Is(err, ErrInvalidUsername) {
+		t.Fatalf("expected ErrInvalidUsername for a 6-character name when MaxLength=5, got %v", err)
+	}
+}
+
+// ---- validateConfig refuses bad bounds --------------------------------------
+
+func TestValidateConfig_rejectsMinLengthBelowOne(t *testing.T) {
+	err := validateConfig(Config{MinLength: 0})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("MinLength=0 must be refused by validateConfig as ErrInvalidConfig, got %v", err)
+	}
+}
+
+func TestValidateConfig_rejectsMaxLengthBelowMinLength(t *testing.T) {
+	err := validateConfig(Config{MinLength: 10, MaxLength: 5})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("MaxLength below MinLength must be refused by validateConfig, got %v", err)
+	}
+}
+
+func TestValidateConfig_rejectsOversizedMaxLength(t *testing.T) {
+	err := validateConfig(Config{MinLength: 1, MaxLength: upperMaxLength + 1})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("MaxLength above the ceiling must be refused, got %v", err)
+	}
+}
+
+func TestNewWithConfig_invalidConfigReturnsErrInvalidConfig(t *testing.T) {
+	// The same bad config that validateConfig refuses must also be
+	// refused by NewWithConfig at construction time, so the failure is
+	// loud at startup rather than at first registration.
+	_, err := NewWithConfig(fakeProvider{}, Config{MinLength: 10, MaxLength: 5})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("NewWithConfig with contradictory bounds must return ErrInvalidConfig, got %v", err)
+	}
+}
+
+// ---- reservedSet: Allow wins over built-in and over Extra -------------------
+
+func TestReservedSet_allowOverridesBuiltIn(t *testing.T) {
+	set := reservedSet(Config{AllowReservedNames: []string{"support"}})
+	if _, ok := set["support"]; ok {
+		t.Error("AllowReservedNames must remove 'support' from the reserved set")
+	}
+	// Spot-check that other built-ins stay reserved.
+	if _, ok := set["admin"]; !ok {
+		t.Error("AllowReservedNames=[support] must NOT remove 'admin' from the reserved set")
+	}
+}
+
+func TestReservedSet_extraIsAdded(t *testing.T) {
+	set := reservedSet(Config{ExtraReservedNames: []string{"founder"}})
+	if _, ok := set["founder"]; !ok {
+		t.Error("ExtraReservedNames must add 'founder' to the reserved set")
+	}
+}
+
+func TestReservedSet_emptyConfigEqualsBuiltIn(t *testing.T) {
+	// The zero Config{} must produce the same set as the original
+	// defaultReservedNames - this is the additive guarantee.
+	got := reservedSet(Config{})
+	want := make(map[string]struct{}, len(defaultReservedNames))
+	for _, n := range defaultReservedNames {
+		want[n] = struct{}{}
+	}
+	for name := range want {
+		if _, ok := got[name]; !ok {
+			t.Errorf("zero Config{} is missing built-in reserved name %q", name)
+		}
+	}
+	for name := range got {
+		if _, ok := want[name]; !ok {
+			t.Errorf("zero Config{} added a name %q that is not in defaultReservedNames", name)
+		}
+	}
+}

--- a/auth/username/errors.go
+++ b/auth/username/errors.go
@@ -16,6 +16,13 @@ import "errors"
 // Use errors.Is to check for this in calling code.
 var ErrInvalidUsername = errors.New("username: invalid username")
 
+// ErrInvalidConfig is returned by NewWithConfig when the provided Config
+// fails validation (for example, MinLength < 1). This is a programming or
+// startup error - it should never reach an HTTP handler.
+//
+// Safety: INTERNAL - do not expose to clients. Treat as a 500.
+var ErrInvalidConfig = errors.New("username: invalid config")
+
 // usernameViolation wraps ErrInvalidUsername with a single specific reason so
 // that both errors.Is(err, ErrInvalidUsername) and errors.Unwrap(err) work correctly.
 // Using fmt.Errorf("%w: %w", ...) would create a multi-unwrap error in Go 1.20+
@@ -27,3 +34,14 @@ func (v *usernameViolation) Error() string {
 }
 func (v *usernameViolation) Is(t error) bool { return t == ErrInvalidUsername }
 func (v *usernameViolation) Unwrap() error   { return v.reason }
+
+// configViolation wraps ErrInvalidConfig with the underlying reason. Same
+// pattern as usernameViolation: a single wrapped error so errors.Unwrap
+// returns the specific cause.
+type configViolation struct{ reason error }
+
+func (v *configViolation) Error() string {
+	return ErrInvalidConfig.Error() + ": " + v.reason.Error()
+}
+func (v *configViolation) Is(t error) bool { return t == ErrInvalidConfig }
+func (v *configViolation) Unwrap() error   { return v.reason }

--- a/auth/username/username.go
+++ b/auth/username/username.go
@@ -1,11 +1,19 @@
 // Package username provides username validation and normalization for authcore.
 //
 // Validation rules (applied after normalization):
-//   - Length between 3 and 32 characters (fixed)
+//   - Length between [Config.MinLength] and [Config.MaxLength] (defaults 3 and 32)
 //   - Only lowercase letters, digits, underscores, and hyphens: [a-z0-9_-]
 //   - Must start and end with a letter or digit (not _ or -)
 //   - No consecutive special characters (__, --, _-, -_)
-//   - Not in the built-in reserved names list
+//   - Not in the reserved names set (built-in list, plus
+//     [Config.ExtraReservedNames], minus [Config.AllowReservedNames])
+//
+// The length bounds and reserved-names list are [configurable policy
+// fields](../docs/configuration.md#the-principle). The character set,
+// normalisation, "must start and end with a letter or digit", and
+// "no consecutive specials" rules stay fixed - the character set in
+// particular is the homoglyph control, and widening it to Unicode is
+// exactly what enables impersonation.
 //
 // The single entry point is [Username.ValidateAndNormalize] — it normalizes
 // (lowercase + trim) and validates in one step, returning the canonical form.
@@ -44,22 +52,42 @@ var _ authcore.Module = (*Username)(nil)
 type Username struct {
 	log      authcore.Logger
 	reserved map[string]struct{} // O(1) lookup set built at New() time
+	minLen   int                 // policy: minimum acceptable length in bytes
+	maxLen   int                 // policy: maximum acceptable length in bytes
 }
 
-// New creates a Username module using the provider's logger.
+// New creates a Username module using the provider's logger. Equivalent to
+// NewWithConfig(p, Config{}) - accepts the same length bounds and reserved
+// names as the existing module always has.
 //
 //	userMod, err := username.New(auth)
 //	if err != nil { log.Fatal(err) }
 func New(p authcore.Provider) (*Username, error) {
-	// Build the reserved names lookup set once at startup so every
-	// ValidateAndNormalize call gets O(1) map lookup instead of O(n) slice scan.
-	reserved := make(map[string]struct{}, len(defaultReservedNames))
-	for _, name := range defaultReservedNames {
-		reserved[name] = struct{}{}
+	return NewWithConfig(p, Config{})
+}
+
+// NewWithConfig creates a Username module with an explicit Config.
+//
+// The zero Config{} reproduces the behaviour of New(p) - today's defaults:
+// 3..32 characters, the built-in reserved list, no additions or removals.
+//
+//	userMod, err := username.NewWithConfig(auth, username.Config{
+//	    MinLength: 5,
+//	    AllowReservedNames: []string{"support"},
+//	})
+func NewWithConfig(p authcore.Provider, cfg Config) (*Username, error) {
+	resolved := applyDefaults(cfg)
+	if err := validateConfig(resolved); err != nil {
+		return nil, err
 	}
 
-	u := &Username{log: p.Logger(), reserved: reserved}
-	u.log.Info("username: module initialised (reserved=%d)", len(reserved))
+	u := &Username{
+		log:      p.Logger(),
+		reserved: reservedSet(resolved),
+		minLen:   resolved.MinLength,
+		maxLen:   resolved.MaxLength,
+	}
+	u.log.Info("username: module initialised (reserved=%d, min=%d, max=%d)", len(u.reserved), u.minLen, u.maxLen)
 	return u, nil
 }
 
@@ -105,11 +133,11 @@ func (u *Username) validate(username string) error {
 	if n == 0 {
 		return &usernameViolation{reason: fmt.Errorf("must not be empty")}
 	}
-	if n < minLength {
-		return &usernameViolation{reason: fmt.Errorf("must be at least %d characters", minLength)}
+	if n < u.minLen {
+		return &usernameViolation{reason: fmt.Errorf("must be at least %d characters", u.minLen)}
 	}
-	if n > maxLength {
-		return &usernameViolation{reason: fmt.Errorf("must be at most %d characters", maxLength)}
+	if n > u.maxLen {
+		return &usernameViolation{reason: fmt.Errorf("must be at most %d characters", u.maxLen)}
 	}
 
 	// First character must be a letter or digit — not _ or -.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,31 @@
 # Configuration & logging
 
+## The principle
+
+authcore is built in two layers: a cryptographic layer that is closed, and a
+policy layer that is open with secure defaults. The split is decided by one
+question: if a user picks the worst legal value for this field, what
+breaks?
+
+- **Their security breaks** - the field is closed. The library ships a
+  single value and the caller cannot weaken it.
+- **Only their own product rule breaks** - the field is open, with today's
+  value as the default. The caller can opt in to a stricter or looser
+  setting without weakening the security floor the library enforces.
+
+### What is open and what is closed, per module
+
+| Module | Open (configurable, secure default) | Closed (security control) |
+|---|---|---|
+| `password` | Work factor: `Memory`, `Iterations`, `Parallelism` · Policy: `MinLength`, `MaxLength`, `RequireUpper`, `RequireLower`, `RequireDigit`, `RequireSymbol` | Argon2id algorithm · 16-byte salt · 32-byte key · PHC output format · constant-time compare · Unicode NFC normalisation |
+| `email` | `RejectPlusAddressing` | RFC 5321/5322 parse and normalisation · IDN punycode conversion |
+| `username` | `MinLength`, `MaxLength`, `ExtraReservedNames`, `AllowReservedNames` | Character set `[a-z0-9_-]` · lowercase + trim normalisation · "must start and end with a letter or digit" rule · "no consecutive specials" rule |
+
+A field listed under "closed" cannot be configured: trying to do so would
+either be rejected at compile time or be a deliberate error in the code.
+The closed set is the homoglyph control, the KDF choice, and the comparison
+discipline - every one of which has a known attack if it is weakened.
+
 ## Config
 
 ```go

--- a/docs/password.md
+++ b/docs/password.md
@@ -33,15 +33,34 @@ case err != nil:
 db.StorePasswordHash(userID, hash)
 ```
 
-`Hash` validates the password **before** spending CPU on hashing:
+`Hash` validates the password **before** spending CPU on hashing. The
+defaults reproduce the policy the library has always enforced, and every
+bound and required class is a [configurable policy field](configuration.md#the-principle),
+not a security primitive:
 
-| Rule | Requirement |
+| Rule | Default |
 |---|---|
-| Length | 12 – 64 characters |
-| Uppercase | At least one (`A`–`Z`, Unicode-aware) |
-| Lowercase | At least one (`a`–`z`, Unicode-aware) |
-| Digit | At least one (`0`–`9`) |
-| Special | At least one (anything that is not a letter or digit) |
+| Length | `MinLength` – `MaxLength` (default 12 – 64 characters) |
+| Uppercase | `RequireUpper` (default `true`) |
+| Lowercase | `RequireLower` (default `true`) |
+| Digit | `RequireDigit` (default `true`) |
+| Special | `RequireSymbol` (default `true`) |
+
+Each `Require*` field is a `*bool`, so that leaving it unset ("keep the
+default") stays distinguishable from setting it to false ("turn this class
+off"). Use `password.Bool` rather than a temporary local:
+
+```go
+cfg := password.DefaultConfig()
+cfg.MinLength = 16
+cfg.RequireSymbol = password.Bool(false) // no symbol required
+pwdMod, err := password.New(auth, cfg)
+```
+
+`ValidatePolicy` reports the rule that was violated in the error message
+("must be at least 16 characters" when you raise `MinLength` to 16, for
+example), so the message you show the user always matches what you
+configured.
 
 Each call also generates a **fresh random salt**, so two hashes of the same
 password are always different strings — but both verify correctly.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -52,6 +52,24 @@ Validation rules (RFC 5321 / RFC 5322):
 > consistent lookup — `User@EXAMPLE.COM` and `user@example.com` are the same
 > address.
 
+### Plus-addressing
+
+Plus-addressing (`user+tag@example.com`) is accepted by default: this is an
+[open policy field](configuration.md#the-principle). A deployment that
+treats `(local, domain)` as the unique account key and wants one mailbox to
+be unable to own N accounts can refuse plus-addressing:
+
+```go
+emailMod, err := email.NewWithConfig(auth, email.Config{
+    RejectPlusAddressing: true,
+})
+// user+tag@example.com is now rejected with the reason "plus-addressing
+// is not allowed".
+```
+
+The structural validation (RFC 5321/5322, IDN punycode, domain rules) is
+unaffected.
+
 > [!NOTE]
 > **Internationalised domains (IDN)** are supported. Unicode domains are
 > converted to ASCII punycode during normalisation:
@@ -121,14 +139,21 @@ db.StoreUser(normalized, ...) // always lowercase, trimmed, validated
 
 Validation rules:
 
-| Rule | Requirement |
+| Rule | Default |
 |---|---|
-| Length | 3 – 32 characters (fixed) |
-| Allowed characters | `[a-z0-9_-]` only |
+| Length | `MinLength` – `MaxLength` (default 3 – 32 characters) |
+| Allowed characters | `[a-z0-9_-]` only (closed - the homoglyph control) |
 | First character | Letter or digit (not `_` or `-`) |
 | Last character | Letter or digit (not `_` or `-`) |
 | Consecutive specials | `__`, `--`, `_-`, `-_` are rejected |
-| Reserved names | Built-in blocklist (fixed) |
+| Reserved names | Built-in blocklist, extended with `Config.ExtraReservedNames` and trimmed with `Config.AllowReservedNames` |
+
+The length bounds and the reserved-names list are
+[configurable policy fields](configuration.md#the-principle). The
+character set, normalisation, and consecutive-specials rule stay closed - 
+widening the character set to Unicode is exactly what enables
+homoglyph impersonation, and is the part of the module that *is* a
+security standard rather than a product default.
 
 > **Always normalize before storing and before querying.** `Alice123` and
 > `alice123` are the same username — store only the canonical (normalized) form.


### PR DESCRIPTION
Closes #326. Closes the configuration half of #325 (items 4 and 5).

Adopts the rule as written in #326: the cryptographic layer is closed, the policy layer is open with secure defaults. A field is configurable when the worst legal value a caller can pick breaks only their own product rule, and fixed when it breaks their security.

Every default reproduces today's behaviour exactly. Nothing gets weaker, and no existing call site changes.

## What opened

| Module | Field | Default |
|---|---|---|
| `password` | `MinLength`, `MaxLength` | 12, 64 |
| `password` | `RequireUpper/Lower/Digit/Symbol` | all on |
| `email` | `RejectPlusAddressing` | off |
| `username` | `MinLength`, `MaxLength` | 3, 32 |
| `username` | `ExtraReservedNames`, `AllowReservedNames` | empty |

The password policy was hardcoded while the README advertised it as "policy-enforced", so a deployment with its own rules had to keep a second validator and run the module's dead policy first. `AllowReservedNames` exists because the built-in blocklist takes `support`, `info`, `test` and `home`, so a company running a real `support` account could not register it.

## Two API decisions worth your eye

**`Require*` are `*bool`, not `bool`.** A plain bool cannot tell "unset" from "deliberately false", and the default has to be true, so the zero value would silently mean on and a caller turning a class off would get it back on. `password.Bool` makes that one line instead of a temporary local taken by address:

```go
cfg := password.DefaultConfig()
cfg.MinLength = 16
cfg.RequireSymbol = password.Bool(false)
```

**`New(p)` is untouched in email and username**, and now calls `NewWithConfig(p, Config{})`. The alternative was changing `New` to take a config, matching `password.New`, but that breaks every consumer for consistency alone. Say so if you would rather have the break; it is cheap to do now and expensive later.

## The character set stays closed, against your own table

#326's table had "Username charset, reserved-name extensions, min/max" open and "Unicode normalization, homoglyph handling" closed, two rows apart. They are the same control. The set is `[a-z0-9_-]` checked byte by byte on already-lowercased input, so the reason a Cyrillic lookalike cannot be registered is not a normalization step, it is that the byte is rejected. Open the set and the homoglyph row protects nothing.

Run the rule's own question on it: a caller who widens the set to Unicode letters lets someone register a name that renders identically to another user's. Their security breaks, so it is closed. Argued in [a comment on #326](https://github.com/Glyndor/authcore/issues/326) before any code was written.

#325 item 5 asked to pin the character set. It is already pinned harder than a config field could pin it, because a config field can be set to something else and a constant cannot. Nothing to build, only to document, which `docs/validation.md` now does.

Also corrected: the comment in `username/config.go` calling the length bounds "a deliberate security standard, not an oversight". No attack gets easier at two characters that is not already possible at three. #326 was right about that label.

## I checked the tests fail when they should

Defaults reproducing today's behaviour is the entire claim, so a green suite proves nothing on its own. Eight sabotages, each reverted:

| Sabotage | Reddens |
|---|---|
| `checkPolicy` ignores `MinLength`, back to a fixed 12 | the min-length test |
| `RequireSymbol` always enforced | the class-off test |
| `rejectPlusAddressing` wired to a constant false | the email test |
| `AllowReservedNames` loop deleted | both exemption tests |
| `ExtraReservedNames` loop deleted | all three addition tests |
| `DefaultConfig().MinLength` set to 10 | five tests, including the boundary and the runnable example |
| `DefaultConfig().RequireSymbol` set to false | the class test and a `Hash` subtest |
| `applyDefaults` overwrites an explicit false | three tests, including `Bool` |

A ninth attempt left the file unchanged. I check with `diff` before reading the result, so it was caught and redone rather than counted as a pass. An inert sabotage reads exactly like a test that works.

**Plus-addressing has no bypass I could find.** A mixed-case `+` is caught, a quoted local part was already refused as malformed, and an address that is both malformed and plussed returns the format error, so the structural check still runs first. That last one was a claim in the working notes, and an asserted ordering is not an exercised one, so I ran it.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go test -race ./...` 9 of 9 packages. Every package stays above the coverage floor of 90: password 97.4, username 94.5, email 92.3.

## Untouched on purpose

Argon2id and its salt and key sizes, the NFC normalization in `Hash`, the email RFC 5321 and 5322 parsing and normalization, the username normalization and the consecutive-separator rule, and the built-in reserved names, which a caller can shrink per name but not clear wholesale.

## Still open from #325

`auth/totp`, `auth/field`, `auth/credential`, and the `Denylist` documentation. #326 said to settle the principle before writing `totp`, which is what this does.
