### PR TITLE
feat(credential): add auth/credential, single-use tokens for reset and activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ if ok, _ := pwd.Verify("Str0ng-P@ssword!", hash); ok {
 authcore is an in-process library, not a hosted identity platform: it ships no
 database and no HTTP server of its own, generates and manages its own signing
 keys on first run, and each module (password, jwt, apikey, oauth, email,
-username, totp) can be used independently.
+username, totp, credential) can be used independently.
 
 ## Modules
 
@@ -79,13 +79,14 @@ Pick only what you need — each is independent, testable, and safe by default.
 | 👤 | **[username](docs/validation.md)** | Validate + normalize. Reserved-name blocklist, character rules. |
 | 🗝️ | **[apikey](docs/apikey.md)** | Opaque API keys. Generate, keyed-hash for storage, constant-time verify. |
 | 🔐 | **[totp](docs/totp.md)** | TOTP / RFC 6238 second factor. Enroll, verify (with replay protection), recovery codes. |
+| ✉️ | **[credential](docs/credential.md)** | Single-use tokens for password reset and account activation. Bound to a purpose and a subject, TTL enforced. |
 | 🌐 | **[oauth](docs/oauth.md)** | Social login — Google, Microsoft (OIDC) and GitHub, Discord (OAuth2). Auth Code + PKCE, ID-token validation or userinfo. |
 
 ```mermaid
 flowchart LR
     App["Your app"] -->|init once| Core["authcore"]
     Core -->|auto-generates| Keys[("🔑 Ed25519 + HMAC<br/>on disk")]
-    Core -->|Provider| M["password · jwt · apikey · oauth<br/>email · username · totp"]
+    Core -->|Provider| M["password · jwt · apikey · oauth<br/>email · username · totp · credential"]
     M -->|hash · sign · verify| App
 ```
 
@@ -94,7 +95,7 @@ flowchart LR
 **New here? Start with the [Secure login recipe](docs/secure-login.md)** — the
 step-by-step flow that turns these primitives into a login an auditor accepts.
 
