### PR TITLE
docs(jwt): say when not to rotate, and what that costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Pick only what you need — each is independent, testable, and safe by default.
 | | Module | Does |
 |---|---|---|
 | 🔑 | **[password](docs/password.md)** | Hash + verify. Argon2id, policy-enforced, self-describing PHC format. |
-| 🎫 | **[jwt](docs/jwt.md)** | Access + refresh tokens. EdDSA / Ed25519, generic claims, rotation. |
+| 🎫 | **[jwt](docs/jwt.md)** | Access + refresh tokens. EdDSA / Ed25519, generic claims, rotation, optional denylist for instant revocation. |
 | 📧 | **[email](docs/validation.md)** | Validate + normalize. RFC 5321/5322, optional cached DNS MX check. |
 | 👤 | **[username](docs/validation.md)** | Validate + normalize. Reserved-name blocklist, character rules. |
 | 🗝️ | **[apikey](docs/apikey.md)** | Opaque API keys. Generate, keyed-hash for storage, constant-time verify. |

--- a/auth/jwt/denylist.go
+++ b/auth/jwt/denylist.go
@@ -25,6 +25,13 @@ const defaultDenylistTimeout = 5 * time.Second
 // SessionID and is stable across rotations — so revoking one entry kills the
 // whole session, every access token in it, immediately.
 //
