### PR TITLE
feat(totp): add auth/totp, TOTP with recovery codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ if ok, _ := pwd.Verify("Str0ng-P@ssword!", hash); ok {
 authcore is an in-process library, not a hosted identity platform: it ships no
 database and no HTTP server of its own, generates and manages its own signing
 keys on first run, and each module (password, jwt, apikey, oauth, email,
-username) can be used independently.
+username, totp) can be used independently.
 
 ## Modules
 
@@ -78,13 +78,14 @@ Pick only what you need — each is independent, testable, and safe by default.
 | 📧 | **[email](docs/validation.md)** | Validate + normalize. RFC 5321/5322, optional cached DNS MX check. |
 | 👤 | **[username](docs/validation.md)** | Validate + normalize. Reserved-name blocklist, character rules. |
 | 🗝️ | **[apikey](docs/apikey.md)** | Opaque API keys. Generate, keyed-hash for storage, constant-time verify. |
+| 🔐 | **[totp](docs/totp.md)** | TOTP / RFC 6238 second factor. Enroll, verify (with replay protection), recovery codes. |
 | 🌐 | **[oauth](docs/oauth.md)** | Social login — Google, Microsoft (OIDC) and GitHub, Discord (OAuth2). Auth Code + PKCE, ID-token validation or userinfo. |
 
 ```mermaid
 flowchart LR
     App["Your app"] -->|init once| Core["authcore"]
     Core -->|auto-generates| Keys[("🔑 Ed25519 + HMAC<br/>on disk")]
-    Core -->|Provider| M["password · jwt · apikey · oauth<br/>email · username"]
+    Core -->|Provider| M["password · jwt · apikey · oauth<br/>email · username · totp"]
     M -->|hash · sign · verify| App
 ```
 
@@ -93,7 +94,7 @@ flowchart LR
 **New here? Start with the [Secure login recipe](docs/secure-login.md)** — the
 step-by-step flow that turns these primitives into a login an auditor accepts.
 