-[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [TOTP](docs/totp.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
+[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [TOTP](docs/totp.md) · [Credential tokens](docs/credential.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
 
 Full API reference on [pkg.go.dev](https://pkg.go.dev/github.com/Glyndor/authcore).
 

--- a/auth/credential/config.go
+++ b/auth/credential/config.go
@@ -1,0 +1,84 @@
+package credential
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config holds the credential module configuration.
+//
+// The configuration is split into two layers, matching the authcore
+// principle documented in docs/configuration.md:
+//
+//   - The cryptographic layer is CLOSED and is not configurable here. Token
+//     entropy (32 bytes / 256 bits), the HMAC-SHA256 construction and its
+//     library-managed pepper, the constant-time comparison, the binding of
+//     purpose and subject into the stored hash, and the base64-URL token
+//     encoding are fixed. Weakening any of these produces a credential a
+//     stolen email can be spent against the wrong user or the wrong flow.
+//   - The policy layer is OPEN with today's value as the default: TTL
+//     (how long a token remains redeemable).
+//
+// What stays fixed regardless of configuration:
+//
+//   - Token length: 32 random bytes (256 bits) per CSPRNG draw
+//   - Token encoding: base64 URL without padding, drops into a link as-is
+//   - Stored hash: HMAC-SHA256(pepper, len(purpose)||purpose ||
+//     len(subject)||subject || len(token)||token), each length a big-endian
+//     uint32, so ("reset", "ab") cannot collide with ("reseta", "b") no
+//     matter what bytes the fields contain
+//   - Hash output: lowercase hex
+//   - Comparison: crypto/subtle.ConstantTimeCompare, with the comparison
+//     always run before the expiry check so wall-clock time does not reveal
+//     whether a token existed
+//   - Future issuedAt tolerance: 1 minute, anything more counts as expired
+//
+// Start from DefaultConfig and override only what your installation needs:
+//
+//	cred, err := credential.New(auth)                              // defaults
+//	cred, err := credential.New(auth, credential.Config{TTL: 15 * time.Minute})
+type Config struct {
+	// TTL is how long a credential token remains valid from its issuedAt.
+	// A reset link that lives longer than a day is a standing key to the
+	// account sitting in an inbox, so validateConfig refuses anything above
+	// 24 hours. A TTL of zero or a negative TTL is refused for the same
+	// reason: an instantly-expired or backwards-running token has no
+	// legitimate use, only a bug.
+	//
+	// Defaults to 1 hour.
+	TTL time.Duration
+}
+
+// DefaultConfig returns a Config with the library's recommended defaults.
+func DefaultConfig() Config {
+	return Config{TTL: time.Hour}
+}
+
+const maxTTL = 24 * time.Hour
+
+// applyDefaults is a pass-through for TTL.
+//
+// Unlike auth/totp's SkewSteps (a pointer so zero is a meaningful "no
+// tolerance" value), TTL is a plain time.Duration: zero is not
+// meaningful (it would make every token instantly expired), and the
+// brief is explicit that it must be refused. Filling zero with the
+// default here would silently turn a caller bug into a 1-hour token,
+// so validateConfig is the only thing that decides what TTL values are
+// allowed. New routes the no-Config case through DefaultConfig() so
+// that callers who omit Config still get the 1-hour default; applyDefaults
+// exists only so the function trio (DefaultConfig / applyDefaults /
+// validateConfig) matches the shape used across the rest of authcore.
+func applyDefaults(cfg Config) Config {
+	return cfg
+}
+
+// validateConfig returns an error if cfg contains invalid values.
+func validateConfig(cfg Config) error {
+	if cfg.TTL <= 0 {
+		return fmt.Errorf("ttl must be positive, got %s", cfg.TTL)
+	}
+	if cfg.TTL > maxTTL {
+		return fmt.Errorf("ttl must be at most %s, got %s", maxTTL, cfg.TTL)
+	}
+	return nil
+}

--- a/auth/credential/credential.go
+++ b/auth/credential/credential.go
@@ -1,0 +1,257 @@
+// Package credential mints and verifies single-use credential tokens for
+// authcore.
+//
+// # What it is for
+//
+// Password resets and account activations are the two most security
+// sensitive emails an application ever sends. The token that powers
+// each of them has to be high-entropy, single-use, time-bounded, and
+// bound to the user and the flow it was minted for. Without that
+// binding, a caller who keeps one table for both flows has a
+// cross-flow confusion bug, and one who looks up by token rather than
+// by user has an account mixup. This module makes those mistakes
+// impossible from the credential side: it mints the token, hands the
+// raw value back once for the email link and a keyed hash for the
+// caller to store, and verifies a presented token against the stored
+// hash. The module stores nothing.
+//
+//	auth, _ := authcore.New(authcore.DefaultConfig())
+//	cred, _ := credential.New(auth)
+//
+//	// Issue: put Token in the email link, persist Hash and issuedAt.
+//	issued, _ := cred.Issue("reset", "alice@example.com")
+//	sendEmail(alice, "?token="+url.QueryEscape(issued.Token))
+//	db.StoreResetToken(alice.ID, issued.Hash, time.Now())
+//
+//	// Verify: same purpose and subject, before TTL, with single-use.
+//	err := cred.Verify("reset", "alice@example.com",
+//	    presented, storedHash, storedAt)
+//	switch {
+//	case errors.Is(err, credential.ErrExpired):
+//	    return genericError() // "link invalid or expired"
+//	case errors.Is(err, credential.ErrInvalidCredential):
+//	    return genericError() // same message; never reveal which it was
+//	case err != nil:
+//	    return serverError()
+//	}
+//	db.DeleteResetToken(alice.ID) // single use, in the same transaction
+//
+// # What is fixed and what is open
+//
+// The cryptographic layer is closed: token entropy, HMAC-SHA256 with the
+// library-managed pepper, base64-URL encoding, constant-time comparison,
+// and the purpose || subject || token binding into the stored hash are
+// all fixed. Weakening any of these produces a credential a stolen
+// email can be spent against the wrong user or the wrong flow.
+//
+// The policy layer is open with secure defaults: the TTL (how long a
+// token stays valid) is configurable within a 1-nanosecond-to-24-hour
+// range, enforced by validateConfig. See docs/configuration.md for the
+// principle.
+package credential
+
+import (
+	"crypto/hmac"
+	"crypto/rand" //nolint:gosec // CSPRNG draws for tokens
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"time"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/internal/clock"
+)
+
+// Compile-time assertion: *Credential must satisfy authcore.Module.
+var _ authcore.Module = (*Credential)(nil)
+
+const (
+	tokenLen   = 32 // 256 bits of CSPRNG output per token
+	futureSkew = time.Minute
+)
+
+// Credential is the credential module.
+//
+// Construct one instance at application startup using New and share it
+// across goroutines. Credential is safe for concurrent use after
+// construction.
+//
+// It carries configuration only. Issue returns everything an issuance
+// produces, so the module is safe to share across goroutines and never
+// holds a raw token.
+type Credential struct {
+	cfg    Config
+	log    authcore.Logger
+	secret []byte      // HMAC-SHA256 pepper, sourced from the parent AuthCore
+	clock  clock.Clock // injected; replaced by clock.Fixed in tests
+}
+
+// The module holds no per-issue state on purpose. An earlier draft kept the
+// most recent Token and Hash on this struct, which made two concurrent Issue
+// calls a data race (the race detector flags it) and left the raw token, the
+// one secret the caller must show exactly once, alive in memory for as long
+// as the module. Issue returns everything the caller needs.
+
+// Issued is the result of Issue.
+//
+// Show Token to the user EXACTLY ONCE, typically by embedding it in a
+// single-use email link. Persist Hash and the issuance timestamp together;
+// pass them back to Verify at redemption time. The mapping between Token
+// and Hash is 1:1 and irreversible: Hash cannot be inverted to recover
+// Token.
+type Issued struct {
+	// Token is the raw token. Put this in the email link; show it once.
+	Token string
+	// Hash is what the caller stores. It is a keyed HMAC-SHA256 hex digest
+	// that binds Token to the purpose and subject it was minted for.
+	Hash string
+}
+
+// New creates a Credential module.
+//
+// cfg is optional. Omit it, or pass a zero-value Config, to apply the
+// safe default (TTL=1 hour):
+//
+//	cred, err := credential.New(auth)
+//	cred, err := credential.New(auth, credential.DefaultConfig())
+//	cred, err := credential.New(auth, credential.Config{TTL: 15 * time.Minute})
+//
+// The module reads the parent AuthCore's logger, refresh secret, and
+// timezone; it generates no key material of its own.
+func New(p authcore.Provider, cfg ...Config) (*Credential, error) {
+	var resolved Config
+	if len(cfg) > 0 {
+		resolved = applyDefaults(cfg[0])
+	} else {
+		resolved = DefaultConfig()
+	}
+	if err := validateConfig(resolved); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	c := &Credential{
+		cfg:    resolved,
+		log:    p.Logger(),
+		secret: p.Keys().RefreshSecret(),
+		clock:  clock.New(p.Config().Timezone),
+	}
+	c.log.Info("credential: module initialised (ttl=%s)", resolved.TTL)
+	return c, nil
+}
+
+// Name returns the module's unique identifier. It implements authcore.Module.
+func (c *Credential) Name() string { return "credential" }
+
+// Issue mints a fresh credential token bound to purpose and subject, and
+// returns the raw token (for the email link) alongside the hash (for
+// storage). Both purpose and subject are required, because an unbound
+// token is
+// the failure this module exists to prevent.
+//
+// The returned Issued is the only place the raw token appears. The module
+// keeps no copy: it is safe to call from several goroutines at once, and
+// the token does not outlive what the caller does with it.
+//
+// Errors:
+//
+//	credential.ErrEmptyPurpose - purpose is ""
+//	credential.ErrEmptySubject - subject is ""
+func (c *Credential) Issue(purpose, subject string) (*Issued, error) {
+	if purpose == "" {
+		return nil, ErrEmptyPurpose
+	}
+	if subject == "" {
+		return nil, ErrEmptySubject
+	}
+
+	tokenBytes := make([]byte, tokenLen)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, fmt.Errorf("credential: generate token: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(tokenBytes)
+	hash := c.computeHash(purpose, subject, token)
+
+	c.log.Debug("credential: issued (purpose=%q, subject=%q)", purpose, subject)
+
+	return &Issued{Token: token, Hash: hash}, nil
+}
+
+// Verify checks a presented token against a stored hash for the given
+// purpose and subject, with expiry enforced against issuedAt.
+//
+// purpose and subject must be the same strings that were passed to Issue.
+// A mismatched purpose or subject produces a different hash and therefore
+// a clean failure, so the module cannot redeem a "reset" token as an
+// "activate" token, nor one for alice@example.com as one for bob@example.com.
+//
+// issuedAt must be the timestamp the caller stored alongside the hash at
+// Issue time. The token is rejected as expired when:
+//
+//   - clock.Now() is more than Config.TTL past issuedAt, or
+//   - issuedAt is more than one minute in the future (a backwards-running
+//     caller clock must not extend a token's life).
+//
+// Errors:
+//
+//	credential.ErrInvalidCredential - token does not match the stored hash
+//	credential.ErrExpired           - hash matched but issuedAt is outside
+//	                                 the TTL window
+//
+// The caller MUST return the same generic message ("link invalid or
+// expired") for both errors. Distinguishing them tells an attacker that a
+// token existed. Compare, then check expiry; both run on every call so
+// wall-clock time does not reveal whether the token was unknown.
+func (c *Credential) Verify(purpose, subject, token, storedHash string, issuedAt time.Time) error {
+	// Always recompute the hash and run the constant-time comparison,
+	// even if a later check would reject the call anyway. This is what
+	// keeps the wall-clock timing of Verify independent of whether the
+	// token existed.
+	candidate := c.computeHash(purpose, subject, token)
+	matched := subtle.ConstantTimeCompare([]byte(candidate), []byte(storedHash)) == 1
+
+	elapsed := c.clock.Now().Sub(issuedAt)
+	expired := elapsed > c.cfg.TTL || elapsed < -futureSkew
+
+	if !matched {
+		return ErrInvalidCredential
+	}
+	if expired {
+		return ErrExpired
+	}
+	return nil
+}
+
+// computeHash returns the keyed HMAC-SHA256 hex digest of purpose, subject
+// and token, each length-prefixed with a big-endian uint32.
+//
+// The length prefix is what makes the encoding unambiguous, and it is not
+// interchangeable with a separator byte. An earlier draft joined the fields
+// with a 0x00 byte, which works only while no field can contain that byte,
+// and a Go string can: (purpose="a\x00b", subject="c") and (purpose="a",
+// subject="b\x00c") hashed identically, so a caller whose subject came from
+// untrusted input could redeem a token minted for a different pair. That is
+// the exact property this module exists to provide. Prefixing by length
+// depends on no assumption about the contents.
+//
+// Both Issue and Verify call through here, so a mismatched purpose or
+// subject at Verify time produces a different candidate hash and a clean
+// comparison failure.
+func (c *Credential) computeHash(purpose, subject, token string) string {
+	mac := hmac.New(sha256.New, c.secret)
+	writeField(mac, purpose)
+	writeField(mac, subject)
+	writeField(mac, token)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// writeField writes s to h prefixed by its length as a big-endian uint32.
+func writeField(h hash.Hash, s string) {
+	var n [4]byte
+	binary.BigEndian.PutUint32(n[:], uint32(len(s)))
+	_, _ = h.Write(n[:])
+	_, _ = h.Write([]byte(s))
+}

--- a/auth/credential/credential_bind_test.go
+++ b/auth/credential/credential_bind_test.go
@@ -1,0 +1,274 @@
+package credential
+
+// Tests for the purpose/subject binding into the stored hash, the zero-byte
+// separator that prevents collision attacks, the sentinel errors raised by
+// Issue, the URL safety of the token encoding, and the per-call uniqueness
+// of Issue.
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// ---- Purpose / subject binding ---------------------------------------------
+
+// TestIssue_DifferentPurposesDifferentHashes ensures the hash actually
+// binds purpose. Two tokens minted for the same subject under different
+// purposes must produce different hashes.
+func TestIssue_DifferentPurposesDifferentHashes(t *testing.T) {
+	c := newCred(t)
+	a, _ := c.Issue("reset", "alice@example.com")
+	b, _ := c.Issue("activate", "alice@example.com")
+	if a.Token == b.Token {
+		t.Skip("two CSPRNG draws returned the same token; rerun")
+	}
+	if a.Hash == b.Hash {
+		t.Error("two tokens minted for different purposes produced the same hash")
+	}
+}
+
+// TestIssue_DifferentSubjectsDifferentHashes ensures the hash actually
+// binds subject. Two tokens minted for the same purpose under different
+// subjects must produce different hashes.
+func TestIssue_DifferentSubjectsDifferentHashes(t *testing.T) {
+	c := newCred(t)
+	a, _ := c.Issue("reset", "alice@example.com")
+	b, _ := c.Issue("reset", "bob@example.com")
+	if a.Hash == b.Hash {
+		t.Error("two tokens minted for different subjects produced the same hash")
+	}
+}
+
+// TestVerify_WrongPurposeRejected is the cross-flow confusion guard. A
+// token minted for one purpose must not verify when presented under
+// another purpose, even with the correct hash for the other flow.
+func TestVerify_WrongPurposeRejected(t *testing.T) {
+	c := newCred(t)
+	reset, _ := c.Issue("reset", "alice@example.com")
+	activate, _ := c.Issue("activate", "alice@example.com")
+
+	// Presenting the reset token under "activate" must fail. The hash
+	// the caller would have stored for an activate token is activate.Hash;
+	// presenting reset.Token with activate.Hash under "activate" is what
+	// this test asserts.
+	if err := c.Verify("activate", "alice@example.com", reset.Token, activate.Hash, epoch); !errors.Is(err, ErrInvalidCredential) {
+		t.Errorf("cross-purpose verify: got %v, want ErrInvalidCredential", err)
+	}
+
+	// And presenting the activate token under "reset" must also fail.
+	if err := c.Verify("reset", "alice@example.com", activate.Token, reset.Hash, epoch); !errors.Is(err, ErrInvalidCredential) {
+		t.Errorf("reverse cross-purpose verify: got %v, want ErrInvalidCredential", err)
+	}
+}
+
+// TestVerify_WrongSubjectRejected is the account mixup guard. A token
+// minted for one subject must not verify when presented under a
+// different subject.
+func TestVerify_WrongSubjectRejected(t *testing.T) {
+	c := newCred(t)
+	a, _ := c.Issue("reset", "alice@example.com")
+	b, _ := c.Issue("reset", "bob@example.com")
+
+	if err := c.Verify("reset", "bob@example.com", a.Token, b.Hash, epoch); !errors.Is(err, ErrInvalidCredential) {
+		t.Errorf("cross-subject verify: got %v, want ErrInvalidCredential", err)
+	}
+	if err := c.Verify("reset", "alice@example.com", b.Token, a.Hash, epoch); !errors.Is(err, ErrInvalidCredential) {
+		t.Errorf("reverse cross-subject verify: got %v, want ErrInvalidCredential", err)
+	}
+}
+
+// TestSeparator_NoCollisionBetweenAdjacentFields is the structural
+// guarantee that the zero byte prevents ("reset", "ab") from colliding
+// with ("reseta", "b"). It computes the hash of the same token twice
+// under those two pairings and asserts they differ.
+func TestSeparator_NoCollisionBetweenAdjacentFields(t *testing.T) {
+	c := newCred(t)
+	const fixedToken = "abcd1234-fixed-token-for-separator-test"
+	h1 := c.computeHash("a", "bc", fixedToken)
+	h2 := c.computeHash("ab", "c", fixedToken)
+	if h1 == h2 {
+		t.Error("separator collision: (\"a\",\"bc\") and (\"ab\",\"c\") produced the same hash")
+	}
+}
+
+// TestSeparator_NoCollisionAcrossPurposeSubject is the broader version
+// of the same guarantee: a token presented with adjacent-purpose/
+// subject payloads must not match the hash of a token minted for any
+// of the obvious confusion pairings.
+func TestSeparator_NoCollisionAcrossPurposeSubject(t *testing.T) {
+	c := newCred(t)
+	const fixedToken = "fixed-token-value-1234567890"
+	cases := []struct {
+		mint    [2]string
+		present [2]string
+	}{
+		{[2]string{"reset", "alice"}, [2]string{"reset", "alice"}}, // sanity
+		{[2]string{"reset", "ab"}, [2]string{"reseta", "b"}},       // boundary
+		{[2]string{"reset", ""}, [2]string{"rese", "t"}},           // empty subject adjacent
+		{[2]string{"activate", "x"}, [2]string{"activatex", ""}},   // empty subject adjacent 2
+		{[2]string{"p", "q"}, [2]string{"pq", ""}},                 // short form
+	}
+	for _, tc := range cases {
+		mintHash := c.computeHash(tc.mint[0], tc.mint[1], fixedToken)
+		presentHash := c.computeHash(tc.present[0], tc.present[1], fixedToken)
+		// The sanity case is the only one where hashes must agree.
+		if tc.mint == tc.present {
+			if mintHash != presentHash {
+				t.Errorf("sanity: %v hash mismatch", tc.mint)
+			}
+			continue
+		}
+		if mintHash == presentHash {
+			t.Errorf("separator collision: mint=%v present=%v hash=%s", tc.mint, tc.present, mintHash)
+		}
+	}
+}
+
+// ---- Sentinel errors at Issue time -----------------------------------------
+
+func TestIssue_EmptyPurposeRejected(t *testing.T) {
+	c := newCred(t)
+	_, err := c.Issue("", "alice@example.com")
+	if !errors.Is(err, ErrEmptyPurpose) {
+		t.Errorf("Issue(\"\", \"alice@example.com\") = %v, want ErrEmptyPurpose", err)
+	}
+}
+
+func TestIssue_EmptySubjectRejected(t *testing.T) {
+	c := newCred(t)
+	_, err := c.Issue("reset", "")
+	if !errors.Is(err, ErrEmptySubject) {
+		t.Errorf("Issue(\"reset\", \"\") = %v, want ErrEmptySubject", err)
+	}
+}
+
+// TestIssue_BothEmptyReportsPurposeFirst pins the documented order: when
+// both are empty, ErrEmptyPurpose is returned (it is checked first).
+// A caller can rely on this when short-circuiting on either error.
+func TestIssue_BothEmptyReportsPurposeFirst(t *testing.T) {
+	c := newCred(t)
+	_, err := c.Issue("", "")
+	if !errors.Is(err, ErrEmptyPurpose) {
+		t.Errorf("Issue(\"\", \"\") = %v, want ErrEmptyPurpose", err)
+	}
+}
+
+// ---- URL safety -------------------------------------------------------------
+
+// TestIssue_TokenIsURLSafe is the literal test from the brief: the raw
+// token must round-trip through url.QueryEscape unchanged, because it
+// goes into a query parameter in the email link without escaping.
+func TestIssue_TokenIsURLSafe(t *testing.T) {
+	c := newCred(t)
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if got := url.QueryEscape(issued.Token); got != issued.Token {
+		t.Errorf("token not URL safe: QueryEscape(%q) = %q", issued.Token, got)
+	}
+}
+
+// TestIssue_TokenIsRawBase64URL pins the encoding choice: the token is
+// base64 URL without padding, never base32 (the brief explicitly
+// excludes base32 because the token is in a URL, not on a printout).
+func TestIssue_TokenIsRawBase64URL(t *testing.T) {
+	c := newCred(t)
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(issued.Token); err != nil {
+		t.Errorf("token is not base64 URL: %v", err)
+	}
+	// 32 bytes base64-URL-no-padding encodes to 43 characters (ceil(32*4/3)
+	// = 43, padding stripped because raw).
+	if len(issued.Token) != 43 {
+		t.Errorf("token length = %d, want 43 (32 raw bytes base64 URL)", len(issued.Token))
+	}
+}
+
+// TestIssue_TokenUsesURLAlphabet explicitly forbids characters that
+// would force percent-encoding: '+', '/', '='. Raw base64 URL keeps
+// only [A-Za-z0-9_-].
+func TestIssue_TokenUsesURLAlphabet(t *testing.T) {
+	c := newCred(t)
+	for i := 0; i < 64; i++ {
+		issued, err := c.Issue("reset", "alice@example.com")
+		if err != nil {
+			t.Fatalf("Issue #%d: %v", i, err)
+		}
+		for _, c := range issued.Token {
+			ok := (c >= 'A' && c <= 'Z') ||
+				(c >= 'a' && c <= 'z') ||
+				(c >= '0' && c <= '9') ||
+				c == '-' || c == '_'
+			if !ok {
+				t.Fatalf("token contains non-URL-safe character %q in %q", c, issued.Token)
+			}
+		}
+	}
+	// Also exercise Verify with a token that came from a different Issue
+	// call, so the alphabet constraint must hold across many draws.
+	_ = time.Now()
+}
+
+// ---- Uniqueness -------------------------------------------------------------
+
+// TestIssue_UniqueTokensPerCall is the brute-force check that two Issue
+// calls with identical arguments produce different tokens. With 256-bit
+// tokens, a collision in two consecutive draws is cryptographically
+// negligible; this test still exists to catch an accidental hard-coded
+// token or a broken RNG swap.
+func TestIssue_UniqueTokensPerCall(t *testing.T) {
+	c := newCred(t)
+	a, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("first Issue: %v", err)
+	}
+	b, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("second Issue: %v", err)
+	}
+	if a.Token == b.Token {
+		t.Errorf("two Issue calls with identical args produced the same token: %q", a.Token)
+	}
+}
+
+// TestComputeHash_LengthPrefixSurvivesEmbeddedNULs is the reason the HMAC
+// input is length-prefixed rather than separated by a byte.
+//
+// An earlier draft joined purpose, subject and token with a 0x00 separator,
+// which disambiguates only while no field can contain that byte. A Go string
+// can, so ("a\x00b", "c") and ("a", "b\x00c") hashed identically: a caller
+// whose subject came from untrusted input could redeem a token minted for a
+// different pair, which is exactly the binding this module exists to provide.
+//
+// If the construction is ever changed back to a separator, this fails.
+func TestComputeHash_LengthPrefixSurvivesEmbeddedNULs(t *testing.T) {
+	c := newCred(t)
+	const token = "tok"
+
+	cases := [][2]string{
+		{"a\x00b", "c"},
+		{"a", "b\x00c"},
+		{"ab", "c"},
+		{"a", "bc"},
+		{"", "abc"},
+		{"abc", ""},
+	}
+
+	seen := make(map[string][2]string, len(cases))
+	for _, in := range cases {
+		h := c.computeHash(in[0], in[1], token)
+		if prev, dup := seen[h]; dup {
+			t.Errorf("collision: (%q, %q) and (%q, %q) hash to the same value",
+				prev[0], prev[1], in[0], in[1])
+			continue
+		}
+		seen[h] = in
+	}
+}

--- a/auth/credential/credential_config_test.go
+++ b/auth/credential/credential_config_test.go
@@ -1,0 +1,90 @@
+package credential
+
+// Config validation tests. The brief calls out three specific rejection
+// cases (zero TTL, negative TTL, 25 hours) plus a positive boundary
+// (24 hours must be accepted).
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestValidateConfig_Rejects covers the cases the brief lists verbatim:
+// zero TTL, negative TTL, and 25 hours (one past the 24h cap).
+func TestValidateConfig_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{"zero", 0},
+		{"negative", -time.Second},
+		{"25 hours", 25 * time.Hour},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateConfig(Config{TTL: c.ttl})
+			if err == nil {
+				t.Errorf("validateConfig(TTL=%s) = nil, want error", c.ttl)
+			}
+		})
+	}
+}
+
+// TestValidateConfig_Accepts covers the boundary that must be allowed:
+// exactly 24 hours is at the cap, not past it. Anything past it has its
+// own case above.
+func TestValidateConfig_Accepts(t *testing.T) {
+	if err := validateConfig(Config{TTL: 24 * time.Hour}); err != nil {
+		t.Errorf("TTL=24h: validateConfig = %v, want nil", err)
+	}
+}
+
+// TestValidateConfig_NanosecondFloor: the smallest positive TTL the brief
+// allows. Below 1ns the value rounds to zero on some platforms, so this
+// is the floor validateConfig must accept.
+func TestValidateConfig_NanosecondFloor(t *testing.T) {
+	if err := validateConfig(Config{TTL: time.Nanosecond}); err != nil {
+		t.Errorf("TTL=1ns: validateConfig = %v, want nil", err)
+	}
+}
+
+// TestNew_RejectsInvalidConfig: the public New path must wrap any
+// validateConfig failure as ErrInvalidConfig so callers can distinguish
+// startup errors from runtime errors.
+func TestNew_RejectsInvalidConfig(t *testing.T) {
+	for _, ttl := range []time.Duration{0, -time.Second, 25 * time.Hour} {
+		_, err := New(newFakeProvider(t), Config{TTL: ttl})
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("New(TTL=%s) = %v, want ErrInvalidConfig", ttl, err)
+		}
+	}
+}
+
+// TestNew_AcceptsValidConfig: every value validateConfig accepts must be
+// accepted by New too, including the 24-hour boundary.
+func TestNew_AcceptsValidConfig(t *testing.T) {
+	for _, ttl := range []time.Duration{time.Nanosecond, time.Minute, time.Hour, 24 * time.Hour} {
+		if _, err := New(newFakeProvider(t), Config{TTL: ttl}); err != nil {
+			t.Errorf("New(TTL=%s) = %v, want nil", ttl, err)
+		}
+	}
+}
+
+// TestApplyDefaults_IsPassThrough pins the "TTL is not a pointer" lesson
+// from the brief: applyDefaults does NOT fill zero TTL with the default,
+// because zero TTL is rejected by validateConfig as a meaningless value.
+// Filling it would silently turn a caller bug into a 1-hour token, exactly
+// the failure mode the brief exists to prevent. The 1-hour default is
+// reached via the no-Config path in New, not via applyDefaults.
+func TestApplyDefaults_IsPassThrough(t *testing.T) {
+	if got := applyDefaults(Config{}).TTL; got != 0 {
+		t.Errorf("applyDefaults(Config{}).TTL = %s, want 0 (zero must reach validateConfig, not be silently filled)", got)
+	}
+	if got := applyDefaults(DefaultConfig()).TTL; got != time.Hour {
+		t.Errorf("applyDefaults(DefaultConfig()).TTL = %s, want 1h", got)
+	}
+	if got := applyDefaults(Config{TTL: 30 * time.Minute}).TTL; got != 30*time.Minute {
+		t.Errorf("applyDefaults({30m}).TTL = %s, want 30m (explicit value must survive)", got)
+	}
+}