+// That holds while you refresh with RotateTokens, which carries the original
+// jti forward. CreateTokens mints a fresh one on every call, so a deployment
+// that refreshes by calling CreateTokens instead must store the newest
+// SessionID and revoke that: access tokens issued under an earlier jti are not
+// covered by the entry and remain valid until their own exp. See the "When not
+// to rotate" section of docs/jwt.md.
+//
 // Leaving Config.Denylist nil keeps the stateless fast path: no lookup, no
 // store, no per-request cost.
 type Denylist interface {

--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -112,6 +112,77 @@ db.ReplaceRefreshHash(session.ID, newPair.RefreshTokenHash)
 // 6. Send the new tokens to the client.
 ```
 
+### When not to rotate
+
+Rotation is the recommended default, but there is one shape of client where it
+actively hurts: a frontend that fires several requests in parallel. Two of them
+find the access token expired at the same moment, both refresh with the same
+refresh token, and the second arrives after step 5 has already replaced the
+hash. It gets a 401 for a token that was valid when it was sent, and the user is
+signed out mid-session for no reason. Next.js applications hit this often,
+because the framework fans out data fetches on a single navigation.
+
+Staying non-rotating is supported. Issue with `CreateTokens`, store the hash,
+and verify with `VerifyRefreshTokenHash` on each refresh without ever calling
+`RotateTokens`:
+
+```go
+// Refresh, without rotating: the client keeps the same refresh token.
+if !jwtMod.VerifyRefreshTokenHash(clientToken, session.RefreshTokenHash) {
+    return http.StatusUnauthorized
+}
+// Mint a fresh pair, hand back only the access token, and keep the stored
+// refresh hash as it is. Two requests racing here both succeed.
+pair, err := jwtMod.CreateTokens(session.UserID, freshClaims)
+if err != nil {
+    return http.StatusUnauthorized
+}
+db.UpdateSessionID(session.ID, pair.SessionID) // see below: this is required
+// Return pair.AccessToken. Do not send pair.RefreshToken.
+```
+
+Two things you give up, and the second one surprises people.
+
+**You lose reuse detection.** Rotation is not what detects a stolen refresh
+token; `RotateTokens` only verifies the presented token and reissues it. The
+detection comes from step 5 above: once you have atomically replaced the stored
+hash, a thief replaying the old token fails the lookup, and a legitimate client
+failing the lookup tells you the token leaked. Drop rotation and you drop that
+signal.
+
+**The denylist stops killing the whole session at once.** `CreateTokens` mints a
+fresh `jti` on every call, while `RotateTokens` carries the original one
+forward. Measured on a fixed clock:
+
+| Call | SessionID |
+|---|---|
+| `CreateTokens` | `018fd3ab-c200-771c-b0e0-17fa236d71af` |
+| `CreateTokens` again | `018fd3ab-c200-7115-a937-fd114f66224d` |
+| `RotateTokens` on the first pair | `018fd3ab-c200-771c-b0e0-17fa236d71af` |
+
+So under rotation every access token in a session shares one `jti`, and a single
+denylist entry kills all of them instantly, which is what the `Denylist`
+documentation promises. Refresh with `CreateTokens` instead and each refresh
+starts a new `jti`, so you must store the newest `SessionID` on the session row
+and revoke that one. Access tokens minted under an earlier `jti` are not covered
+by that entry and stay valid until their own `exp`, which is `AccessTokenTTL`,
+15 minutes by default.
+
+That is usually acceptable, but it is a different promise: instant for the
+current segment, up to one access TTL for anything issued before it. If you need
+the stronger guarantee, either rotate, or coalesce refreshes in the client so
+only one is ever in flight.
+
+So the trade is real in both directions:
+
+- **Rotate** when your client refreshes from one place at a time, which covers
+  most mobile apps and server-rendered sessions. You get reuse detection and a
+  session-wide kill switch.
+- **Do not rotate** when your client can refresh concurrently and you would
+  rather not build request coalescing. Compensate with a shorter
+  `AccessTokenTTL`, so the uncovered window shrinks, and keep the stored
+  `SessionID` current.
+
 ## Revocation & logout
 
 Access tokens are **stateless JWTs**: once issued, an access token stays valid


### PR DESCRIPTION
Closes item 6 of #325 and the first of its two friction points.

## Item 6 was mostly already done

`Denylist` is documented at length in `docs/jwt.md` (setup, store example, `ErrTokenRevoked`, fail-closed, sizing entries to `exp`) and again in section 6 of `docs/secure-login.md`. The issue says it "appears nowhere in `docs/secure-login.md`", and that is no longer true.

The one place it really was missing is the README module table, where the jwt row listed rotation and stopped. That row now names the denylist. That is the whole of item 6, and I would rather say so than manufacture work around a claim that has aged out.

The other friction point needed nothing either: `docs/key-management.md` already covers environment-provided key material under "Sourcing keys without a volume", with `os.Getenv` in the example.

## The rotation caveat was genuinely undocumented

Nothing in `docs/` mentioned the parallel-request race, and it is real: a frontend that fans out several fetches on one navigation can have two of them refresh with the same token, and the second arrives after the stored hash has been replaced. It gets a 401 for a token that was valid when it was sent. `CreateTokens`, `HashRefreshToken` and `VerifyRefreshTokenHash` already support staying non-rotating; now the docs say so, with the code.

They also say what it costs, because "rotation is optional" without that is worse than silence.

**Reuse detection**, and where it actually lives. `RotateTokens` detects nothing: it verifies the presented token and reissues. The detection is the caller atomically replacing the stored hash, so a replayed old token fails the lookup. Drop rotation and you drop that signal.

**The denylist stops killing the whole session at once.** This one I did not expect, and it is written down nowhere. `RotateTokens` carries the original `jti` forward; `CreateTokens` mints a fresh one per call. Measured on a fixed clock:

| Call | SessionID |
|---|---|
| `CreateTokens` | `018fd3ab-c200-771c-b0e0-17fa236d71af` |
| `CreateTokens` again | `018fd3ab-c200-7115-a937-fd114f66224d` |
| `RotateTokens` on the first pair | `018fd3ab-c200-771c-b0e0-17fa236d71af` |

`denylist.go` promises that one entry kills the whole session "because the jti is stable across rotations". True, and it holds only while you rotate. Refresh by calling `CreateTokens` and each refresh starts a new `jti`, so the caller must store the newest `SessionID` and revoke that one, while access tokens minted under an earlier `jti` stay valid until their own `exp` (one `AccessTokenTTL`, 15 minutes by default).

That is a different guarantee, not a broken one. But a reader told "just add a denylist" would never find it, so `denylist.go` now carries the caveat next to the promise, and `docs/jwt.md` explains the trade in both directions.

## Verification

The session-id table above is measured, not read off the source: I drove `CreateTokens` twice and `RotateTokens` once against a fixed clock and printed the ids. My first draft of this section said to "compensate with a Denylist" and would have shipped advice that quietly does not work, which is why it is here as a table rather than a claim.

`go build`, `go vet`, `gofmt -l` clean, `go test -race ./...` 10 of 10 packages. The only code change is a doc comment.

## Still open in #325

`auth/field` and `auth/credential`. The latter is in progress on a separate branch.