-[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
+[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [TOTP](docs/totp.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
 
 Full API reference on [pkg.go.dev](https://pkg.go.dev/github.com/Glyndor/authcore).
 

--- a/auth/totp/config.go
+++ b/auth/totp/config.go
@@ -1,0 +1,165 @@
+package totp
+
+import "fmt"
+
+// Config holds the totp module configuration.
+//
+// The configuration is split into two layers, matching the authcore
+// principle documented in docs/configuration.md:
+//
+//   - The cryptographic layer is CLOSED and is not configurable here.
+//     HMAC-SHA1, 30-second time step, 6-digit codes, 20-byte secrets, and
+//     constant-time comparison are the interoperability baseline: every
+//     widely-used authenticator app ignores the algorithm, digits and
+//     period parameters of an otpauth:// URI and assumes SHA1/6/30, so a
+//     configurable value here would produce an enrollment that works in
+//     your test environment and locks the user out on their phone.
+//   - The policy layer is OPEN with today's value as the default:
+//     SkewSteps (clock-skew window), RecoveryCodeCount (how many recovery
+//     codes to mint), and Issuer (the label shown in the authenticator).
+//
+// What stays fixed regardless of configuration:
+//
+//   - Algorithm: HMAC-SHA1 (RFC 6238 §1.2)
+//   - Time step: 30 seconds
+//   - Code length: 6 decimal digits
+//   - Secret length: 160 bits (20 bytes) per RFC 4226 §4 R1
+//   - Secret encoding: base32, no padding, for manual entry
+//   - Recovery-code length: 10 bytes (80 bits) per code
+//   - Recovery-code hashing: keyed HMAC-SHA256, peppered with the library's
+//     managed refresh secret
+//   - Comparison discipline: crypto/subtle.ConstantTimeCompare, scanning
+//     every entry in the window before returning
+//
+// Start from DefaultConfig and override only what your installation needs:
+//
+//	totpMod, err := totp.New(auth, totp.DefaultConfig())
+//	totpMod, err := totp.New(auth, totp.Config{SkewSteps: 2})
+type Config struct {
+	// SkewSteps is the number of time steps either side of the current one
+	// that Verify will accept. The total window is 2*SkewSteps+1 steps.
+	// A skew of 1 (the default) accepts the current step plus one step on
+	// either side - enough to absorb ordinary clock drift between the
+	// user's device and the server.
+	//
+	// Each extra step on either side widens the window a stolen code stays
+	// valid in by 30 seconds, so the cap is 10 (5 minutes total). The cap
+	// is enforced by validateConfig - larger values are rejected at New().
+	//
+	// The pointer lets the caller express three states: nil means "keep
+	// the default of 1", and an explicit Int(0) means "accept only the
+	// current step". A plain int cannot distinguish "unset" from
+	// "deliberately zero", and getting that wrong is a lockout rather
+	// than a weakening: a caller who left the field alone would silently
+	// get no tolerance at all, and every user whose phone clock drifts by
+	// a few seconds would fail to sign in.
+	//
+	// Must not point to a negative value. Defaults to 1.
+	SkewSteps *int
+
+	// RecoveryCodeCount is how many recovery codes to mint at enrollment.
+	// Recovery codes let a user who has lost their authenticator device
+	// regain access to their account by redeeming a one-time code. Each
+	// code is 10 random bytes (80 bits) formatted as two base32 groups
+	// separated by a hyphen so it can be read off a printout.
+	//
+	// The minimum is 1 (refused: a single code is not a recovery
+	// mechanism). The maximum is 50 (refused: more codes mean a larger
+	// hash list to scan on every verification, with negligible user
+	// benefit past a small handful).
+	//
+	// Defaults to 10.
+	RecoveryCodeCount int
+
+	// Issuer is the human-readable label of the issuing application shown
+	// in the user's authenticator alongside the account name. It is
+	// embedded in the otpauth:// URI both as the path prefix and as the
+	// "issuer" query parameter.
+	//
+	// An empty Issuer is allowed: the URI is then built without the issuer
+	// parameter and the label, and the authenticator will display only
+	// the account name. Set this for every production deployment so users
+	// can tell two enrollments with the same account name apart.
+	//
+	// Defaults to "".
+	Issuer string
+}
+
+// DefaultConfig returns a Config with the library's recommended defaults.
+func DefaultConfig() Config {
+	return Config{
+		SkewSteps:         Int(1),
+		RecoveryCodeCount: 10,
+		Issuer:            "",
+	}
+}
+
+const (
+	maxSkewSteps         = 10 // 10 steps either side = 5 minutes total window
+	minRecoveryCodeCount = 1
+	maxRecoveryCodeCount = 50
+)
+
+// applyDefaults fills zero-value fields with values from DefaultConfig.
+//
+// SkewSteps is left alone: zero is a meaningful value ("no skew, only
+// the current step matches") rather than a sentinel for "unset". The
+// default of 1 is applied when the caller passes no Config at all to
+// New (handled by New, not here). RecoveryCodeCount=0 is filled with
+// the default because no production deployment wants zero recovery
+// codes, and the value is range-checked by validateConfig.
+func applyDefaults(cfg Config) Config {
+	def := DefaultConfig()
+	if cfg.RecoveryCodeCount == 0 {
+		cfg.RecoveryCodeCount = def.RecoveryCodeCount
+	}
+	if cfg.SkewSteps == nil {
+		cfg.SkewSteps = def.SkewSteps
+	}
+	return cfg
+}
+
+// Int returns a pointer to v, for setting SkewSteps on Config.
+//
+// SkewSteps is a pointer so that leaving it unset ("keep the default of
+// one step either side") stays distinguishable from setting it to zero
+// ("accept only the current step"). Without this helper the caller needs
+// a temporary local just to take its address:
+//
+//	zero := 0
+//	cfg.SkewSteps = &zero
+//
+// With it, turning the tolerance window off is one line:
+//
+//	cfg := totp.DefaultConfig()
+//	cfg.SkewSteps = totp.Int(0) // only the current step is accepted
+//	mod, err := totp.New(auth, cfg)
+//
+// This mirrors password.Bool, which exists for the same reason on the
+// password policy fields.
+func Int(v int) *int { return &v }
+
+// validateConfig returns an error if cfg contains invalid values.
+// applyDefaults is always called before validateConfig, so SkewSteps and
+// RecoveryCodeCount are guaranteed to be at least their defaults.
+func validateConfig(cfg Config) error {
+	// applyDefaults always runs first, so SkewSteps is never nil here. The
+	// guard is kept so a future caller of validateConfig cannot panic on a
+	// raw Config that skipped it.
+	if cfg.SkewSteps == nil {
+		return fmt.Errorf("skew steps must be set")
+	}
+	if *cfg.SkewSteps < 0 {
+		return fmt.Errorf("skew steps must not be negative, got %d", *cfg.SkewSteps)
+	}
+	if *cfg.SkewSteps > maxSkewSteps {
+		return fmt.Errorf("skew steps must be at most %d, got %d", maxSkewSteps, *cfg.SkewSteps)
+	}
+	if cfg.RecoveryCodeCount < minRecoveryCodeCount {
+		return fmt.Errorf("recovery code count must be at least %d, got %d", minRecoveryCodeCount, cfg.RecoveryCodeCount)
+	}
+	if cfg.RecoveryCodeCount > maxRecoveryCodeCount {
+		return fmt.Errorf("recovery code count must be at most %d, got %d", maxRecoveryCodeCount, cfg.RecoveryCodeCount)
+	}
+	return nil
+}

--- a/auth/totp/config_default_test.go
+++ b/auth/totp/config_default_test.go
@@ -1,0 +1,45 @@
+package totp
+
+import "testing"
+
+// TestApplyDefaults_zeroConfigUsesTheDocumentedSkew pins the difference
+// between "the caller left SkewSteps alone" and "the caller asked for no
+// tolerance at all". They are the same value in a plain int, and getting
+// them confused is a lockout rather than a weakening: a caller who built
+// New(p) with no Config would silently get a zero-width window, and every
+// user whose phone clock drifts a few seconds would fail to sign in while
+// the field's own documentation promised one step of tolerance.
+//
+// This is why SkewSteps is a *int. If it is ever changed back to an int,
+// the first assertion below fails.
+func TestApplyDefaults_zeroConfigUsesTheDocumentedSkew(t *testing.T) {
+	t.Parallel()
+
+	if got := *applyDefaults(Config{}).SkewSteps; got != 1 {
+		t.Errorf("New(p) with no Config must use the documented default of 1, got %d", got)
+	}
+	if got := *applyDefaults(DefaultConfig()).SkewSteps; got != 1 {
+		t.Errorf("DefaultConfig must agree with the zero Config, got %d", got)
+	}
+	if got := *applyDefaults(Config{SkewSteps: Int(0)}).SkewSteps; got != 0 {
+		t.Errorf("an explicit Int(0) must survive applyDefaults, got %d", got)
+	}
+}
+
+// TestInt_returnsADistinctPointer guards the helper itself. Returning a
+// pointer to a shared variable would let one Config mutate another.
+func TestInt_returnsADistinctPointer(t *testing.T) {
+	t.Parallel()
+
+	a, b := Int(3), Int(3)
+	if a == b {
+		t.Fatal("Int must return a fresh pointer per call, not a shared one")
+	}
+	if *a != 3 || *b != 3 {
+		t.Fatalf("Int(3) must point to 3, got %d and %d", *a, *b)
+	}
+	*a = 7
+	if *b != 3 {
+		t.Error("mutating one Int result changed another: the pointers are shared")
+	}
+}

--- a/auth/totp/enroll_test.go
+++ b/auth/totp/enroll_test.go
@@ -1,0 +1,306 @@
+package totp
+
+// Second half of the totp test suite, split from totp_test.go to stay under
+// the repository's per-file line limit. Shares that file's fixtures
+// (newTOTP, fakeProvider, fixed clocks) because both live in package totp.
+
+import (
+	"encoding/base32"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// ---- Enroll -----------------------------------------------------------------
+
+func TestEnroll_UniqueSecretsAndCodes(t *testing.T) {
+	mod := newTOTP(t, Config{Issuer: "Acme", RecoveryCodeCount: 5})
+	a, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("first Enroll: %v", err)
+	}
+	b, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("second Enroll: %v", err)
+	}
+	if a.Secret == b.Secret {
+		t.Error("two Enroll calls produced the same secret")
+	}
+	if len(a.RecoveryCodes) != 5 || len(b.RecoveryCodes) != 5 {
+		t.Fatalf("RecoveryCodes length = %d and %d, want 5", len(a.RecoveryCodes), len(b.RecoveryCodes))
+	}
+	for i := range a.RecoveryCodes {
+		if a.RecoveryCodes[i] == b.RecoveryCodes[i] {
+			t.Errorf("recovery code %d matched between enrollments", i)
+		}
+	}
+}
+
+func TestEnroll_SecretShape(t *testing.T) {
+	mod := newTOTP(t)
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if len(enr.Secret) != 32 {
+		t.Errorf("secret length = %d, want 32 (20 bytes base32 no padding)", len(enr.Secret))
+	}
+	if _, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(enr.Secret); err != nil {
+		t.Errorf("secret is not valid base32: %v", err)
+	}
+}
+
+func TestEnroll_RecoveryCodesShape(t *testing.T) {
+	mod := newTOTP(t, Config{RecoveryCodeCount: 8})
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if len(enr.RecoveryCodes) != 8 || len(enr.RecoveryHashes) != 8 {
+		t.Fatalf("recovery slice length = %d/%d, want 8", len(enr.RecoveryCodes), len(enr.RecoveryHashes))
+	}
+	for i, c := range enr.RecoveryCodes {
+		// "XXXXXXXX-XXXXXXXX" -> 8 + 1 + 8 = 17 chars, base32 only.
+		if len(c) != 17 {
+			t.Errorf("recovery code %d has length %d, want 17", i, len(c))
+		}
+		if c[8] != '-' {
+			t.Errorf("recovery code %d missing hyphen at position 8: %q", i, c)
+		}
+		plain := strings.ReplaceAll(c, "-", "")
+		if _, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(plain); err != nil {
+			t.Errorf("recovery code %d not valid base32: %v", i, err)
+		}
+		// Hash must be a hex-encoded HMAC-SHA256: 64 lowercase hex chars.
+		if len(enr.RecoveryHashes[i]) != 64 {
+			t.Errorf("recovery hash %d has length %d, want 64", i, len(enr.RecoveryHashes[i]))
+		}
+	}
+}
+
+// ---- URI --------------------------------------------------------------------
+
+func TestEnroll_URI_RoundTrips(t *testing.T) {
+	mod := newTOTP(t, Config{Issuer: "Acme Corp"})
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	u, err := url.Parse(enr.URI)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", enr.URI, err)
+	}
+	if u.Scheme != "otpauth" {
+		t.Errorf("scheme = %q, want otpauth", u.Scheme)
+	}
+	if u.Host != "totp" {
+		t.Errorf("host = %q, want totp", u.Host)
+	}
+	if u.Path != "/Acme%20Corp:alice@example.com" {
+		t.Errorf("path = %q, want /Acme%%20Corp:alice@example.com", u.Path)
+	}
+	q := u.Query()
+	if q.Get("secret") != enr.Secret {
+		t.Errorf("secret query = %q, want %q", q.Get("secret"), enr.Secret)
+	}
+	if q.Get("issuer") != "Acme Corp" {
+		t.Errorf("issuer query = %q, want %q", q.Get("issuer"), "Acme Corp")
+	}
+	if q.Get("algorithm") != "SHA1" {
+		t.Errorf("algorithm = %q, want SHA1", q.Get("algorithm"))
+	}
+	if q.Get("digits") != "6" {
+		t.Errorf("digits = %q, want 6", q.Get("digits"))
+	}
+	if q.Get("period") != "30" {
+		t.Errorf("period = %q, want 30", q.Get("period"))
+	}
+}
+
+// TestEnroll_URI_AwkwardAccountName verifies the URI survives account
+// names containing a colon, a space and a non-ASCII character.
+func TestEnroll_URI_AwkwardAccountName(t *testing.T) {
+	mod := newTOTP(t, Config{Issuer: "Acme"})
+	enr, err := mod.Enroll("Señor López:work@acme.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	u, err := url.Parse(enr.URI)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", enr.URI, err)
+	}
+	if u.Scheme != "otpauth" || u.Host != "totp" {
+		t.Errorf("unexpected host part: scheme=%q host=%q", u.Scheme, u.Host)
+	}
+	// Path must preserve the structural colon between issuer and
+	// account, and percent-encode the awkward characters inside each
+	// segment.
+	wantPath := "/Acme:" + url.PathEscape("Señor López:work@acme.com")
+	if u.Path != wantPath {
+		t.Errorf("path = %q, want %q", u.Path, wantPath)
+	}
+	// Round-trip the issuer-segment alone: it must be recoverable.
+	issuerSeg := strings.SplitN(strings.TrimPrefix(u.Path, "/"), ":", 2)[0]
+	got, err := url.PathUnescape(issuerSeg)
+	if err != nil {
+		t.Fatalf("PathUnescape(%q): %v", issuerSeg, err)
+	}
+	if got != "Acme" {
+		t.Errorf("issuer segment = %q, want %q", got, "Acme")
+	}
+}
+
+func TestEnroll_URI_NoIssuer(t *testing.T) {
+	// Empty Issuer means the URI is built without the issuer parameter
+	// and the label, so the path is just "/" + account.
+	mod := newTOTP(t)
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	u, err := url.Parse(enr.URI)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	if u.Path != "/alice@example.com" {
+		t.Errorf("path = %q, want /alice@example.com", u.Path)
+	}
+	if u.Query().Get("issuer") != "" {
+		t.Errorf("issuer query should be empty, got %q", u.Query().Get("issuer"))
+	}
+}
+
+// ---- Recovery codes ---------------------------------------------------------
+
+func TestVerifyRecoveryCode_AllMatch(t *testing.T) {
+	mod := newTOTP(t, Config{RecoveryCodeCount: 8})
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	for i, c := range enr.RecoveryCodes {
+		gotIdx, ok := mod.VerifyRecoveryCode(c, enr.RecoveryHashes)
+		if !ok {
+			t.Errorf("recovery code %d (%q) did not verify", i, c)
+			continue
+		}
+		if gotIdx != i {
+			t.Errorf("recovery code %d returned index %d", i, gotIdx)
+		}
+	}
+}
+
+func TestVerifyRecoveryCode_WrongCode(t *testing.T) {
+	mod := newTOTP(t, Config{RecoveryCodeCount: 4})
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if _, ok := mod.VerifyRecoveryCode("AAAA1111-BBBB2222", enr.RecoveryHashes); ok {
+		t.Error("a non-mint code verified as if it were in the list")
+	}
+	if _, ok := mod.VerifyRecoveryCode("", enr.RecoveryHashes); ok {
+		t.Error("empty code verified")
+	}
+}
+
+func TestVerifyRecoveryCode_Normalisation(t *testing.T) {
+	mod := newTOTP(t, Config{RecoveryCodeCount: 4})
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	c := enr.RecoveryCodes[2]
+
+	variants := []string{
+		c,                               // as-is
+		strings.ReplaceAll(c, "-", ""),  // no hyphen
+		strings.ToUpper(c),              // uppercase (base32 letters)
+		strings.ReplaceAll(c, "-", " "), // space instead of hyphen
+		strings.ReplaceAll(strings.ToUpper(c), "-", " "),
+	}
+	for _, v := range variants {
+		idx, ok := mod.VerifyRecoveryCode(v, enr.RecoveryHashes)
+		if !ok || idx != 2 {
+			t.Errorf("variant %q failed to verify (idx=%d ok=%v)", v, idx, ok)
+		}
+	}
+}
+
+func TestVerifyRecoveryCode_EmptyList(t *testing.T) {
+	mod := newTOTP(t)
+	if idx, ok := mod.VerifyRecoveryCode("ABCD1234-EFGH5678", nil); ok {
+		t.Errorf("non-empty code matched an empty hash list (idx=%d)", idx)
+	}
+}
+
+func TestHashRecoveryCode_MatchesEnrollmentHashes(t *testing.T) {
+	mod := newTOTP(t)
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	for i, c := range enr.RecoveryCodes {
+		if got := mod.HashRecoveryCode(c); got != enr.RecoveryHashes[i] {
+			t.Errorf("HashRecoveryCode(%q) = %q, want %q", c, got, enr.RecoveryHashes[i])
+		}
+	}
+}
+
+func TestHashRecoveryCode_Peppered(t *testing.T) {
+	// Hashing the same code under two different refresh secrets must
+	// produce different digests; otherwise the pepper is not applied.
+	p1 := newFakeProvider(t)
+	p2 := fakeProvider{keys: fakeKeys{secret: []byte(strings.Repeat("z", 32))}}
+	m1, _ := New(p1)
+	m2, _ := New(p2)
+	if m1.HashRecoveryCode("ABCD1234-EFGH5678") == m2.HashRecoveryCode("ABCD1234-EFGH5678") {
+		t.Error("hash is identical under different server secrets; HMAC pepper is not applied")
+	}
+}
+
+// ---- validateConfig --------------------------------------------------------
+
+func TestValidateConfig_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"SkewSteps above cap", Config{SkewSteps: Int(11)}},
+		{"negative SkewSteps", Config{SkewSteps: Int(-1)}},
+		{"RecoveryCodeCount below floor", Config{RecoveryCodeCount: -1}},
+		{"RecoveryCodeCount 51", Config{RecoveryCodeCount: 51}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := New(newFakeProvider(t), c.cfg)
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Errorf("New(%+v) = %v, want ErrInvalidConfig", c.cfg, err)
+			}
+		})
+	}
+}
+
+func TestValidateConfig_RecoveryCodeCountZeroFallsBackToDefault(t *testing.T) {
+	// RecoveryCodeCount 0 falls back to the default (10) via applyDefaults,
+	// so it must NOT be rejected by validateConfig.
+	if _, err := New(newFakeProvider(t), Config{RecoveryCodeCount: 0}); err != nil {
+		t.Errorf("RecoveryCodeCount 0 should default, got %v", err)
+	}
+}
+
+func TestValidateConfig_Boundaries(t *testing.T) {
+	// SkewSteps exactly at the cap (10) must be accepted.
+	if _, err := New(newFakeProvider(t), Config{SkewSteps: Int(10)}); err != nil {
+		t.Errorf("SkewSteps=10 should be accepted: %v", err)
+	}
+	// RecoveryCodeCount at the boundaries (1, 50) must be accepted.
+	if _, err := New(newFakeProvider(t), Config{RecoveryCodeCount: 1}); err != nil {
+		t.Errorf("RecoveryCodeCount=1 should be accepted: %v", err)
+	}
+	if _, err := New(newFakeProvider(t), Config{RecoveryCodeCount: 50}); err != nil {
+		t.Errorf("RecoveryCodeCount=50 should be accepted: %v", err)
+	}
+}