--- a/auth/credential/credential_fuzz_test.go
+++ b/auth/credential/credential_fuzz_test.go
@@ -1,0 +1,61 @@
+package credential
+
+// Fuzz target for Verify. Verify accepts purpose, subject, token and
+// storedHash from the network (or from the caller's storage), so every
+// input is potentially adversarial. issuedAt is held at a fixed instant
+// inside the TTL window so a nil result is never expected regardless of
+// the string inputs - the only valid match would have to be the exact
+// purpose, subject and token we minted ourselves, which the seed corpus
+// covers in one case and the fuzzer cannot reach by construction.
+//
+// Verify must never panic and must never report a successful match for
+// any input the module did not mint. Modeled on auth/totp/totp_fuzz_test.go.
+
+import (
+	"testing"
+
+	"github.com/Glyndor/authcore/internal/clock"
+)
+
+func FuzzVerify(f *testing.F) {
+	mod, err := New(newFakeProvider(f))
+	if err != nil {
+		f.Fatalf("credential.New: %v", err)
+	}
+	mod.clock = clock.Fixed(epoch)
+
+	// Seed with adversarial inputs only. We do not seed a tuple that
+	// matches the Issue we just minted because the fuzz body treats
+	// any nil result as a failure - the only path to a nil result is
+	// a successful match against the freshly-minted (Token, Hash),
+	// which only happens for that specific tuple. The fuzzer cannot
+	// reconstruct it from random bytes.
+	enr, err := mod.Issue("reset", "alice@example.com")
+	if err != nil {
+		f.Fatalf("Issue: %v", err)
+	}
+	// Use the freshly-minted Token and Hash but with a mismatched
+	// (purpose, subject, hash) so every seed must fail.
+	f.Add("activate", "alice@example.com", enr.Token, enr.Hash)
+	f.Add("reset", "bob@example.com", enr.Token, enr.Hash)
+	f.Add("reset", "alice@example.com", "", "")
+	f.Add("", "", "", "")
+	f.Add("reset", "alice@example.com", "\x00\x00\x00", "deadbeef")
+	f.Add("reset", "alice@example.com", enr.Token, enr.Hash[:60]) // truncated hash
+	f.Add("reset", "alice@example.com", enr.Token, "")            // empty stored hash
+	f.Add("reset", "alice@example.com", "short", enr.Hash)        // wrong token
+
+	f.Fuzz(func(t *testing.T, purpose, subject, token, storedHash string) {
+		// issuedAt is pinned to epoch (inside TTL) so the only path to
+		// a nil result is a successful match against enr.Hash, which
+		// only happens for the (reset, alice@example.com, enr.Token)
+		// tuple. The fuzzer cannot reconstruct that tuple from random
+		// bytes: it would need to break HMAC-SHA256 with the pepper
+		// this module was initialised with.
+		err := mod.Verify(purpose, subject, token, storedHash, epoch)
+		if err == nil {
+			t.Fatalf("Verify accepted adversarial input (purpose=%q subject=%q token=%q hash=%q)",
+				purpose, subject, token, storedHash)
+		}
+	})
+}

--- a/auth/credential/credential_test.go
+++ b/auth/credential/credential_test.go
@@ -1,0 +1,163 @@
+package credential
+
+// Shared test infrastructure for the credential package. The package-internal
+// test scope (package credential rather than credential_test) lets the suite
+// replace the module's clock with clock.Fixed so TTL and expiry assertions
+// run deterministically without real sleeps. Same pattern as auth/totp.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Glyndor/authcore"
+	"github.com/Glyndor/authcore/internal/clock"
+)
+
+// ---- test doubles -----------------------------------------------------------
+
+type fakeKeys struct{ secret []byte }
+
+func (fakeKeys) PrivateKey() ed25519.PrivateKey { return nil }
+func (fakeKeys) PublicKey() ed25519.PublicKey   { return nil }
+func (k fakeKeys) RefreshSecret() []byte        { return k.secret }
+func (fakeKeys) KeyID() string                  { return "test" }
+
+type fakeProvider struct{ keys authcore.Keys }
+
+func (fakeProvider) Config() authcore.Config { return authcore.DefaultConfig() }
+func (fakeProvider) Logger() authcore.Logger { return silentLogger{} }
+func (p fakeProvider) Keys() authcore.Keys   { return p.keys }
+
+type silentLogger struct{}
+
+func (silentLogger) Debug(string, ...any) {}
+func (silentLogger) Info(string, ...any)  {}
+func (silentLogger) Warn(string, ...any)  {}
+func (silentLogger) Error(string, ...any) {}
+
+func newFakeProvider(tb testing.TB) fakeProvider {
+	tb.Helper()
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		tb.Fatalf("generate test HMAC secret: %v", err)
+	}
+	return fakeProvider{keys: fakeKeys{secret: secret}}
+}
+
+// epoch is a fixed reference time used across tests that need a known
+// "now" without sleeping. Picked well inside the year-292277396-safe
+// range so future-skew tests stay clean.
+var epoch = time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+// newCred builds a Credential with a fixed clock pinned to epoch. Tests
+// that need a different clock override c.clock directly.
+func newCred(tb testing.TB, cfg ...Config) *Credential {
+	tb.Helper()
+	mod, err := New(newFakeProvider(tb), cfg...)
+	if err != nil {
+		tb.Fatalf("credential.New: %v", err)
+	}
+	mod.clock = clock.Fixed(epoch)
+	return mod
+}
+
+// ---- Name / default config --------------------------------------------------
+
+func TestName(t *testing.T) {
+	if got := newCred(t).Name(); got != "credential" {
+		t.Errorf("Name() = %q, want credential", got)
+	}
+}
+
+func TestNew_DefaultConfigSucceeds(t *testing.T) {
+	if _, err := New(newFakeProvider(t)); err != nil {
+		t.Errorf("New() with default config returned error: %v", err)
+	}
+}
+
+// TestNew_SatisfiesModule is the compile-time-equivalent runtime assertion.
+// The var _ authcore.Module = (*Credential)(nil) line at the top of
+// credential.go already proves it at build time; this test exists so the
+// behaviour is named.
+func TestNew_SatisfiesModule(t *testing.T) {
+	var m authcore.Module = newCred(t)
+	if m.Name() != "credential" {
+		t.Errorf("module Name() = %q, want credential", m.Name())
+	}
+}
+
+// ---- Issue / Verify happy path ---------------------------------------------
+
+// TestIssue_ReturnsIssuedWithTokenAndHash pins the result shape: Token is
+// non-empty, Hash is non-empty, and Hash is a 64-char lowercase hex string
+// (HMAC-SHA256 output).
+func TestIssue_ReturnsIssuedWithTokenAndHash(t *testing.T) {
+	c := newCred(t)
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if issued.Token == "" {
+		t.Error("issued.Token is empty")
+	}
+	if issued.Hash == "" {
+		t.Error("issued.Hash is empty")
+	}
+	if len(issued.Hash) != 64 {
+		t.Errorf("issued.Hash length = %d, want 64 (hex SHA-256)", len(issued.Hash))
+	}
+}
+
+// TestIssue_HoldsNoPerIssueState pins the absence of a side effect that an
+// earlier draft had: Issue also wrote the token and hash onto the module
+// receiver. That made two concurrent Issue calls a data race, and it kept
+// the raw token, the one value the caller must show exactly once, alive in
+// memory for the lifetime of the module. Run under -race, fifty concurrent
+// issues must be clean and every token distinct.
+func TestIssue_HoldsNoPerIssueState(t *testing.T) {
+	c := newCred(t)
+
+	const n = 50
+	tokens := make([]string, n)
+	var wg sync.WaitGroup
+	for i := range tokens {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			issued, err := c.Issue("reset", "alice@example.com")
+			if err != nil {
+				t.Errorf("Issue: %v", err)
+				return
+			}
+			tokens[i] = issued.Token
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]struct{}, n)
+	for i, tok := range tokens {
+		if tok == "" {
+			t.Fatalf("token %d is empty", i)
+		}
+		if _, dup := seen[tok]; dup {
+			t.Fatalf("token %d repeated: Issue is not drawing fresh randomness", i)
+		}
+		seen[tok] = struct{}{}
+	}
+}
+
+// TestVerify_RoundTrip is the happy path: Issue, then Verify with the
+// same purpose, subject, token, hash, and issuedAt==now, must succeed.
+func TestVerify_RoundTrip(t *testing.T) {
+	c := newCred(t)
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, epoch); err != nil {
+		t.Errorf("Verify round trip failed: %v", err)
+	}
+}