--- a/auth/totp/errors.go
+++ b/auth/totp/errors.go
@@ -1,0 +1,50 @@
+package totp
+
+import "errors"
+
+// Sentinel errors returned by the totp package.
+// Use errors.Is to check for these in calling code.
+var (
+	// ErrInvalidConfig is returned by New when the provided Config fails
+	// validation (e.g. SkewSteps above 10, RecoveryCodeCount out of range).
+	//
+	// Safety: INTERNAL — a startup/programming error. Treat as a 500.
+	ErrInvalidConfig = errors.New("totp: invalid configuration")
+
+	// ErrInvalidSecret is returned by Verify when the presented secret is not
+	// valid base32 (with or without padding). The caller should treat this
+	// as a programming or storage error: secrets minted by Enroll are always
+	// valid, so an invalid one means the stored value was corrupted.
+	//
+	// Safety: INTERNAL — do not echo back to the client.
+	ErrInvalidSecret = errors.New("totp: invalid base32 secret")
+
+	// ErrMalformedCode is returned by Verify when the candidate code is not
+	// exactly six decimal digits. Distinct from ErrInvalidCode so the caller
+	// can tell apart "the code shape is wrong" from "the code is the right
+	// shape but does not match".
+	//
+	// Safety: CLIENT-SAFE — both cases are the same outcome to the user
+	// (reject), but the distinction is useful for logs and for rate-limiting
+	// policies that want to count malformed inputs separately.
+	ErrMalformedCode = errors.New("totp: code must be six decimal digits")
+
+	// ErrInvalidCode is returned by Verify when the candidate code has the
+	// right shape (six digits) but does not match any time step in the
+	// verification window.
+	//
+	// Safety: CLIENT-SAFE — return a generic "unauthorized" to the client.
+	ErrInvalidCode = errors.New("totp: code does not match")
+
+	// ErrCodeReused is returned by Verify when the candidate code matches a
+	// time step that has already been accepted (one whose step is less than
+	// or equal to lastUsedStep). It is the module's only signal that a
+	// replay was attempted; the caller should treat it as a security event
+	// and revoke the user's second factor.
+	//
+	// Safety: CLIENT-SAFE — the caller chooses the response. The user-visible
+	// message is normally the same as ErrInvalidCode to avoid telling an
+	// attacker the code was once valid, but the caller MUST log this case
+	// distinctly because it is the signal that a stolen code was tried.
+	ErrCodeReused = errors.New("totp: code already used")
+)

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -1,0 +1,455 @@
+// Package totp provides Time-based One-Time Password (TOTP, RFC 6238)
+// authentication for authcore.
+//
+// TOTP is the algorithm behind the six-digit rotating codes shown by
+// Google Authenticator, 1Password, Authy and every other authenticator
+// app. authcore enrolls a user by minting a high-entropy shared secret,
+// returns an otpauth:// URI that the user's app scans as a QR code, and
+// verifies the codes the user subsequently produces - all in constant
+// time, with built-in replay protection.
+//
+//	auth, _   := authcore.New(authcore.DefaultConfig())
+//	totpMod, _ := totp.New(auth)
+//
+//	// Enroll - show the URI to the user, store secret + recovery hashes.
+//	enr, _ := totpMod.Enroll("alice@example.com")
+//	db.StoreTOTP(userID, enr.Secret, enr.RecoveryHashes)
+//
+//	// Verify - compare, then store the returned step as lastUsedStep.
+//	step, err := totpMod.Verify(secret, presented, lastStep)
+//	if errors.Is(err, totp.ErrCodeReused) { revokeFactor(userID); return }
+//	if err != nil { return http.StatusUnauthorized }
+//	db.SetLastStep(userID, step)
+//
+// # What is fixed and what is open
+//
+// The cryptographic layer is closed: HMAC-SHA1, 30-second time step,
+// 6-digit codes, 20-byte secrets and constant-time comparison are the
+// interoperability baseline - every widely-used authenticator app
+// ignores the algorithm, digits and period parameters of an otpauth://
+// URI and assumes SHA1/6/30. A configurable value here produces an
+// enrollment that works in your test environment and locks the user out
+// on their phone.
+//
+// The policy layer is open with secure defaults: the clock-skew window
+// (SkewSteps), the number of recovery codes (RecoveryCodeCount) and the
+// issuer label (Issuer) can be tuned per deployment without weakening
+// the security floor. See docs/configuration.md for the principle.
+//
+// # Replay protection
+//
+// A TOTP code stays valid for its whole 30-second window, so an attacker
+// who observes one can replay it until the window closes. The module
+// refuses to hide the problem: Verify returns the matched time step
+// and refuses any step at or below lastUsedStep with ErrCodeReused. A
+// caller who always passes 0 has NO replay protection - that is
+// documented on Verify itself.
+package totp
+
+import (
+	"crypto/hmac"
+	"crypto/rand" //nolint:gosec // CSPRNG draws for secrets and recovery codes
+	"crypto/sha1" //nolint:gosec // HMAC-SHA1 is the TOTP interoperability baseline; SHA1 collision attacks do not apply to HMAC
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base32"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/internal/clock"
+)
+
+// Compile-time assertion: *TOTP must satisfy authcore.Module.
+var _ authcore.Module = (*TOTP)(nil)
+
+// Cryptographic constants fixed by RFC 6238 §1.2 and the otpauth
+// interoperability baseline. They are intentionally not configurable.
+const (
+	digits    = 6  // every authenticator app assumes this
+	timeStep  = 30 // 30-second window
+	secretLen = 20 // 160-bit shared secret per RFC 4226 §4 R1
+	algoSHA1  = "SHA1"
+)
+
+// recoveryLen is the byte length of a single recovery code CSPRNG draw.
+// 10 bytes = 80 bits, formatted as two base32 groups of 8 chars joined
+// by a hyphen (e.g. "ABCD1234-EFGH5678").
+const recoveryLen = 10
+
+// Enrollment is the result of Enroll.
+//
+// Show Secret, URI and RecoveryCodes to the user EXACTLY ONCE - none is
+// recoverable afterwards. Persist Secret (the lookup key, base32) and
+// RecoveryHashes (the verification material). Never persist the raw
+// RecoveryCodes; they must not survive the enrollment request.
+type Enrollment struct {
+	// Secret is the shared secret in base32 (no padding), the form
+	// authenticator apps accept for manual entry.
+	Secret string
+	// URI is the otpauth:// URI to encode in the QR code the user scans.
+	URI string
+	// RecoveryCodes are the raw recovery codes, formatted as two base32
+	// groups of 8 chars separated by a hyphen. Hand them to the user
+	// ONCE; the caller must delete them from memory after display.
+	RecoveryCodes []string
+	// RecoveryHashes are the corresponding HMAC-SHA256 digests of the
+	// raw codes (peppered with the library's refresh secret). Store
+	// these and pass them to VerifyRecoveryCode. The mapping is
+	// positional: RecoveryHashes[i] is the hash of RecoveryCodes[i].
+	RecoveryHashes []string
+}
+
+// TOTP is the TOTP module.
+//
+// Construct one instance at application startup using New and share it
+// across goroutines. TOTP is safe for concurrent use after construction.
+type TOTP struct {
+	cfg    Config
+	log    authcore.Logger
+	secret []byte      // HMAC-SHA256 pepper for recovery-code hashing
+	clock  clock.Clock // injected; replaced by clock.Fixed in tests
+}
+
+// New creates a TOTP module.
+//
+// cfg is optional - omit it, or pass a zero-value Config, to apply the
+// safe defaults (SkewSteps=1, RecoveryCodeCount=10, Issuer="").
+//
+//	totpMod, err := totp.New(auth)                      // defaults
+//	totpMod, err := totp.New(auth, totp.DefaultConfig()) // explicit
+//	totpMod, err := totp.New(auth, totp.Config{Issuer: "Acme"})
+//
+// One caveat for the zero-value Config{}: SkewSteps=0 is a meaningful
+// value ("no skew, only the current step matches"), not a sentinel
+// for "use the default", so applyDefaults deliberately does not
+// substitute 1 in its place. To get SkewSteps=1 with no other
+// configuration, pass nothing to New, or pass DefaultConfig().
+//
+// The module reads the parent AuthCore's logger and refresh secret; it
+// generates no key material of its own.
+func New(p authcore.Provider, cfg ...Config) (*TOTP, error) {
+	var resolved Config
+	if len(cfg) > 0 {
+		resolved = applyDefaults(cfg[0])
+	} else {
+		resolved = DefaultConfig()
+	}
+	if err := validateConfig(resolved); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	t := &TOTP{
+		cfg:    resolved,
+		log:    p.Logger(),
+		secret: p.Keys().RefreshSecret(),
+		clock:  clock.New(p.Config().Timezone),
+	}
+	t.log.Info("totp: module initialised (skew=%d, recovery_codes=%d, issuer=%q)",
+		resolved.SkewSteps, resolved.RecoveryCodeCount, resolved.Issuer)
+	return t, nil
+}
+
+// Name returns the module's unique identifier. It implements authcore.Module.
+func (t *TOTP) Name() string { return "totp" }
+
+// Enroll generates a fresh shared secret for accountName, an otpauth://
+// URI the user's app can scan as a QR code, and a set of recovery codes.
+// Returned values must be shown to the user ONCE (URI as QR, RecoveryCodes
+// as a printable list). An empty Config.Issuer means the URI is built
+// without the issuer parameter and the label, and the authenticator
+// displays only the account name.
+func (t *TOTP) Enroll(accountName string) (*Enrollment, error) {
+	secretBytes, err := randomBytes(secretLen)
+	if err != nil {
+		return nil, fmt.Errorf("totp: generate secret: %w", err)
+	}
+	secret := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(secretBytes)
+
+	uri, err := buildURI(t.cfg.Issuer, accountName, secret)
+	if err != nil {
+		return nil, fmt.Errorf("totp: build uri: %w", err)
+	}
+
+	rawCodes := make([]string, t.cfg.RecoveryCodeCount)
+	hashes := make([]string, t.cfg.RecoveryCodeCount)
+	for i := 0; i < t.cfg.RecoveryCodeCount; i++ {
+		buf, err := randomBytes(recoveryLen)
+		if err != nil {
+			return nil, fmt.Errorf("totp: generate recovery code: %w", err)
+		}
+		encoded := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf)
+		formatted := formatRecoveryCode(encoded)
+		rawCodes[i] = formatted
+		// hashRecoveryCode normalises on the way in, so the stored
+		// hash matches what VerifyRecoveryCode computes regardless
+		// of how the user typed the code.
+		hashes[i] = t.hashRecoveryCode(formatted)
+	}
+
+	t.log.Debug("totp: enrolled (account=%q, recovery_codes=%d)", accountName, len(rawCodes))
+
+	return &Enrollment{
+		Secret:         secret,
+		URI:            uri,
+		RecoveryCodes:  rawCodes,
+		RecoveryHashes: hashes,
+	}, nil
+}
+
+// Verify checks candidate code against secret for the current time step
+// and the configured skew window. It returns the time step the code
+// matched on success.
+//
+// # Replay protection
+//
+// lastUsedStep is REQUIRED. Pass the time step Verify returned on the
+// previous successful verification for this user (0 if no previous
+// verification is known). Any step at or below lastUsedStep is refused
+// with ErrCodeReused - even if the code is otherwise valid.
+//
+// A caller who always passes 0 has NO replay protection: every code
+// that matches the current window is accepted, including codes the
+// user has already used. That is correct for a first verification, and
+// the documented wrong behaviour for every other.
+//
+// Storing the returned step:
+//
+//	step, err := totpMod.Verify(secret, presented, lastStep)
+//	switch {
+//	case errors.Is(err, totp.ErrCodeReused):
+//	    // A code already accepted was tried again - security event.
+//	    log.Warn("totp: replay attempt")
+//	    revokeFactor(userID)
+//	    return
+//	case err != nil:
+//	    return http.StatusUnauthorized
+//	}
+//	db.SetLastStep(userID, step)
+//
+// Errors:
+//
+//	totp.ErrInvalidCode   - six digits, matches no step in the window
+//	totp.ErrMalformedCode - not six decimal digits
+//	totp.ErrInvalidSecret - secret is not valid base32
+//	totp.ErrCodeReused    - matches a step at or below lastUsedStep
+func (t *TOTP) Verify(secret, code string, lastUsedStep uint64) (uint64, error) {
+	if !isSixDigits(code) {
+		return 0, ErrMalformedCode
+	}
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return 0, err
+	}
+
+	currentStep := uint64(t.clock.Now().Unix()) / timeStep
+
+	// Scan every step in the window. Never early-return on the first
+	// match: that would let an attacker distinguish "matched the
+	// current step" from "matched a neighbouring step" by timing.
+	var matchedStep uint64
+	var matched byte
+	skew := uint64(*t.cfg.SkewSteps)
+	// When currentStep is smaller than skew the lower bound wraps to a
+	// value near the top of the uint64 range, which is above the upper
+	// bound, so the loop body does not run and Verify reports no match.
+	// That needs the clock to read within skew steps of the Unix epoch, so
+	// it cannot happen in production, and reporting no match is the safe
+	// answer when it does. There is no negative step: this is uint64.
+	for step := currentStep - skew; step <= currentStep+skew; step++ {
+		if stepMatches(step, key, code) {
+			matched = 1
+			matchedStep = step
+		}
+	}
+
+	if matched == 0 {
+		return 0, ErrInvalidCode
+	}
+	if matchedStep <= lastUsedStep {
+		return 0, ErrCodeReused
+	}
+	return matchedStep, nil
+}
+
+// HashRecoveryCode returns the keyed HMAC-SHA256 hex digest of code,
+// matching the values stored in Enrollment.RecoveryHashes.
+func (t *TOTP) HashRecoveryCode(code string) string {
+	return t.hashRecoveryCode(code)
+}
+
+// VerifyRecoveryCode reports whether code matches any of storedHashes,
+// scanning every hash in constant time. Returns the zero-based index of
+// the matched hash and true on success. The caller MUST mark that code
+// as used (delete or flag the row) before the next call - otherwise the
+// same code can be redeemed repeatedly.
+//
+// Verification normalises code on the way in (hyphens and spaces are
+// stripped, letters are uppercased), so users can read codes off a
+// printout with any grouping they like.
+func (t *TOTP) VerifyRecoveryCode(code string, storedHashes []string) (int, bool) {
+	candidate := t.hashRecoveryCode(normalizeRecoveryCode(code))
+	var matchedIdx int
+	var matched byte
+	for i, h := range storedHashes {
+		if subtle.ConstantTimeCompare([]byte(candidate), []byte(h)) == 1 {
+			matched = 1
+			matchedIdx = i
+		}
+	}
+	if matched == 0 {
+		return 0, false
+	}
+	return matchedIdx, true
+}
+
+// randomBytes returns n bytes of CSPRNG output.
+func randomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// hashRecoveryCode returns the keyed HMAC-SHA256 hex digest of the
+// normalised form of code (no hyphens, no spaces, uppercase), peppered
+// with the library's managed refresh secret. Normalising here means
+// Enroll, HashRecoveryCode and VerifyRecoveryCode all hash the same
+// byte sequence regardless of how the user typed the code.
+func (t *TOTP) hashRecoveryCode(code string) string {
+	mac := hmac.New(sha256.New, t.secret)
+	mac.Write([]byte(normalizeRecoveryCode(code)))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// decodeSecret decodes a base32 secret (with or without padding) into
+// raw bytes. Empty input is invalid: Enroll never produces an empty
+// secret, so an empty value here means a corrupted store.
+func decodeSecret(s string) ([]byte, error) {
+	if s == "" {
+		return nil, ErrInvalidSecret
+	}
+	enc := base32.StdEncoding.WithPadding(base32.NoPadding)
+	if len(s)%8 != 0 {
+		// Tolerate padded input as well.
+		enc = base32.StdEncoding
+	}
+	key, err := enc.DecodeString(s)
+	if err != nil || len(key) == 0 {
+		return nil, ErrInvalidSecret
+	}
+	return key, nil
+}
+
+// stepMatches reports whether code equals the 6-digit TOTP value for
+// step under key, comparing in constant time.
+func stepMatches(step uint64, key []byte, code string) bool {
+	otp := generateTOTP(key, step)
+	return subtle.ConstantTimeCompare([]byte(otp), []byte(code)) == 1
+}
+
+// generateTOTP returns the 6-digit decimal TOTP value for step under
+// key (RFC 4226 HOTP on an 8-byte big-endian counter).
+func generateTOTP(key []byte, step uint64) string {
+	mac := hmac.New(sha1.New, key) //nolint:gosec // HMAC-SHA1 is the TOTP interoperability baseline
+	var counter [8]byte
+	binary.BigEndian.PutUint64(counter[:], step)
+	mac.Write(counter[:])
+	sum := mac.Sum(nil)
+	// RFC 4226 §5.3 dynamic truncation.
+	offset := sum[len(sum)-1] & 0x0F
+	truncated := (uint32(sum[offset])&0x7F)<<24 |
+		uint32(sum[offset+1])<<16 |
+		uint32(sum[offset+2])<<8 |
+		uint32(sum[offset+3])
+	mod := truncated % 1_000_000
+	return fmt.Sprintf("%06d", mod)
+}
+
+// buildURI assembles the otpauth:// URI for the enrollment.
+//
+// With Issuer set:
+//
+//	otpauth://totp/{issuer}:{account}?secret={secret}&issuer={issuer}
+//
+// Both issuer occurrences are percent-encoded; the colon between them
+// stays literal (it is structural). With Issuer empty:
+//
+//	otpauth://totp/{account}?secret={secret}
+//
+// The authenticator algorithm, digits and period are also included so
+// any client that does parse them sees the closed defaults.
+func buildURI(issuer, account, secret string) (string, error) {
+	q := url.Values{}
+	q.Set("secret", secret)
+	q.Set("algorithm", algoSHA1)
+	q.Set("digits", strconv.Itoa(digits))
+	q.Set("period", strconv.Itoa(timeStep))
+
+	var path string
+	if issuer != "" {
+		// The colon is structural; ":", "@" and the sub-delims are
+		// safe inside a URL path (RFC 3986 §3.3) so url.URL does
+		// not re-escape it.
+		path = "/" + url.PathEscape(issuer) + ":" + url.PathEscape(account)
+		q.Set("issuer", issuer)
+	} else {
+		path = "/" + url.PathEscape(account)
+	}
+
+	u := url.URL{
+		Scheme:   "otpauth",
+		Host:     "totp",
+		Path:     path,
+		RawQuery: q.Encode(),
+	}
+	return u.String(), nil
+}
+
+// isSixDigits reports whether s is exactly six ASCII decimal digits.
+func isSixDigits(s string) bool {
+	if len(s) != 6 {
+		return false
+	}
+	for i := 0; i < 6; i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// formatRecoveryCode inserts a hyphen at the midpoint of an 8-character
+// base32 string. 10 raw bytes encode to 16 base32 chars, so the split
+// is 8/8: "ABCD1234EFGH5678" -> "ABCD1234-EFGH5678".
+func formatRecoveryCode(encoded string) string {
+	if len(encoded) != 16 {
+		return encoded
+	}
+	return encoded[:8] + "-" + encoded[8:]
+}
+
+// normalizeRecoveryCode strips hyphens and spaces and uppercases so
+// users can read codes off a printout with any grouping.
+func normalizeRecoveryCode(code string) string {
+	var b strings.Builder
+	b.Grow(len(code))
+	for i := 0; i < len(code); i++ {
+		c := code[i]
+		switch {
+		case c == '-' || c == ' ':
+			// drop
+		case c >= 'a' && c <= 'z':
+			b.WriteByte(c - 32)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}

--- a/auth/totp/totp_fuzz_test.go
+++ b/auth/totp/totp_fuzz_test.go
@@ -1,0 +1,95 @@
+package totp
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Glyndor/authcore/internal/clock"
+)
+
+// FuzzVerify drives Verify with arbitrary secret/code pairs. Both inputs
+// come from the network (the secret from the user's stored row, the
+// code from the form), so neither must panic. Verify must also never
+// report a successful match for a random input: with a fixed clock and
+// a known-good secret, the only inputs that succeed are the published
+// TOTP values for the current window, and the fuzzer corpus seeds
+// deliberately miss those.
+func FuzzVerify(f *testing.F) {
+	mod, err := New(newFakeProvider(f))
+	if err != nil {
+		f.Fatalf("totp.New: %v", err)
+	}
+	mod.clock = clock.Fixed(time.Unix(1234567890, 0).UTC())
+
+	// Seed with realistic and adversarial inputs.
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		f.Fatalf("Enroll: %v", err)
+	}
+	f.Add(enr.Secret, "000000")
+	f.Add(enr.Secret, "999999")
+	f.Add(enr.Secret, "")
+	f.Add(enr.Secret, "123456")
+	f.Add("not-base32!@#", "123456")
+	f.Add("", "123456")
+	f.Add(enr.Secret, "abcdef")
+	f.Add(enr.Secret, "12345")
+	f.Add(enr.Secret, "1234567")
+	f.Add(enr.Secret, "０１２３４５") // fullwidth digits
+
+	f.Fuzz(func(t *testing.T, secret, code string) {
+		// Both lastUsedStep values: 0 (no replay protection) and a
+		// large number (must reject everything as "already used" if
+		// it ever matched). Neither path may panic.
+		_, _ = mod.Verify(secret, code, 0)
+		_, _ = mod.Verify(secret, code, 1<<63)
+	})
+}
+
+// FuzzVerifyRecoveryCode drives VerifyRecoveryCode with arbitrary code
+// input against a hash list freshly minted by this module. The code
+// comes from the user (and so is adversarial); the hashes come from
+// the database (and so can be any byte sequence the application stored).
+// The function must never panic and must never report a match for a
+// code that was not actually minted by this module.
+func FuzzVerifyRecoveryCode(f *testing.F) {
+	mod, err := New(newFakeProvider(f))
+	if err != nil {
+		f.Fatalf("totp.New: %v", err)
+	}
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		f.Fatalf("Enroll: %v", err)
+	}
+	stored := enr.RecoveryHashes
+
+	// Seeds: real codes from this module, plus adversarial garbage
+	// that must not be accepted.
+	f.Add(enr.RecoveryCodes[0])
+	f.Add("")
+	f.Add("AAAA1111-BBBB2222")
+	f.Add("\x00\x00\x00")
+	f.Add(strings.Repeat("A", 1024))
+
+	f.Fuzz(func(t *testing.T, code string) {
+		// Vary the hash list shape too: empty, freshly-minted,
+		// oversized. Each variation is fed as a sub-call rather than
+		// as a fuzzer argument because Go fuzzing accepts only a
+		// limited set of types in the signature.
+		cases := [][]string{nil, {}, stored}
+		for _, hashes := range cases {
+			idx, ok := mod.VerifyRecoveryCode(code, hashes)
+			if !ok {
+				continue
+			}
+			// A match is only valid if the stored hash equals the
+			// hash of the presented code under the same pepper.
+			if got := mod.HashRecoveryCode(code); got != hashes[idx] {
+				t.Fatalf("VerifyRecoveryCode accepted code %q at index %d, "+
+					"but HashRecoveryCode(%q) = %q != hashes[%d] = %q",
+					code, idx, code, got, idx, hashes[idx])
+			}
+		}
+	})
+}

--- a/auth/totp/totp_test.go
+++ b/auth/totp/totp_test.go
@@ -1,0 +1,362 @@
+package totp
+
+// Internal test package (package totp, not package totp_test) so that the
+// clock can be replaced with clock.Fixed and the test secrets generated
+// from raw bytes match what the production code base32-decodes back. This
+// matches the pattern in auth/jwt where time-sensitive tests live inside
+// the package's own test scope.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base32"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/internal/clock"
+)
+
+// ---- test infrastructure ----------------------------------------------------
+
+type fakeKeys struct {
+	secret []byte
+}
+
+func (fakeKeys) PrivateKey() ed25519.PrivateKey { return nil }
+func (fakeKeys) PublicKey() ed25519.PublicKey   { return nil }
+func (k fakeKeys) RefreshSecret() []byte        { return k.secret }
+func (fakeKeys) KeyID() string                  { return "test" }
+
+type fakeProvider struct{ keys authcore.Keys }
+
+func (fakeProvider) Config() authcore.Config { return authcore.DefaultConfig() }
+func (fakeProvider) Logger() authcore.Logger { return silentLogger{} }
+func (p fakeProvider) Keys() authcore.Keys   { return p.keys }
+
+type silentLogger struct{}
+
+func (silentLogger) Debug(string, ...any) {}
+func (silentLogger) Info(string, ...any)  {}
+func (silentLogger) Warn(string, ...any)  {}
+func (silentLogger) Error(string, ...any) {}
+
+func newFakeProvider(tb testing.TB) fakeProvider {
+	tb.Helper()
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		tb.Fatalf("generate test HMAC secret: %v", err)
+	}
+	return fakeProvider{keys: fakeKeys{secret: secret}}
+}
+
+// epoch is a fixed reference time used across tests that need a known
+// "now" without sleeping.
+var epoch = time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+// newTOTP creates a TOTP module with a fixed clock pinned to epoch.
+func newTOTP(tb testing.TB, cfg ...Config) *TOTP {
+	tb.Helper()
+	mod, err := New(newFakeProvider(tb), cfg...)
+	if err != nil {
+		tb.Fatalf("totp.New: %v", err)
+	}
+	mod.clock = clock.Fixed(epoch)
+	return mod
+}
+
+// ---- Name / default config -------------------------------------------------
+
+func TestName(t *testing.T) {
+	m := newTOTP(t)
+	if m.Name() != "totp" {
+		t.Errorf("Name() = %q, want totp", m.Name())
+	}
+}
+
+func TestNew_DefaultConfigSucceeds(t *testing.T) {
+	_, err := New(newFakeProvider(t))
+	if err != nil {
+		t.Errorf("New() with default config returned error: %v", err)
+	}
+}
+
+// ---- RFC 6238 Appendix B test vectors ---------------------------------------
+//
+// The reference secret is the 20 ASCII bytes of "12345678901234567890".
+// Verify must accept the published (time, code) triples for HMAC-SHA1.
+// These are the only assertions that check the implementation against
+// the standard rather than against itself, so they are mandatory.
+
+const rfcSecretASCII = "12345678901234567890"
+
+// rfcSecretB32 is rfcSecretASCII encoded as base32 without padding.
+// 20 bytes -> 32 base32 chars exactly.
+var rfcSecretB32 = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(rfcSecretASCII))
+
+// rfcVectors is the RFC 6238 Appendix B HMAC-SHA1 test vector table.
+//
+// The published TOTP column in the RFC is 8-digit (the RFC's chosen
+// digit count). The module under test enforces the closed interop
+// baseline of 6 digits (digits=6) per docs/configuration.md: a
+// configurable value here would lock the user out of every
+// widely-used authenticator app, so the module ships one value. The
+// 8-digit codes are kept in the table for reference; code6 is the
+// 6-digit equivalent computed as the RFC's HOTP truncated value mod
+// 10^6, zero-padded - the HMAC and dynamic truncation are identical,
+// only the final mod differs.
+//
+// For each (time, secret) pair, Verify MUST succeed with code6 and
+// the returned step MUST equal time/30. If a vector does not pass,
+// the implementation is wrong; do not edit the table.
+var rfcVectors = []struct {
+	name  string
+	time  int64
+	code8 string // RFC 6238 Appendix B published value (8 digits)
+	code6 string // 6-digit equivalent (mod 10^6, zero-padded)
+}{
+	{"step 1 (T=59)", 59, "94287082", "287082"},
+	{"step 37037036 (T=1111111109)", 1111111109, "07081804", "081804"},
+	{"step 37037037 (T=1111111111)", 1111111111, "14050471", "050471"},
+	{"step 41152263 (T=1234567890)", 1234567890, "89005924", "005924"},
+	{"step 66666666 (T=2000000000)", 2000000000, "69279037", "279037"},
+	{"step 666666666 (T=20000000000)", 20000000000, "65353130", "353130"},
+}
+
+func TestVerify_RFC6238AppendixB(t *testing.T) {
+	mod := newTOTP(t, Config{SkewSteps: Int(0)}) // exact match only
+	for _, v := range rfcVectors {
+		t.Run(v.name, func(t *testing.T) {
+			mod.clock = clock.Fixed(time.Unix(v.time, 0).UTC())
+			step, err := mod.Verify(rfcSecretB32, v.code6, 0)
+			if err != nil {
+				t.Fatalf("Verify(%q) at t=%d (RFC %s) returned err=%v, want nil",
+					v.code6, v.time, v.code8, err)
+			}
+			want := uint64(v.time) / timeStep
+			if step != want {
+				t.Errorf("Verify(%q) at t=%d returned step=%d, want %d",
+					v.code6, v.time, step, want)
+			}
+		})
+	}
+}
+
+// rfcVectorsSkew1 is the same set but with a generous skew window so a
+// subclass of bugs (off-by-one in the window calculation) cannot mask a
+// failing vector. The published codes are computed at the step itself,
+// so they sit at the centre of the window and must still verify.
+func TestVerify_RFC6238AppendixB_withSkew1(t *testing.T) {
+	mod := newTOTP(t, Config{SkewSteps: Int(1)})
+	for _, v := range rfcVectors {
+		t.Run(v.name, func(t *testing.T) {
+			mod.clock = clock.Fixed(time.Unix(v.time, 0).UTC())
+			if _, err := mod.Verify(rfcSecretB32, v.code6, 0); err != nil {
+				t.Fatalf("Verify with skew=1 at t=%d returned err=%v, want nil",
+					v.time, err)
+			}
+		})
+	}
+}
+
+// ---- Skew window ------------------------------------------------------------
+
+// TestVerify_SkewSteps1_AcceptsNeighbours exercises the window: with
+// SkewSteps=1, codes from the previous and next step are accepted but
+// a code from two steps away is not.
+func TestVerify_SkewSteps1_AcceptsNeighbours(t *testing.T) {
+	mod := newTOTP(t, Config{SkewSteps: Int(1)})
+	const baseTime int64 = 60 // any 30-second boundary
+	// Compute the TOTP code at baseTime directly via the package helper
+	// so the test is deterministic without hardcoding a value.
+	key, err := decodeSecret(rfcSecretB32)
+	if err != nil {
+		t.Fatalf("decodeSecret: %v", err)
+	}
+	code := generateTOTP(key, uint64(baseTime)/timeStep)
+
+	mod.clock = clock.Fixed(time.Unix(baseTime, 0).UTC())
+	current, err := mod.Verify(rfcSecretB32, code, 0)
+	if err != nil {
+		t.Fatalf("current step should verify: %v", err)
+	}
+	if current != uint64(baseTime)/timeStep {
+		t.Fatalf("current step = %d, want %d", current, uint64(baseTime)/timeStep)
+	}
+
+	// The same code must verify at baseTime-30 and baseTime+30.
+	mod.clock = clock.Fixed(time.Unix(baseTime-30, 0).UTC())
+	if _, err := mod.Verify(rfcSecretB32, code, 0); err != nil {
+		t.Errorf("code from previous step should verify with SkewSteps=1: %v", err)
+	}
+	mod.clock = clock.Fixed(time.Unix(baseTime+30, 0).UTC())
+	if _, err := mod.Verify(rfcSecretB32, code, 0); err != nil {
+		t.Errorf("code from next step should verify with SkewSteps=1: %v", err)
+	}
+
+	// Two steps away must be rejected.
+	mod.clock = clock.Fixed(time.Unix(baseTime-60, 0).UTC())
+	if _, err := mod.Verify(rfcSecretB32, code, 0); !errors.Is(err, ErrInvalidCode) {
+		t.Errorf("code from two steps away: got %v, want ErrInvalidCode", err)
+	}
+	mod.clock = clock.Fixed(time.Unix(baseTime+60, 0).UTC())
+	if _, err := mod.Verify(rfcSecretB32, code, 0); !errors.Is(err, ErrInvalidCode) {
+		t.Errorf("code from two steps away: got %v, want ErrInvalidCode", err)
+	}
+}
+
+// TestVerify_SkewSteps0_OnlyCurrentStep exercises the strictest window:
+// with SkewSteps=0, only the current step matches; neighbouring steps
+// are rejected.
+func TestVerify_SkewSteps0_OnlyCurrentStep(t *testing.T) {
+	mod := newTOTP(t, Config{SkewSteps: Int(0)})
+	const baseTime int64 = 90
+	key, err := decodeSecret(rfcSecretB32)
+	if err != nil {
+		t.Fatalf("decodeSecret: %v", err)
+	}
+	code := generateTOTP(key, uint64(baseTime)/timeStep)
+	t.Logf("baseTime=%d step=%d code=%s", baseTime, uint64(baseTime)/timeStep, code)
+
+	mod.clock = clock.Fixed(time.Unix(baseTime, 0).UTC())
+	current, err := mod.Verify(rfcSecretB32, code, 0)
+	if err != nil {
+		t.Fatalf("current step should verify with SkewSteps=0: %v", err)
+	}
+	if current != uint64(baseTime)/timeStep {
+		t.Fatalf("current step = %d, want %d", current, uint64(baseTime)/timeStep)
+	}
+
+	mod.clock = clock.Fixed(time.Unix(baseTime-30, 0).UTC())
+	got := mod.clock.Now().Unix()
+	t.Logf("clock set to %d, now=%d, currentStep=%d, code=%s, codeAtStep=%s",
+		baseTime-30, got, got/timeStep, code, generateTOTP(key, uint64(got)/timeStep))
+	if _, err := mod.Verify(rfcSecretB32, code, 0); !errors.Is(err, ErrInvalidCode) {
+		t.Errorf("previous step with SkewSteps=0: got %v, want ErrInvalidCode", err)
+	}
+	mod.clock = clock.Fixed(time.Unix(baseTime+30, 0).UTC())
+	if _, err := mod.Verify(rfcSecretB32, code, 0); !errors.Is(err, ErrInvalidCode) {
+		t.Errorf("next step with SkewSteps=0: got %v, want ErrInvalidCode", err)
+	}
+}
+
+// ---- Replay protection ------------------------------------------------------
+
+func TestVerify_ReplayReturnsErrCodeReused(t *testing.T) {
+	mod := newTOTP(t, Config{SkewSteps: Int(0)})
+	const baseTime int64 = 120
+	key, err := decodeSecret(rfcSecretB32)
+	if err != nil {
+		t.Fatalf("decodeSecret: %v", err)
+	}
+	code := generateTOTP(key, uint64(baseTime)/timeStep)
+
+	mod.clock = clock.Fixed(time.Unix(baseTime, 0).UTC())
+	step, err := mod.Verify(rfcSecretB32, code, 0)
+	if err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	if step != uint64(baseTime)/timeStep {
+		t.Fatalf("step = %d, want %d", step, uint64(baseTime)/timeStep)
+	}
+
+	// Replay the same code with the returned step as lastUsedStep.
+	if _, err := mod.Verify(rfcSecretB32, code, step); !errors.Is(err, ErrCodeReused) {
+		t.Errorf("replayed code: got %v, want ErrCodeReused", err)
+	}
+
+	// lastUsedStep equal to the matched step also triggers it.
+	if _, err := mod.Verify(rfcSecretB32, code, step); !errors.Is(err, ErrCodeReused) {
+		t.Errorf("replayed code with equal lastUsedStep: got %v, want ErrCodeReused", err)
+	}
+}
+
+func TestVerify_ReplayAcrossNeighbouringSteps(t *testing.T) {
+	// A code for step N is also valid (with SkewSteps >= 1) at any clock
+	// time whose current step is in [N-1, N+1]. Once we have accepted it,
+	// any subsequent accept at a neighbouring step must also report
+	// ErrCodeReused because the matched step is at or below lastUsedStep.
+	mod := newTOTP(t, Config{SkewSteps: Int(1)})
+	const baseTime int64 = 150
+	key, err := decodeSecret(rfcSecretB32)
+	if err != nil {
+		t.Fatalf("decodeSecret: %v", err)
+	}
+	code := generateTOTP(key, uint64(baseTime)/timeStep)
+
+	mod.clock = clock.Fixed(time.Unix(baseTime, 0).UTC())
+	step, err := mod.Verify(rfcSecretB32, code, 0)
+	if err != nil {
+		t.Fatalf("first verify at t=%d: %v", baseTime, err)
+	}
+
+	mod.clock = clock.Fixed(time.Unix(baseTime+30, 0).UTC())
+	if _, err := mod.Verify(rfcSecretB32, code, step); !errors.Is(err, ErrCodeReused) {
+		t.Errorf("replayed code from neighbour step: got %v, want ErrCodeReused", err)
+	}
+}
+
+func TestVerify_LastUsedStepZeroNeverRejects(t *testing.T) {
+	// The doc comment for Verify states plainly that a caller who always
+	// passes 0 has no replay protection: every matching code is accepted.
+	mod := newTOTP(t, Config{SkewSteps: Int(0)})
+	const baseTime int64 = 210
+	key, err := decodeSecret(rfcSecretB32)
+	if err != nil {
+		t.Fatalf("decodeSecret: %v", err)
+	}
+	code := generateTOTP(key, uint64(baseTime)/timeStep)
+	mod.clock = clock.Fixed(time.Unix(baseTime, 0).UTC())
+	for i := 0; i < 5; i++ {
+		if _, err := mod.Verify(rfcSecretB32, code, 0); err != nil {
+			t.Fatalf("verify #%d with lastUsedStep=0 returned %v, want nil", i, err)
+		}
+	}
+}
+
+// ---- Malformed inputs -------------------------------------------------------
+
+func TestVerify_MalformedCode(t *testing.T) {
+	mod := newTOTP(t)
+	const baseTime int64 = 30
+	mod.clock = clock.Fixed(time.Unix(baseTime, 0).UTC())
+	cases := []struct {
+		name string
+		code string
+	}{
+		{"empty", ""},
+		{"five digits", "12345"},
+		{"seven digits", "1234567"},
+		{"letter", "12345a"},
+		{"symbol", "12345!"},
+		{"unicode digit", "１２３４５６"}, // six fullwidth digits
+		{"trailing space", "123456 "},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := mod.Verify(rfcSecretB32, c.code, 0)
+			if !errors.Is(err, ErrMalformedCode) {
+				t.Errorf("Verify(%q) = %v, want ErrMalformedCode", c.code, err)
+			}
+		})
+	}
+}
+
+func TestVerify_InvalidSecret(t *testing.T) {
+	mod := newTOTP(t, Config{SkewSteps: Int(0)})
+	mod.clock = clock.Fixed(epoch)
+	cases := []string{
+		"",
+		"not-base32!",
+		"@@@@",
+		"1", // valid base32 but too short
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := mod.Verify(c, "123456", 0); !errors.Is(err, ErrInvalidSecret) {
+				t.Errorf("Verify(secret=%q) = %v, want ErrInvalidSecret", c, err)
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ breaks?
 | `password` | Work factor: `Memory`, `Iterations`, `Parallelism` · Policy: `MinLength`, `MaxLength`, `RequireUpper`, `RequireLower`, `RequireDigit`, `RequireSymbol` | Argon2id algorithm · 16-byte salt · 32-byte key · PHC output format · constant-time compare · Unicode NFC normalisation |
 | `email` | `RejectPlusAddressing` | RFC 5321/5322 parse and normalisation · IDN punycode conversion |
 | `username` | `MinLength`, `MaxLength`, `ExtraReservedNames`, `AllowReservedNames` | Character set `[a-z0-9_-]` · lowercase + trim normalisation · "must start and end with a letter or digit" rule · "no consecutive specials" rule |
+| `totp` | Clock-skew window: `SkewSteps` (`*int`, 0 to 10, default 1, set with `totp.Int`) · `RecoveryCodeCount` (1 to 50, default 10) · `Issuer` (label shown in the authenticator) | HMAC-SHA1 algorithm · 30-second time step · 6-digit codes · 20-byte secrets · constant-time compare · full-window scan before any return |
 
 A field listed under "closed" cannot be configured: trying to do so would
 either be rejected at compile time or be a deliberate error in the code.

--- a/docs/totp.md
+++ b/docs/totp.md
@@ -1,0 +1,165 @@
+# TOTP (Time-based One-Time Password)
+
+`auth/totp` implements the second factor every authenticator app
+already speaks: six-digit rotating codes derived from a shared secret
+(RFC 6238, layered on RFC 4226 HOTP). authcore enrolls a user by
+minting a high-entropy shared secret, returns an `otpauth://` URI the
+user's app scans as a QR code, and verifies the codes the user
+subsequently produces - all in constant time, with built-in replay
+protection.
+
+The library never stores anything; you store the secret and the
+recovery-code hashes. See the [error reference](errors.md).
+
+## Setup
+
+```go
+auth, err := authcore.New(authcore.DefaultConfig())
+totpMod, err := totp.New(auth)                       // defaults
+totpMod, err := totp.New(auth, totp.Config{Issuer: "Acme"})
+```
+
+## Enrolling a user
+
+```go
+enr, err := totpMod.Enroll("alice@example.com")
+if err != nil { return http.StatusInternalServerError }
+
+// Show the URI to the user as a QR code; show RecoveryCodes as a
+// printable list, exactly once. The user types RecoveryCodes into the
+// app OR the app scans the QR code, which encodes the URI.
+qrImageFromURI(enr.URI)
+printAndWipe(enr.RecoveryCodes) // 10 codes by default
+
+// Persist the secret (lookup key) and the hashes (verification
+// material). Never persist RecoveryCodes; the raw codes must not
+// survive the request.
+db.StoreTOTP(userID, enr.Secret, enr.RecoveryHashes)
+```
+
+The `URI` is an `otpauth://totp/...` URI per the de-facto cross-vendor
+standard. It encodes the secret, the issuer (if configured) and the
+account name; the algorithm (`SHA1`), digit count (`6`) and time step
+(`30` seconds) are also embedded so any client that does parse them
+sees the closed defaults. Empty `Config.Issuer` means the URI is built
+without the issuer parameter and the label, and the authenticator
+displays only the account name.
+
+## Verifying a code
+
+```go
+secret     := db.GetSecret(userID)
+lastStep   := db.GetLastStep(userID) // 0 if no previous verification
+presented  := form.Code              // six digits the user typed
+
+step, err := totpMod.Verify(secret, presented, lastStep)
+switch {
+case errors.Is(err, totp.ErrCodeReused):
+    // A code already accepted was tried again - security event.
+    // The user may have given a stolen code to an attacker who is
+    // now replaying it from a different network. Log and revoke the
+    // factor; do NOT show a different message than a normal failure,
+    // or you tell the attacker that the code was once valid.
+    log.Warn("totp: replay attempt (user=%s)", userID)
+    revokeFactor(userID)
+    return http.StatusUnauthorized
+case err != nil:
+    // ErrInvalidCode (wrong code), ErrMalformedCode (not six digits),
+    // ErrInvalidSecret (storage corruption). Same response to the
+    // client; the distinction is for logs and rate-limit accounting.
+    return http.StatusUnauthorized
+}
+db.SetLastStep(userID, step) // persist the returned step
+```
+
+`Verify` compares the candidate code against every step in the
+configured window with `crypto/subtle.ConstantTimeCompare` and never
+returns early on the first match, so the time taken does not reveal
+which step (if any) matched.
+
+## Recovery codes
+
+Recovery codes are one-time backdoor codes the user can redeem if they
+have lost their authenticator device. They are minted at enrollment,
+hashed before storage, and must be deleted from the user's record after
+successful use.
+
+```go
+hashes := db.GetRecoveryHashes(userID)
+idx, ok := totpMod.VerifyRecoveryCode(form.RecoveryCode, hashes)
+if !ok {
+    return http.StatusUnauthorized
+}
+// Single-use: delete the matched hash so the same code can never
+// redeem again.
+hashes = append(hashes[:idx], hashes[idx+1:]...)
+db.SetRecoveryHashes(userID, hashes)
+```
+
+`VerifyRecoveryCode` normalises the input (strips hyphens and spaces,
+uppercases letters) and scans every hash in the list in constant time,
+returning the index of the match so the caller can mark that one used.
+A code not in the list returns `false`. The module does **not**
+remember which codes have been redeemed; the caller enforces
+single-use by deleting the index that was returned.
+
+## Footguns the caller must handle
+
+Two things the module deliberately does not do, because they belong
+to the application and are easy to forget:
+
+1. **Rate limiting is the caller's job.** A six-digit code has a
+   million possible values and the window accepts several time steps,
+   so unlimited attempts are brute forceable (10 codes/second would
+   crack any code in under a day). Throttle failed attempts per user,
+   ideally with an exponential backoff after a handful of misses and
+   a hard lockout or notification after a dozen.
+
+2. **Recovery codes are single use and the caller enforces it.**
+   The module returns the index of the matched code; deleting or
+   flagging that row in your store is the caller's responsibility.
+   Without that step, a stolen recovery code can be redeemed
+   repeatedly until the user notices.
+
+## What is fixed and why
+
+The cryptographic layer is **closed**: HMAC-SHA1, 30-second time
+step, 6-digit codes, 20-byte secrets and constant-time comparison
+are the interoperability baseline. Every widely-used authenticator
+app (Google Authenticator, 1Password, Authy, Microsoft Authenticator,
+Bitwarden, ...) ignores the `algorithm`, `digits` and `period`
+parameters of an `otpauth://` URI and assumes SHA1/6/30. A
+configurable value here produces an enrollment that works in your
+test environment and locks the user out on the user's phone. There
+is no "strict RFC" escape hatch.
+
+The policy layer is **open with secure defaults**: see
+[configuration](configuration.md) for the principle. The caller can
+tune `SkewSteps` (clock-skew window), `RecoveryCodeCount` (how many
+recovery codes to mint) and `Issuer` (the label shown in the
+authenticator) per deployment without weakening the security floor
+the library enforces.
+
+`SkewSteps` is a `*int`, so that leaving it unset ("use the default of
+one step either side") stays distinguishable from asking for no
+tolerance at all. Use `totp.Int` rather than a temporary local:
+
+```go
+cfg := totp.DefaultConfig()
+cfg.SkewSteps = totp.Int(0) // only the current step is accepted
+mod, err := totp.New(auth, cfg)
+```
+
+Getting that distinction wrong is a lockout rather than a weakening: a
+plain `int` left at its zero value would give a zero-width window while
+the documentation promised one step, and every user whose phone clock
+drifts by a few seconds would fail to sign in. `password.Bool` exists
+for the same reason on the password policy fields.
+
+## Revoking
+
+Delete the row that stores the secret (or flag it) and check on
+lookup. There is no token to expire - a TOTP enrollment lives until
+you remove it. To rotate without losing the user's authenticator,
+mint a fresh enrollment with `Enroll` and migrate the user's device
+to scan the new QR code.


### PR DESCRIPTION
Closes the first item of #325, the one the issue calls the biggest gap and puts first in its own priority list.

RFC 6238 TOTP over HMAC-SHA1, plus single-use recovery codes. Pure computation, so it fits the no-database contract: the caller stores the secret, the last used step and the recovery hashes.

Applies the rule settled in #326 from scratch rather than retrofitting it, which is why that issue said to settle it first.

| Closed, not configurable | Open, defaulting to today's value |
|---|---|
| HMAC-SHA1, 30 second step, 6 digits, 20 byte secrets | `SkewSteps`, the clock tolerance window |
| Constant time comparison, full window scan | `RecoveryCodeCount` |
| Recovery code entropy | `Issuer`, the label the authenticator shows |

The first column is interoperability as much as security. Authenticator apps in wide use ignore the `algorithm`, `digits` and `period` parameters of an `otpauth://` URI and assume SHA1, 6 and 30, so a configurable value there produces an enrollment that passes your test and locks the user out on their phone. No strict-RFC escape hatch.

## Replay is what decides whether this is real

A TOTP code stays valid for its whole window, so an observer can replay it until the window closes, and a stateless module cannot stop that on its own. What it can do is refuse to hide it.

`Verify` returns the time step the code matched. The caller stores that and passes it back as `lastUsedStep`; any step at or below it is refused with `ErrCodeReused`.

```go
step, err := mod.Verify(secret, code, user.LastTOTPStep)
if errors.Is(err, totp.ErrCodeReused) { /* someone replayed it */ }
user.LastTOTPStep = step // store before you let them in
```

`lastUsedStep` is a required parameter, not an option and not a second method, so there is no verification path a caller can reach that silently has no replay protection.

## The defect I found in the first draft

`SkewSteps` was a plain `int`, `DefaultConfig()` returned 1, the field's own comment promised 1, and `applyDefaults` never filled it:

```
totp.New(auth)                       -> skew 0, no tolerance at all
totp.New(auth, totp.DefaultConfig()) -> skew 1
```

The zero-config path silently contradicted its own documentation, and the failure mode is a lockout rather than a weakening: every user whose phone clock drifts a few seconds fails to sign in, while the docs say that case is covered. Nothing was red, because 0 is a legal value and no test compared the two paths against each other.

Same "unset versus deliberately zero" problem the password policy hit in #334, so it gets the same answer: `SkewSteps` is a `*int` and `totp.Int` mirrors `password.Bool`. Both meanings stay expressible, and `TestApplyDefaults_zeroConfigUsesTheDocumentedSkew` fails if the field is ever changed back.

I also corrected a comment in the verification loop. It said an underflow when `currentStep` is below `skew` was harmless because "the resulting negative step fails its HMAC comparison". There is no negative step, this is `uint64`: the lower bound wraps near 2^64, lands above the upper bound, and the loop body does not run at all. Measured with a fixed clock at the epoch. The behaviour is safe either way, but the stated reason was not the real one, and a wrong reason in a verification loop is worth correcting even when the outcome is right.

## What I measured

**The RFC 6238 vectors were derived independently first.** I wrote a separate implementation and produced the Appendix B values before reading this one, then ran them against it. All six match at six digits: `287082`, `081804`, `050471`, `005924`, `279037`, `353130` for the published seed. That is the only assertion here that checks the module against the standard rather than against itself.

Three sabotages, each reverted:

| Sabotage | Reddens |
|---|---|
| replay guard deleted | both replay tests |
| window pinned to a constant 1, ignoring `SkewSteps` | the zero-skew test |
| `SkewSteps` default fill removed | the regression test above |

Both fuzz targets clean for 20 seconds each, 3.6M and 3.3M executions, no new interesting inputs and no crash.

`go build`, `go vet`, `gofmt -l` clean, `go test -race ./...` 10 of 10 packages, coverage 94.8 for this package against a floor of 90.

The generated test file came out at 516 lines of code, over the repository's hard limit of 500, so it is split in two along its own section boundaries.

## Two footguns, stated in `docs/totp.md` rather than left implied

**Rate limiting is the caller's job.** Six digits is a million possibilities and the window accepts several steps, so unlimited attempts are brute forceable. The module cannot throttle; the caller must.

**Recovery codes are single use and the caller enforces it.** `VerifyRecoveryCode` returns the index of the match so the row can be deleted or flagged. Nothing in the module remembers it.

## Still open in #325

`auth/field`, `auth/credential`, and the `Denylist` documentation.