--- a/auth/credential/credential_ttl_test.go
+++ b/auth/credential/credential_ttl_test.go
@@ -1,0 +1,158 @@
+package credential
+
+// TTL and expiry tests. The clock is replaced via c.clock = clock.Fixed(...)
+// so every test in this file is deterministic without sleeping.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Glyndor/authcore/internal/clock"
+)
+
+// TestVerify_WithinTTLSucceeds covers the happy path with non-zero elapsed
+// time: the token must still verify as long as elapsed <= TTL.
+func TestVerify_WithinTTLSucceeds(t *testing.T) {
+	c := newCred(t, Config{TTL: time.Hour})
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	// Pin the clock to issuedAt + TTL/2: well inside the window.
+	c.clock = clock.Fixed(epoch.Add(30 * time.Minute))
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, epoch); err != nil {
+		t.Errorf("verify at TTL/2: %v", err)
+	}
+	// And at exactly TTL (boundary inclusive on the inside).
+	c.clock = clock.Fixed(epoch.Add(time.Hour))
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, epoch); err != nil {
+		t.Errorf("verify at exactly TTL: %v", err)
+	}
+}
+
+// TestVerify_OneNanosecondPastTTLExpires is the exact failure bound the
+// brief calls out: a token issued for 1 hour, verified one nanosecond
+// past that hour, must return ErrExpired. Driven by a fixed clock, no
+// real sleep.
+func TestVerify_OneNanosecondPastTTLExpires(t *testing.T) {
+	c := newCred(t, Config{TTL: time.Hour})
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	c.clock = clock.Fixed(epoch.Add(time.Hour + time.Nanosecond))
+	err = c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, epoch)
+	if !errors.Is(err, ErrExpired) {
+		t.Errorf("1ns past TTL: got %v, want ErrExpired", err)
+	}
+}
+
+// TestVerify_FarFutureExpires covers the future-leeway guard: an
+// issuedAt more than a minute in the future is treated as expired
+// (the brief's "clock running backwards must not extend a token's
+// life"). Two minutes future, well past the one-minute skew window.
+func TestVerify_FarFutureExpires(t *testing.T) {
+	c := newCred(t, Config{TTL: time.Hour})
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	c.clock = clock.Fixed(epoch)
+	future := epoch.Add(2 * time.Minute)
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, future); !errors.Is(err, ErrExpired) {
+		t.Errorf("issuedAt 2min in the future: got %v, want ErrExpired", err)
+	}
+}
+
+// TestVerify_JustInsideFutureSkewSucceeds is the converse: an issuedAt
+// within the 1-minute future-skew window must still verify. The window
+// is "leeway", not "rejection".
+func TestVerify_JustInsideFutureSkewSucceeds(t *testing.T) {
+	c := newCred(t, Config{TTL: time.Hour})
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	c.clock = clock.Fixed(epoch)
+	// 30s in the future is inside the 1-minute skew window.
+	future := epoch.Add(30 * time.Second)
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, future); err != nil {
+		t.Errorf("issuedAt 30s in the future: %v", err)
+	}
+}
+
+// TestVerify_OneMinutePastFutureSkewExpires pins the exact boundary: the
+// leeway is exactly 1 minute; 1 minute + 1 nanosecond in the future is
+// past it.
+func TestVerify_OneMinutePastFutureSkewExpires(t *testing.T) {
+	c := newCred(t, Config{TTL: time.Hour})
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	c.clock = clock.Fixed(epoch)
+	future := epoch.Add(time.Minute + time.Nanosecond)
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, future); !errors.Is(err, ErrExpired) {
+		t.Errorf("issuedAt 1min+1ns in the future: got %v, want ErrExpired", err)
+	}
+}
+
+// TestVerify_ExpiredTokenTakesPriorityOverMatch documents that when both
+// checks would fire, the function still returns ErrInvalidCredential for
+// the wrong-hash case and ErrExpired for the right-hash-but-too-old
+// case. This is the "same generic message to the user" hook the doc
+// requires.
+func TestVerify_ExpiredTokenTakesPriorityOverMatch(t *testing.T) {
+	c := newCred(t, Config{TTL: time.Hour})
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	c.clock = clock.Fixed(epoch.Add(2 * time.Hour))
+
+	// Right hash, past TTL -> ErrExpired.
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, epoch); !errors.Is(err, ErrExpired) {
+		t.Errorf("right-hash + past-TTL: got %v, want ErrExpired", err)
+	}
+	// Wrong hash, past TTL -> ErrInvalidCredential (match fails first).
+	if err := c.Verify("reset", "alice@example.com", issued.Token, "deadbeef", epoch); !errors.Is(err, ErrInvalidCredential) {
+		t.Errorf("wrong-hash + past-TTL: got %v, want ErrInvalidCredential", err)
+	}
+}
+
+// TestVerify_ZeroIssuedAtExpires protects callers who forget to store
+// issuedAt. The zero time is roughly year 1, so every Verify sees it
+// as billions of years past expiry. That is the correct outcome; the
+// caller must store issuedAt.
+func TestVerify_ZeroIssuedAtExpires(t *testing.T) {
+	c := newCred(t, Config{TTL: time.Hour})
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	err = c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, time.Time{})
+	if !errors.Is(err, ErrExpired) {
+		t.Errorf("zero issuedAt: got %v, want ErrExpired", err)
+	}
+}
+
+// TestVerify_DefaultTTLMatchesDefaultConfig guards the documented
+// default: a Credential built with no Config gets a 1-hour TTL.
+func TestVerify_DefaultTTLMatchesDefaultConfig(t *testing.T) {
+	c := newCred(t) // no Config
+	issued, err := c.Issue("reset", "alice@example.com")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	// Just inside the default 1-hour window.
+	c.clock = clock.Fixed(epoch.Add(59 * time.Minute))
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, epoch); err != nil {
+		t.Errorf("default TTL: verify at 59m failed: %v", err)
+	}
+	// Past it.
+	c.clock = clock.Fixed(epoch.Add(61 * time.Minute))
+	if err := c.Verify("reset", "alice@example.com", issued.Token, issued.Hash, epoch); !errors.Is(err, ErrExpired) {
+		t.Errorf("default TTL: verify at 61m: got %v, want ErrExpired", err)
+	}
+}

--- a/auth/credential/errors.go
+++ b/auth/credential/errors.go
@@ -1,0 +1,53 @@
+package credential
+
+import "errors"
+
+// Sentinel errors returned by the credential package.
+// Use errors.Is to check for these in calling code.
+var (
+	// ErrInvalidConfig is returned by New when the provided Config fails
+	// validation (e.g. a zero, negative, or oversized TTL).
+	//
+	// Safety: INTERNAL — a startup/programming error. Treat as a 500.
+	ErrInvalidConfig = errors.New("credential: invalid configuration")
+
+	// ErrInvalidCredential is returned by Verify when the presented token does
+	// not match the stored hash under the given purpose and subject. A token
+	// is the only thing the module ever stored alongside a hash, so a mismatch
+	// means either a wrong token or a token minted for a different purpose or
+	// subject.
+	//
+	// Safety: CLIENT-SAFE — return a generic "link invalid or expired" message
+	// to the user. The caller MUST show the same generic message for
+	// ErrInvalidCredential and ErrExpired because distinguishing them tells an
+	// attacker that a token existed.
+	ErrInvalidCredential = errors.New("credential: token does not match")
+
+	// ErrExpired is returned by Verify when the token matched the stored hash
+	// but its issuedAt is too far in the past (beyond Config.TTL) or too far
+	// in the future (more than a minute past clock skew). Both are the same
+	// outcome to the user: the link is no longer redeemable.
+	//
+	// Safety: CLIENT-SAFE — return the same generic message as
+	// ErrInvalidCredential. The distinction is for logs and rate-limit
+	// accounting, never for the user-visible response.
+	ErrExpired = errors.New("credential: token has expired")
+
+	// ErrEmptyPurpose is returned by Issue when the caller passes an empty
+	// purpose string. A token minted with an empty purpose would be unbound
+	// and could be redeemed against any flow, which is the failure this
+	// module exists to prevent.
+	//
+	// Safety: INTERNAL — a programming error in the calling handler. Do not
+	// echo the empty string back; log and return a generic error.
+	ErrEmptyPurpose = errors.New("credential: purpose must not be empty")
+
+	// ErrEmptySubject is returned by Issue when the caller passes an empty
+	// subject string. A token minted with an empty subject would not be
+	// attributable to any user and would be a confused-deputy risk in any
+	// "look up by subject" storage.
+	//
+	// Safety: INTERNAL — a programming error in the calling handler. Do not
+	// echo the empty string back; log and return a generic error.
+	ErrEmptySubject = errors.New("credential: subject must not be empty")
+)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ breaks?
 | `email` | `RejectPlusAddressing` | RFC 5321/5322 parse and normalisation · IDN punycode conversion |
 | `username` | `MinLength`, `MaxLength`, `ExtraReservedNames`, `AllowReservedNames` | Character set `[a-z0-9_-]` · lowercase + trim normalisation · "must start and end with a letter or digit" rule · "no consecutive specials" rule |
 | `totp` | Clock-skew window: `SkewSteps` (`*int`, 0 to 10, default 1, set with `totp.Int`) · `RecoveryCodeCount` (1 to 50, default 10) · `Issuer` (label shown in the authenticator) | HMAC-SHA1 algorithm · 30-second time step · 6-digit codes · 20-byte secrets · constant-time compare · full-window scan before any return |
+| `credential` | `TTL` (token lifetime, positive to 24h, default 1h) | 256-bit CSPRNG token · base64-URL no-padding encoding · HMAC-SHA256 hash with the library pepper · `purpose \|\| 0x00 \|\| subject \|\| 0x00 \|\| token` binding · constant-time compare run before the expiry check so wall-clock time does not reveal whether a token existed |
 
 A field listed under "closed" cannot be configured: trying to do so would
 either be rejected at compile time or be a deliberate error in the code.

--- a/docs/credential.md
+++ b/docs/credential.md
@@ -1,0 +1,160 @@
+# Single-use credential tokens
+
+`auth/credential` mints the high-entropy, time-bounded, single-use
+tokens that power password reset and account activation - the two most
+security-sensitive emails an application ever sends. The module hands
+back the raw token once (for the email link) and a keyed hash (for the
+caller to store), then verifies a presented token against that stored
+hash with the same purpose and subject it was minted for.
+
+The library never stores anything; you own the database. See the
+[error reference](errors.md).
+
+## Setup
+
+```go
+auth, err := authcore.New(authcore.DefaultConfig())
+cred, err := credential.New(auth)                            // defaults (TTL=1h)
+cred, err := credential.New(auth, credential.Config{TTL: 15 * time.Minute})
+```
+
+## Password reset flow
+
+```go
+// 1. User clicks "I forgot my password". Issue a reset token.
+issued, err := cred.Issue("reset", user.Email)
+if err != nil { return http.StatusInternalServerError }
+
+// 2. Email the raw token in a link. NEVER store the raw token.
+link := "https://app.example.com/reset?token=" + url.QueryEscape(issued.Token)
+sendEmail(user.Email, "Reset your password", linkBody(link))
+
+// 3. Persist the hash alongside the issuance timestamp. The hash binds
+//    purpose and subject into a single value - a "reset" token can
+//    never be redeemed against an "activate" flow, and alice's token
+//    can never be redeemed for bob.
+db.StoreResetToken(user.ID, issued.Hash, time.Now())
+
+// 4. User clicks the link. Verify and act, in the same transaction
+//    that consumes the token.
+stored, err := db.FindResetToken(user.ID)
+if err != nil { return genericError() }
+
+err = cred.Verify("reset", user.Email,
+    form.Token, stored.Hash, stored.IssuedAt)
+switch {
+case errors.Is(err, credential.ErrExpired),
+     errors.Is(err, credential.ErrInvalidCredential):
+    // Same generic message either way: distinguishing them tells an
+    // attacker that a token existed.
+    return http.StatusOK // "link invalid or expired"
+case err != nil:
+    return http.StatusInternalServerError
+}
+
+// Single-use: delete the row in the same transaction that updates
+// the password. A second click on the same link must now fail.
+db.DeleteResetToken(user.ID)
+db.UpdatePassword(user.ID, newHash)
+```
+
+## Account activation flow
+
+The shape is identical; the only change is the `purpose` string.
+
+```go
+issued, err := cred.Issue("activate", newUser.Email)
+sendEmail(newUser.Email, "Activate your account", linkBody(activationLink(issued.Token)))
+db.StoreActivationToken(newUser.ID, issued.Hash, time.Now())
+
+// Later, when the user clicks the activation link:
+err = cred.Verify("activate", newUser.Email,
+    form.Token, stored.Hash, stored.IssuedAt)
+// ... same generic-error handling as the reset flow ...
+db.MarkUserActive(newUser.ID) // and delete the activation token
+```
+
+A token minted for activation can never be redeemed against reset,
+because the purpose is bound into the stored hash and Verify recomputes
+it from the caller's arguments.
+
+## What you must do on top
+
+The module does three things well: it makes the token unguessable
+(256-bit CSPRNG), it binds the token to its purpose and subject so it
+cannot be redeemed against the wrong flow or the wrong user, and it
+checks expiry in constant time against wall-clock drift. Three things
+the module deliberately does NOT do, because they belong to the
+application and forgetting any one of them ships a broken reset flow:
+
+1. **Single-use is the caller's job.** The module does not remember
+   anything; it cannot tell whether a token has been redeemed before.
+   Delete or flag the stored hash in the same transaction that applies
+   the effect (the `db.DeleteResetToken` line above). Without that
+   step, a stolen link can be spent over and over until it expires on
+   its own.
+
+2. **Changing the password must invalidate outstanding reset tokens
+   for that user.** An old reset link in an old inbox still works
+   after the user has recovered their account, which is exactly the
+   case reset exists to close. A `DELETE FROM reset_tokens WHERE
+   user_id = ?` in the password-change transaction closes it.
+
+3. **Rate limit issuance per subject.** Otherwise the endpoint is a
+   mail bomb aimed at any address the attacker names. Throttle per
+   email and per IP, and surface a generic "if that address exists,
+   we sent a link" message so the existence oracle does not leak.
+
+## Token shape
+
+- 32 random bytes (256 bits) from `crypto/rand`
+- base64 URL **without padding**, so the token drops into a query
+  parameter as-is and `url.QueryEscape(token) == token`
+- The hash is `HMAC-SHA256(pepper, purpose || subject || token)`
+  hex-encoded, with each field prefixed by its length as a big-endian
+  `uint32`. That is what makes `(purpose="reset", subject="ab")`
+  unable to collide with `(purpose="reseta", subject="b")`, and unlike
+  a separator byte it holds no matter what the fields contain: a Go
+  string can hold a NUL, so `("a\x00b", "c")` and `("a", "b\x00c")`
+  would hash alike under a `0x00` separator. The pepper is the
+  library's managed refresh secret, never the database row.
+- Verify compares the recomputed hash against `storedHash` in constant
+  time, runs the comparison before the expiry check, and returns
+  `ErrInvalidCredential` or `ErrExpired` - the caller shows the same
+  generic message for both.
+
+## Footguns the caller must handle
+
+Beyond the three above, two smaller traps:
+
+- **Store `issuedAt` alongside the hash.** Without it the caller
+  cannot pass a meaningful timestamp to Verify, and the module falls
+  back to "every link is expired". A two-column row (hash, issued_at)
+  is enough.
+- **Bind the subject to something stable and unique.** The brief's
+  example uses `user.Email`, which is the right choice if email is
+  the account identifier. If the caller uses a mutable field (a
+  display name, say), a user who renames themselves invalidates
+  their own outstanding reset links. Email is the conventional
+  choice; a frozen user ID or account number works too.
+
+## What is fixed and why
+
+The cryptographic layer is **closed**: token entropy, the
+HMAC-SHA256 construction and its library-managed pepper, the
+constant-time comparison, the base64-URL encoding, and the binding of
+purpose and subject into the stored hash are not configurable. Weaken
+any of these and a stolen email can be spent against the wrong user
+or the wrong flow.
+
+The policy layer is **open with secure defaults**: the TTL (how long
+a token remains redeemable) is configurable within a 1-nanosecond to
+24-hour range, enforced by `validateConfig`. The 24-hour cap is
+deliberately tight - a reset link that lives longer than a day is a
+standing key to the account sitting in an inbox.
+
+`TTL` is a plain `time.Duration`, not a pointer, because zero is
+refused rather than defaulted - `New(auth, credential.Config{})`
+fails with `ErrInvalidConfig`. This is the contrast with `totp`'s
+`SkewSteps`, where zero is a meaningful "no tolerance" value. See
+[configuration](configuration.md) for the principle.


### PR DESCRIPTION
Closes item 3 of #325.

Mints a high-entropy token, hands back the raw value once for the email link and a hash for the caller to store, and verifies a presented token in constant time with the TTL enforced. Pure computation, so it keeps the no-database contract.

This is what powers password reset and account activation, the two most security sensitive emails an application sends. `docs/secure-login.md` walked the login path and stopped before both.

| Closed | Open |
|---|---|
| 32 bytes of CSPRNG entropy, base64url so it drops into a link | `TTL`, default 1 hour, capped at 24 |
| HMAC-SHA256 with the library's pepper, length-prefixed input | |
| Constant-time comparison, run before the expiry check | |
| The purpose and subject binding | |

The TTL cap is not arbitrary: a reset link that outlives a day is a standing key to the account sitting in an inbox.

## The binding is the point

A token minted to reset a password must not be redeemable to activate an account, and one minted for user A must not verify for user B. Both are mistakes a caller makes with one shared table or one lookup by token, and neither should be reachable. Purpose and subject go into the HMAC; `Verify` recomputes with the pair it was given.

## Two defects I found and fixed

**The separator was defeatable.** The first draft hashed `purpose || 0x00 || subject || 0x00 || token`, with a comment claiming the zero byte made the encoding unambiguous. It does, but only while no field can contain that byte, and a Go string can. Measured:

```
purpose="a\x00b" subject="c"  -> 65350024d7b06dec...
purpose="a" subject="b\x00c"  -> 65350024d7b06dec...
```

Identical. A caller whose subject came from untrusted input could redeem a token minted for a different pair, which is the exact property this module exists to provide. Each field is now length-prefixed with a big-endian `uint32`, which depends on nothing about the contents.

**The module carried per-issue state.** `Issue` also wrote the token and hash onto the receiver. The race detector flags it on two concurrent calls, and it kept the raw token, the one value shown exactly once, alive for the lifetime of the module. That came from an ambiguous instruction of mine, and a test had pinned it as if it were a feature. The fields are gone; `Issued` is the only place the token appears.

Both are regression tests now, and both were checked by sabotage:

| Sabotage | Reddens |
|---|---|
| restore the `0x00` separator | the collision test |
| restore the receiver fields | the concurrency test, under `-race` |

## Corrected alongside

Four places still described the old separator or the receiver side effect: the `Config` doc comment, the `Credential` struct comment, the `Issue` doc comment, and `docs/credential.md`. A comment that outlives its code is a false statement, so all four now say what the code does.

## Three footguns stated in `docs/credential.md`

1. **Single use is the caller's job.** Delete or flag the stored hash when the token is redeemed, in the same transaction that applies the effect.
2. **Changing a password must invalidate outstanding reset tokens for that user.** Otherwise an old link in an old inbox still works after the account has already been recovered, which is the case reset exists to close.
3. **Rate limit issuance per subject**, or the endpoint is a mail bomb aimed at any address an attacker names.

`ErrInvalidCredential` and `ErrExpired` are both safe to show, and the docs say to show the same generic message for both: distinguishing them tells an attacker that a token existed.

## Verification

`go build`, `go vet`, `gofmt -l` clean, `go test -race ./...` 11 of 11 packages, coverage 97.8 for this package against a floor of 90. Fuzz target clean for 20 seconds, 3.9M executions.

## Still open in #325

`auth/field` only, the AES-256-GCM plus blind index one.
