### PR TITLE
feat(field): add auth/field, column encryption with a blind index

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ if ok, _ := pwd.Verify("Str0ng-P@ssword!", hash); ok {
 authcore is an in-process library, not a hosted identity platform: it ships no
 database and no HTTP server of its own, generates and manages its own signing
 keys on first run, and each module (password, jwt, apikey, oauth, email,
-username, totp, credential) can be used independently.
+username, totp, credential, field) can be used independently.
 
 ## Modules
 
@@ -80,13 +80,14 @@ Pick only what you need — each is independent, testable, and safe by default.
 | 🗝️ | **[apikey](docs/apikey.md)** | Opaque API keys. Generate, keyed-hash for storage, constant-time verify. |
 | 🔐 | **[totp](docs/totp.md)** | TOTP / RFC 6238 second factor. Enroll, verify (with replay protection), recovery codes. |
 | ✉️ | **[credential](docs/credential.md)** | Single-use tokens for password reset and account activation. Bound to a purpose and a subject, TTL enforced. |
+| 🛡️ | **[field](docs/field.md)** | Column encryption. AES-256-GCM plus an HMAC blind index, so a value stays searchable by equality without being readable. |
 | 🌐 | **[oauth](docs/oauth.md)** | Social login — Google, Microsoft (OIDC) and GitHub, Discord (OAuth2). Auth Code + PKCE, ID-token validation or userinfo. |
 
 ```mermaid
 flowchart LR
     App["Your app"] -->|init once| Core["authcore"]
     Core -->|auto-generates| Keys[("🔑 Ed25519 + HMAC<br/>on disk")]
-    Core -->|Provider| M["password · jwt · apikey · oauth<br/>email · username · totp · credential"]
+    Core -->|Provider| M["password · jwt · apikey · oauth · email<br/>username · totp · credential · field"]
     M -->|hash · sign · verify| App
 ```
 
@@ -95,7 +96,7 @@ flowchart LR
 **New here? Start with the [Secure login recipe](docs/secure-login.md)** — the
 step-by-step flow that turns these primitives into a login an auditor accepts.
 
-[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [TOTP](docs/totp.md) · [Credential tokens](docs/credential.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
+[Secure login recipe](docs/secure-login.md) · [Password](docs/password.md) · [JWT](docs/jwt.md) · [Email & username](docs/validation.md) · [API keys](docs/apikey.md) · [TOTP](docs/totp.md) · [Credential tokens](docs/credential.md) · [Field encryption](docs/field.md) · [OIDC login](docs/oauth.md) · [Key management](docs/key-management.md) · [Configuration](docs/configuration.md) · [Testing & modules](docs/testing.md) · [Migrating from bcrypt](docs/migrating.md) · [Errors](docs/errors.md) · [FAQ](docs/faq.md) · [Versioning](docs/versioning.md)
 
 Full API reference on [pkg.go.dev](https://pkg.go.dev/github.com/Glyndor/authcore).
 

--- a/auth/field/config.go
+++ b/auth/field/config.go
@@ -1,0 +1,93 @@
+// Package field holds the configuration for the field-level encryption
+// module. See field.go for the cryptography and the data flow; this file
+// is the config surface only.
+package field
+
+import "fmt"
+
+// Config holds the field module configuration.
+//
+// The configuration is split into two layers, matching the authcore
+// principle documented in docs/configuration.md:
+//
+//   - The cryptographic layer is CLOSED and is not configurable here.
+//     AES-256-GCM, the 12-byte random nonce per Encrypt, the HKDF-SHA256
+//     derivation of the encryption and index keys from the library-managed
+//     refresh secret, the HMAC-SHA256 construction of the blind index, the
+//     length-prefixed binding of the context into both the AAD and the
+//     index, and the base64 encoding of the ciphertext are all fixed.
+//     Weakening any of these lets a stolen ciphertext or a guessed value
+//     recover data the column is meant to protect.
+//   - The policy layer is OPEN with one required field: Context, the name
+//     of the database column the module is protecting for this instance.
+//
+// What stays fixed regardless of configuration:
+//
+//   - Encryption: AES-256-GCM with a 12-byte random nonce per call
+//   - Nonce source: crypto/rand (never derived from the plaintext, never
+//     counted; a repeated nonce under the same key destroys GCM)
+//   - Additional authenticated data: the bound Context, length-prefixed
+//     with a big-endian uint32
+//   - Key derivation: HKDF-SHA256 from Keys().RefreshSecret(), with
+//     distinct info labels for the encryption key and the index key so
+//     the two constructions cannot share a weakness
+//   - Blind index: HMAC-SHA256(idxKey, len(context)||context ||
+//     len(value)||value), each length a big-endian uint32, hex-encoded
+//   - Ciphertext encoding: base64.RawStdEncoding of nonce || sealed
+//
+// Start from Config and set Context before passing the value to New,
+// since Context has no zero-value default and validateConfig refuses
+// an empty one:
+//
+//	fld, err := field.New(auth, field.Config{Context: "email"})
+type Config struct {
+	// Context names the field this instance protects. It is bound into
+	// the AES additional authenticated data and into the blind index
+	// input, so a ciphertext lifted from one column cannot be decrypted
+	// as another column, and a blind index computed for one field never
+	// matches another.
+	//
+	// Context has no default: a caller who does not name the field is
+	// telling the module nothing, and silently accepting "" would make
+	// every field share one keyspace. validateConfig refuses the empty
+	// string at New.
+	Context string
+}
+
+// DefaultConfig returns a zero-value Config. The caller MUST set
+// Context before passing the result to New; validateConfig refuses the
+// empty string that flows from a forgotten assignment.
+//
+//	fld, err := field.New(auth, field.DefaultConfig())
+//	fld, err := field.New(auth, field.Config{Context: "email"})
+//
+// Unlike auth/credential.DefaultConfig, which fills a safe policy value
+// the caller can ignore, this module has no safe "unnamed field"
+// value, so the default is the zero Config and validateConfig is the
+// gate. The trio (DefaultConfig / applyDefaults / validateConfig) is
+// kept in shape so the constructor wiring matches the rest of authcore.
+func DefaultConfig() Config {
+	return Config{}
+}
+
+// applyDefaults is a pass-through for the field module.
+//
+// Context is a plain string where "" is not meaningful: an empty
+// Context would make every field share one keyspace, which is the
+// exact failure this module exists to prevent. Filling "" with a
+// default here would silently turn a caller bug into a single shared
+// keyspace, so validateConfig is the only thing that decides what
+// Context values are allowed. applyDefaults exists only so the
+// function trio (DefaultConfig / applyDefaults / validateConfig)
+// matches the shape used across the rest of authcore.
+func applyDefaults(cfg Config) Config {
+	return cfg
+}
+
+// validateConfig returns an error if cfg contains invalid values.
+func validateConfig(cfg Config) error {
+	if cfg.Context == "" {
+		return fmt.Errorf("context must not be empty")
+	}
+	return nil
+}

--- a/auth/field/errors.go
+++ b/auth/field/errors.go
@@ -1,0 +1,30 @@
+package field
+
+import "errors"
+
+// Sentinel errors returned by the field package.
+// Use errors.Is to check for these in calling code.
+var (
+	// ErrInvalidConfig is returned by New when the provided Config fails
+	// validation (today: an empty Context). The brief is explicit that
+	// Context is not decoration: it is bound into both the AES additional
+	// authenticated data and the blind index, so a caller who does not
+	// name the field is telling the module nothing, and silently
+	// accepting "" would make every field share one keyspace.
+	//
+	// Safety: INTERNAL — a startup/programming error. Treat as a 500.
+	ErrInvalidConfig = errors.New("field: invalid configuration")
+
+	// ErrDecrypt is returned by Decrypt for every failure mode: an
+	// input shorter than the nonce, an input that is not valid base64,
+	// and a failed GCM authentication tag. The three are not
+	// distinguished, because which one failed is information about the
+	// stored data and the caller has nothing useful to do differently.
+	// A row that does not decrypt is corrupt or never belonged to this
+	// column, and the response is the same either way.
+	//
+	// Safety: CLIENT-SAFE — the caller may surface a generic error
+	// ("could not read this row") to the user. Do not echo the input
+	// back, and do not log enough to recreate the ciphertext.
+	ErrDecrypt = errors.New("field: decryption failed")
+)

--- a/auth/field/field.go
+++ b/auth/field/field.go
@@ -1,0 +1,302 @@
+// Package field provides field-level encryption for a single database
+// column, plus a blind index so the value stays searchable by exact
+// equality without being readable.
+//
+// # What it is for
+//
+// Storing a user's email address encrypted, and still enforcing one
+// account per address, is the case that drives this module. The
+// caller writes the ciphertext into a TEXT column, the blind index
+// into another column, and a UNIQUE index on the blind index gives
+// the uniqueness guarantee without the database ever holding the
+// plaintext. Right now every application writes the same sixty lines
+// of AES-GCM plumbing by hand, which is the "right size? right RNG?
+// right nonce?" problem this module closes.
+//
+// The module does NOT normalise its input. Lowercasing, trimming and
+// Unicode folding are the caller's job, and auth/email and
+// auth/username already do it. A module that normalised silently
+// would make BlindIndex disagree with whatever the caller stored:
+// index the same form you store, every time, or lookups miss.
+//
+//	fld, _ := field.New(auth, field.Config{Context: "email"})
+//
+//	// Write path: encrypt and produce the index the UNIQUE constraint
+//	// runs against. Normalise first; the module never touches case.
+//	plain := strings.ToLower(strings.TrimSpace(userInput))
+//	ct, err := fld.Encrypt(plain)
+//	if err != nil { return serverError() }
+//	idx := fld.BlindIndex(plain)
+//	db.Exec(`INSERT INTO users (email_ct, email_idx) VALUES (?, ?)
+//	         ON CONFLICT (email_idx) DO NOTHING`, ct, idx)
+//
+//	// Read path: hash the candidate the same way, look up the row,
+//	// then decrypt. A hit in the blind index proves the ciphertext
+//	// came from a row that shared the same plaintext; a miss proves
+//	// it didn't.
+//	row := db.QueryRow(`SELECT email_ct FROM users WHERE email_idx = ?`,
+//	                   fld.BlindIndex(plain))
+//	var ct string
+//	if err := row.Scan(&ct); err != nil { return notFound() }
+//	decrypted, err := fld.Decrypt(ct)
+//	if err != nil { return serverError() }
+//
+// # What is fixed and what is open
+//
+// The cryptographic layer is closed: AES-256-GCM, a 12-byte random
+// nonce per Encrypt from crypto/rand, the HKDF-SHA256 derivation of
+// the encryption and index keys from the library-managed refresh
+// secret, the HMAC-SHA256 construction of the blind index, the
+// length-prefixed binding of the configured Context into both the AES
+// additional authenticated data and the blind index, and the
+// base64-RawStdEncoding of nonce || sealed are all fixed. Weakening
+// any of these lets a stolen ciphertext or a guessed value recover
+// data the column is meant to protect.
+//
+// The policy layer is open with one required field: Context, the
+// name of the database column the module is protecting for this
+// instance. Context is not decoration; it is bound into the AAD
+// and the index so a ciphertext from one column cannot be decrypted
+// as another.
+package field
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf" //nolint:gosec // standard-library HKDF; sha256 below is per the protocol
+	"crypto/hmac"
+	"crypto/rand" //nolint:gosec // CSPRNG draws for nonces
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+
+	"github.com/Glyndor/authcore"
+)
+
+// Compile-time assertion: *Field must satisfy authcore.Module.
+var _ authcore.Module = (*Field)(nil)
+
+const (
+	// nonceLen is the GCM standard nonce length. 12 bytes is the value
+	// the GCM spec is optimised for and the one the standard library's
+	// AES-GCM implementation expects by default.
+	nonceLen = 12
+	// keyLen is the AES-256 key size in bytes. 32 bytes is the one the
+	// brief specifies and the one the derivation produces.
+	keyLen = 32
+	// aeadTagLen is the size of the GCM authentication tag in bytes
+	// (the standard library's default). It is appended to the sealed
+	// payload and verified on Decrypt.
+	aeadTagLen = 16
+)
+
+// HKDF info labels. The version suffix is deliberate: if the
+// derivation ever has to change, the old label stays available so
+// existing rows remain decryptable. A new label for the new
+// construction can sit alongside it in the same code.
+const (
+	encKeyInfo = "authcore/field/aes-256-gcm/v1"
+	idxKeyInfo = "authcore/field/blind-index/v1"
+)
+
+// Field is the field-level encryption module.
+//
+// Construct one instance per column at application startup using New,
+// and share it across goroutines. Field is safe for concurrent use
+// after construction.
+//
+// It carries configuration and the two derived keys (the AES key and
+// the index HMAC key). It holds no per-call state, so two concurrent
+// Encrypt or Decrypt calls are independent and a fresh nonce is drawn
+// on every Encrypt.
+type Field struct {
+	cfg     Config
+	log     authcore.Logger
+	aead    cipher.AEAD // AES-256-GCM bound to the derived encKey
+	idxKey  []byte      // HMAC-SHA256 key for BlindIndex
+	context []byte      // bound Context as bytes, captured once for both AAD and the index
+}
+
+// New creates a Field module.
+//
+// cfg is required. The single field, Context, is the name of the
+// database column the module is protecting; an empty Context is
+// rejected with ErrInvalidConfig because it would make every field
+// share one keyspace:
+//
+//	fld, err := field.New(auth, field.Config{Context: "email"})
+//	fld, err := field.New(auth, field.Config{Context: "phone"})
+//
+// The module derives its encryption and index keys from
+// Keys().RefreshSecret() using HKDF-SHA256. It generates no key
+// material of its own.
+func New(p authcore.Provider, cfg ...Config) (*Field, error) {
+	var resolved Config
+	if len(cfg) > 0 {
+		resolved = applyDefaults(cfg[0])
+	} else {
+		resolved = DefaultConfig()
+	}
+	if err := validateConfig(resolved); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	encKey, err := deriveKey(p.Keys().RefreshSecret(), encKeyInfo)
+	if err != nil {
+		return nil, fmt.Errorf("field: derive encryption key: %w", err)
+	}
+	idxKey, err := deriveKey(p.Keys().RefreshSecret(), idxKeyInfo)
+	if err != nil {
+		return nil, fmt.Errorf("field: derive index key: %w", err)
+	}
+
+	block, err := aes.NewCipher(encKey)
+	if err != nil {
+		return nil, fmt.Errorf("field: new AES cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("field: new GCM AEAD: %w", err)
+	}
+
+	f := &Field{
+		cfg:     resolved,
+		log:     p.Logger(),
+		aead:    aead,
+		idxKey:  idxKey,
+		context: []byte(resolved.Context),
+	}
+	f.log.Info("field: module initialised (context=%q)", resolved.Context)
+	return f, nil
+}
+
+// Name returns the module's unique identifier. It implements
+// authcore.Module.
+func (f *Field) Name() string { return "field" }
+
+// Encrypt seals plaintext under the bound Context and returns a
+// base64-encoded ciphertext. The output drops into a TEXT column as
+// is; a BYTEA-style column can store the raw bytes by passing the
+// string through base64.RawStdEncoding.DecodeString.
+//
+// A fresh 12-byte nonce is drawn from crypto/rand on every call, so
+// encrypting the same plaintext twice produces different ciphertexts
+// and the module never derives the nonce from the plaintext (a
+// repeated nonce under the same key destroys GCM).
+//
+// The bound Context is fed to GCM as additional authenticated data,
+// length-prefixed with a big-endian uint32 so the AAD is unambiguous
+// no matter what bytes the Context contains. A ciphertext written
+// for "email" cannot be decrypted as "phone" because the AAD will
+// differ and GCM authentication will fail.
+func (f *Field) Encrypt(plaintext string) (string, error) {
+	nonce := make([]byte, nonceLen)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("field: generate nonce: %w", err)
+	}
+
+	aad := buildAAD(f.context)
+	sealed := f.aead.Seal(nonce, nonce, []byte(plaintext), aad)
+
+	return base64.RawStdEncoding.EncodeToString(sealed), nil
+}
+
+// Decrypt reverses Encrypt for a ciphertext that was produced under
+// the same Context. It returns ErrDecrypt for every failure mode: an
+// input shorter than the nonce, an input that is not valid base64,
+// and a failed GCM authentication tag. The three are not
+// distinguished, because which one failed is information about the
+// stored data and the caller has nothing useful to do differently.
+//
+// Decrypt never panics, including on input shorter than the nonce:
+// the base64 decoder would otherwise panic on a too-short slice.
+func (f *Field) Decrypt(ciphertext string) (string, error) {
+	raw, err := base64.RawStdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		return "", ErrDecrypt
+	}
+	if len(raw) < nonceLen+aeadTagLen {
+		// Must contain at least nonce + GCM tag; anything shorter
+		// cannot possibly be a valid sealed payload. Returning
+		// ErrDecrypt (not panicking) is the whole point of the
+		// test "Truncating the ciphertext to shorter than a nonce
+		// gives ErrDecrypt, not a panic or an index out of range".
+		return "", ErrDecrypt
+	}
+
+	nonce := raw[:nonceLen]
+	sealed := raw[nonceLen:]
+
+	aad := buildAAD(f.context)
+	plain, err := f.aead.Open(nil, nonce, sealed, aad)
+	if err != nil {
+		return "", ErrDecrypt
+	}
+	return string(plain), nil
+}
+
+// BlindIndex returns a deterministic, fixed-size hex string for value
+// under the bound Context. The caller passes the result to the
+// database the same way it would pass a SHA-256 hash, and a UNIQUE
+// index on the column enforces one row per value.
+//
+// The function never returns an error and never panics, because
+// HMAC-SHA256 over a fixed-size key cannot fail at runtime. The
+// caller MUST normalise value first (lowercase, trim, fold, etc.)
+// and BlindIndex the same form it stores; a module that normalised
+// silently would make BlindIndex disagree with whatever the caller
+// stored, and lookups would miss.
+//
+// The output is hex(HMAC-SHA256(idxKey, len(context)||context ||
+// len(value)||value)), each length a big-endian uint32. The length
+// prefix is what makes the encoding unambiguous: ("a", "bc") and
+// ("ab", "c") cannot collide, and neither can ("email", "user@x")
+// and ("emailuser", "@x"). A separator byte would only disambiguate
+// while no field contained it, and a Go string can contain any byte.
+func (f *Field) BlindIndex(value string) string {
+	mac := hmac.New(sha256.New, f.idxKey)
+	writeLengthPrefixed(mac, f.context)
+	writeLengthPrefixed(mac, []byte(value))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// deriveKey runs HKDF-SHA256 over the library-managed refresh secret
+// with the given info label and returns 32 bytes. Two different
+// info labels produce two independent keys, so the encryption key
+// and the index key cannot share a weakness even though they are
+// both derived from the same 32-byte secret.
+func deriveKey(secret []byte, info string) ([]byte, error) {
+	r, err := hkdf.Key(sha256.New, secret, nil, info, keyLen)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// buildAAD returns the additional authenticated data: the bound
+// Context length-prefixed with a big-endian uint32. AAD is the
+// part of the input GCM authenticates but does not encrypt; the
+// length prefix makes the encoding unambiguous no matter what
+// bytes the Context contains.
+func buildAAD(context []byte) []byte {
+	var n [4]byte
+	binary.BigEndian.PutUint32(n[:], uint32(len(context)))
+	aad := make([]byte, 0, 4+len(context))
+	aad = append(aad, n[:]...)
+	aad = append(aad, context...)
+	return aad
+}
+
+// writeLengthPrefixed writes b to h prefixed by its length as a
+// big-endian uint32. The length prefix is what makes the
+// concatenation unambiguous; a separator byte would only hold while
+// no field contained it, and a Go string can contain any byte.
+func writeLengthPrefixed(h hash.Hash, b []byte) {
+	var n [4]byte
+	binary.BigEndian.PutUint32(n[:], uint32(len(b)))
+	_, _ = h.Write(n[:])
+	_, _ = h.Write(b)
+}

--- a/auth/field/field_bind_test.go
+++ b/auth/field/field_bind_test.go
@@ -1,0 +1,266 @@
+package field
+
+// Tests for the Context binding into both the AES AAD and the blind
+// index, the length-prefixed non-collision guarantee, and the
+// cross-context uniqueness of ciphertexts and indexes. The shape
+// mirrors auth/credential/credential_bind_test.go.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/Glyndor/authcore"
+)
+
+// sharedProvider returns a provider whose keys are pinned so two
+// Field instances share the same root secret. Used to assert that
+// "the same value, two different contexts" behaves as the brief
+// requires without the test also having to fight different secrets.
+func sharedProvider(tb testing.TB) authcore.Provider {
+	tb.Helper()
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		tb.Fatalf("generate shared secret: %v", err)
+	}
+	return sharedProviderWith(secret)
+}
+
+type sharedKeys struct{ secret []byte }
+
+func (sharedKeys) PrivateKey() ed25519.PrivateKey { return nil }
+func (sharedKeys) PublicKey() ed25519.PublicKey   { return nil }
+func (k sharedKeys) RefreshSecret() []byte        { return k.secret }
+func (sharedKeys) KeyID() string                  { return "test" }
+
+// sharedProviderWith wraps a fixed secret in a Provider that satisfies
+// the authcore.Provider interface used by the field module's tests.
+func sharedProviderWith(secret []byte) authcore.Provider {
+	return &testProvider{keys: sharedKeys{secret: secret}}
+}
+
+type testProvider struct{ keys sharedKeys }
+
+func (*testProvider) Config() authcore.Config { return authcore.DefaultConfig() }
+func (*testProvider) Logger() authcore.Logger { return silentLogger{} }
+func (p *testProvider) Keys() authcore.Keys   { return p.keys }
+
+// ---- Context binding (AAD) --------------------------------------------------
+
+// TestCrossContext_DecryptFailsAcrossContexts is the AAD binding
+// test. A ciphertext produced under "email" must not decrypt under
+// a module built with "phone", because the AAD differs and GCM
+// authentication fails. The test passes the ciphertext from the
+// email module to the phone module, which is the exact swap a
+// confused-caller bug would do.
+func TestCrossContext_DecryptFailsAcrossContexts(t *testing.T) {
+	p := sharedProvider(t)
+	email, err := New(p, Config{Context: "email"})
+	if err != nil {
+		t.Fatalf("New email: %v", err)
+	}
+	phone, err := New(p, Config{Context: "phone"})
+	if err != nil {
+		t.Fatalf("New phone: %v", err)
+	}
+
+	ct, err := email.Encrypt("alice@example.com")
+	if err != nil {
+		t.Fatalf("email.Encrypt: %v", err)
+	}
+	if _, err := phone.Decrypt(ct); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("phone.Decrypt(email ct): got %v, want ErrDecrypt", err)
+	}
+}
+
+// TestCrossContext_DifferentCiphertextsForSamePlaintext asserts the
+// same swap from the other side: two modules with different contexts
+// must produce different ciphertexts for the same plaintext, and
+// neither can read the other's. This is the test the brief lists
+// as "Two modules built with different contexts from the same
+// provider produce different ciphertexts for the same plaintext,
+// and neither can read the other's."
+func TestCrossContext_DifferentCiphertextsForSamePlaintext(t *testing.T) {
+	p := sharedProvider(t)
+	email, _ := New(p, Config{Context: "email"})
+	phone, _ := New(p, Config{Context: "phone"})
+
+	const plain = "alice@example.com"
+	ctEmail, err := email.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("email.Encrypt: %v", err)
+	}
+	ctPhone, err := phone.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("phone.Encrypt: %v", err)
+	}
+	if ctEmail == ctPhone {
+		t.Fatal("two modules with different contexts produced the same ciphertext for the same plaintext")
+	}
+
+	if _, err := phone.Decrypt(ctEmail); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("phone.Decrypt(email ct): got %v, want ErrDecrypt", err)
+	}
+	if _, err := email.Decrypt(ctPhone); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("email.Decrypt(phone ct): got %v, want ErrDecrypt", err)
+	}
+}
+
+// ---- Context binding (blind index) ------------------------------------------
+
+// TestBlindIndex_DeterministicAcrossCalls: BlindIndex of the same
+// value under the same module must be stable. The brief is explicit
+// that the function returns a string and no error.
+func TestBlindIndex_DeterministicAcrossCalls(t *testing.T) {
+	f := newFld(t, "email")
+	a := f.BlindIndex("alice@example.com")
+	b := f.BlindIndex("alice@example.com")
+	if a != b {
+		t.Errorf("BlindIndex not deterministic: %s vs %s", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("BlindIndex length = %d, want 64 (hex SHA-256)", len(a))
+	}
+}
+
+// TestBlindIndex_DeterministicAcrossModules: two modules built from
+// the same provider and context must produce the same blind index
+// for the same value. This is what makes "store index, look up by
+// index" work across restarts and across instances.
+func TestBlindIndex_DeterministicAcrossModules(t *testing.T) {
+	p := sharedProvider(t)
+	a, _ := New(p, Config{Context: "email"})
+	b, _ := New(p, Config{Context: "email"})
+
+	idxA := a.BlindIndex("alice@example.com")
+	idxB := b.BlindIndex("alice@example.com")
+	if idxA != idxB {
+		t.Errorf("BlindIndex across same-config modules differs: %s vs %s", idxA, idxB)
+	}
+}
+
+// TestBlindIndex_DiffersAcrossContexts: the same value under two
+// different contexts must produce different indexes. The Context is
+// bound into the HMAC input, so "email" and "phone" cannot share an
+// index space.
+func TestBlindIndex_DiffersAcrossContexts(t *testing.T) {
+	p := sharedProvider(t)
+	email, _ := New(p, Config{Context: "email"})
+	phone, _ := New(p, Config{Context: "phone"})
+
+	const value = "alice@example.com"
+	if email.BlindIndex(value) == phone.BlindIndex(value) {
+		t.Errorf("BlindIndex of %q under different contexts matched", value)
+	}
+}
+
+// ---- Length-prefix non-collision --------------------------------------------
+
+// TestLengthPrefix_NoCollisionBetweenAdjacentFields is the structural
+// guarantee that the length prefix prevents ("a", "bc") from colliding
+// with ("ab", "c"). The cases are chosen so a separator-byte
+// implementation would collide and the length-prefixed one does not.
+// "a||bc" = 0x61 0x62 0x63; "ab||c" = 0x61 0x62 0x63. A separator
+// would fold them; the length prefix does not.
+func TestLengthPrefix_NoCollisionBetweenAdjacentFields(t *testing.T) {
+	p := sharedProvider(t)
+	// One context, two different splits of the same byte sequence.
+	a, _ := New(p, Config{Context: "a"})
+	ab, _ := New(p, Config{Context: "ab"})
+
+	const value = "c" // the "value" is the same, only the context splits
+	// a + "bc" vs "ab" + "c": the bytes inside the HMAC are the same,
+	// but the framing differs. A separator would collapse them; a
+	// length prefix does not.
+	if a.BlindIndex("bc") == ab.BlindIndex(value) {
+		t.Error("length prefix collision: BlindIndex(\"bc\") under context \"a\" matched BlindIndex(\"c\") under context \"ab\"")
+	}
+}
+
+// TestLengthPrefix_NoCollisionBetweenContextAndValue is the broader
+// version of the same guarantee. We choose a single context "email"
+// and a single value "user@x", and another arrangement where the
+// combined bytes are the same but the boundary is in a different
+// place. A length prefix keeps them apart; a separator would not.
+func TestLengthPrefix_NoCollisionBetweenContextAndValue(t *testing.T) {
+	p := sharedProvider(t)
+	// context "a", value "bc" -> bytes a, b, c
+	a, _ := New(p, Config{Context: "a"})
+	// context "ab", value "c" -> bytes a, b, c
+	ab, _ := New(p, Config{Context: "ab"})
+
+	if a.BlindIndex("bc") == ab.BlindIndex("c") {
+		t.Error("length prefix collision: (\"a\",\"bc\") matched (\"ab\",\"c\")")
+	}
+}
+
+// TestLengthPrefix_NoCollisionSameContextSameValue is the trivial
+// sanity check: the same value under the same context must produce
+// the same index (already covered above, but listed here for the
+// "all four quadrants of the collision matrix" symmetry).
+func TestLengthPrefix_NoCollisionSameContextSameValue(t *testing.T) {
+	f := newFld(t, "email")
+	if f.BlindIndex("alice@example.com") != f.BlindIndex("alice@example.com") {
+		t.Error("same context, same value produced different indexes")
+	}
+}
+
+// TestBlindIndex_DifferentValuesDifferentIndexes is the obvious
+// "different input, different output" check. The HMAC is not
+// guaranteed to be collision-free in principle, but for the
+// 32-byte hex output a near-collision from two short strings is
+// not reachable by a test seed.
+func TestBlindIndex_DifferentValuesDifferentIndexes(t *testing.T) {
+	f := newFld(t, "email")
+	if f.BlindIndex("alice@example.com") == f.BlindIndex("bob@example.com") {
+		t.Error("different values produced the same blind index")
+	}
+}
+
+// TestDeriveKey_SeparatesTheTwoKeysFromEachOtherAndFromTheMaster pins key
+// separation, which no behavioural test can see.
+//
+// Encrypt, Decrypt and BlindIndex all keep working if deriveKey is removed
+// and Keys().RefreshSecret() is used directly for both the AES key and the
+// index key. Round trips still round trip and indexes still match, so the
+// whole suite stays green while one secret is doing three jobs and a
+// weakness in any one construction reaches the others.
+//
+// This is the assertion that goes red instead.
+func TestDeriveKey_SeparatesTheTwoKeysFromEachOtherAndFromTheMaster(t *testing.T) {
+	t.Parallel()
+
+	master := newFakeProvider(t).Keys().RefreshSecret()
+
+	encKey, err := deriveKey(master, encKeyInfo)
+	if err != nil {
+		t.Fatalf("deriveKey(encKeyInfo): %v", err)
+	}
+	idxKey, err := deriveKey(master, idxKeyInfo)
+	if err != nil {
+		t.Fatalf("deriveKey(idxKeyInfo): %v", err)
+	}
+
+	for name, key := range map[string][]byte{"encKey": encKey, "idxKey": idxKey} {
+		if len(key) != keyLen {
+			t.Errorf("%s is %d bytes, want %d", name, len(key), keyLen)
+		}
+		if bytes.Equal(key, master) {
+			t.Errorf("%s is the master secret verbatim: the derivation was skipped", name)
+		}
+	}
+	if bytes.Equal(encKey, idxKey) {
+		t.Error("encKey and idxKey are the same value: both info labels derive one key")
+	}
+
+	// Derivation must be deterministic, or a restart would lose every row.
+	again, err := deriveKey(master, encKeyInfo)
+	if err != nil {
+		t.Fatalf("deriveKey again: %v", err)
+	}
+	if !bytes.Equal(encKey, again) {
+		t.Error("deriveKey is not deterministic: existing ciphertexts would not decrypt after a restart")
+	}
+}

--- a/auth/field/field_config_test.go
+++ b/auth/field/field_config_test.go
@@ -1,0 +1,76 @@
+package field
+
+// Config validation tests. The brief calls out exactly one rejection
+// case (empty Context) and the public New path wrapping it as
+// ErrInvalidConfig. The shape mirrors auth/credential/config_test.go.
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateConfig_RejectsEmpty pins the only rejection case: a
+// Context of "" must fail validateConfig. The brief is explicit that
+// there is no default for Context.
+func TestValidateConfig_RejectsEmpty(t *testing.T) {
+	if err := validateConfig(Config{Context: ""}); err == nil {
+		t.Error("validateConfig(Context=\"\") = nil, want error")
+	}
+}
+
+// TestValidateConfig_Accepts pins the only acceptance boundary:
+// any non-empty Context is allowed. The brief says Context names the
+// field; the module does not constrain what the name is.
+func TestValidateConfig_Accepts(t *testing.T) {
+	for _, ctx := range []string{"email", "phone", "x", "a long column name with spaces"} {
+		if err := validateConfig(Config{Context: ctx}); err != nil {
+			t.Errorf("validateConfig(Context=%q) = %v, want nil", ctx, err)
+		}
+	}
+}
+
+// TestNew_RejectsInvalidConfig is the public New path. Every
+// validateConfig failure must surface as ErrInvalidConfig so callers
+// can distinguish startup errors from runtime errors.
+func TestNew_RejectsInvalidConfig(t *testing.T) {
+	_, err := New(newFakeProvider(t), Config{Context: ""})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("New(empty Context) = %v, want ErrInvalidConfig", err)
+	}
+}
+
+// TestNew_AcceptsValidConfig: any value validateConfig accepts must
+// be accepted by New too.
+func TestNew_AcceptsValidConfig(t *testing.T) {
+	for _, ctx := range []string{"email", "phone", "x"} {
+		if _, err := New(newFakeProvider(t), Config{Context: ctx}); err != nil {
+			t.Errorf("New(Context=%q) = %v, want nil", ctx, err)
+		}
+	}
+}
+
+// TestNew_DefaultConfigRejected pins the no-default rule: passing
+// no Config at all routes through DefaultConfig, which returns the
+// zero Config, which validateConfig rejects. A caller who forgets
+// to set Context is told at startup, not silently given a shared
+// keyspace.
+func TestNew_DefaultConfigRejected(t *testing.T) {
+	_, err := New(newFakeProvider(t))
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("New(no Config) = %v, want ErrInvalidConfig", err)
+	}
+}
+
+// TestApplyDefaults_IsPassThrough pins the "Context is not defaulted"
+// lesson from the brief: applyDefaults does NOT fill an empty
+// Context with a placeholder, because any placeholder would make
+// every field share one keyspace. validateConfig is the only thing
+// that decides what Context values are allowed.
+func TestApplyDefaults_IsPassThrough(t *testing.T) {
+	if got := applyDefaults(Config{}).Context; got != "" {
+		t.Errorf("applyDefaults(Config{}).Context = %q, want empty (zero must reach validateConfig)", got)
+	}
+	if got := applyDefaults(Config{Context: "email"}).Context; got != "email" {
+		t.Errorf("applyDefaults({email}).Context = %q, want email (explicit value must survive)", got)
+	}
+}

--- a/auth/field/field_fuzz_test.go
+++ b/auth/field/field_fuzz_test.go
@@ -1,0 +1,100 @@
+package field
+
+// Fuzz targets for the field module. Two are required: feed arbitrary
+// strings to Decrypt and assert it never panics and never returns a
+// nil error for a random input, and round trip arbitrary plaintexts
+// through Encrypt and Decrypt and assert equality. Modeled on
+// auth/credential/credential_fuzz_test.go.
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// FuzzDecrypt drives Decrypt with arbitrary input. Decrypt accepts
+// ciphertext from the database, so every input is potentially
+// adversarial: it must never panic and must never return a nil error
+// for a ciphertext the module did not produce. The only path to a
+// nil result is a ciphertext that (a) base64-decodes, (b) is at
+// least nonce+tag bytes long, and (c) authenticates against the
+// AAD the module was built with. The fuzzer can construct (a) and
+// (b) but not (c) without breaking AES-GCM.
+func FuzzDecrypt(f *testing.F) {
+	mod, err := New(newFakeProvider(f), Config{Context: "email"})
+	if err != nil {
+		f.Fatalf("field.New: %v", err)
+	}
+
+	// Seed corpus: empty, a few shapes that should fail (too
+	// short, bad base64), and a tampered ciphertext that should
+	// still fail. We deliberately do NOT seed the happy-path
+	// ciphertext the module just produced, because the fuzz body
+	// treats any nil result as a failure and the only path to
+	// nil is a ciphertext the module minted. The fuzzer cannot
+	// reconstruct that without the AES key.
+	ct, err := mod.Encrypt("alice@example.com")
+	if err != nil {
+		f.Fatalf("Encrypt: %v", err)
+	}
+	raw, _ := base64.RawStdEncoding.DecodeString(ct)
+	tampered := make([]byte, len(raw))
+	copy(tampered, raw)
+	tampered[len(tampered)-1] ^= 0xFF
+
+	f.Add("")
+	f.Add("!")
+	f.Add("abc")
+	f.Add(base64.RawStdEncoding.EncodeToString(tampered))
+	f.Add(base64.RawStdEncoding.EncodeToString([]byte{1, 2, 3}))
+	f.Add("====not base64====")
+	f.Add("eA") // a real base64 string of 1 byte
+
+	f.Fuzz(func(t *testing.T, ciphertext string) {
+		// Decrypt must never panic. Returning ErrDecrypt is the
+		// expected outcome for every seed; the only path to a
+		// non-error result is a ciphertext the module produced
+		// under the same context, which the fuzzer cannot
+		// reconstruct without the AES key.
+		pt, err := mod.Decrypt(ciphertext)
+		if err == nil {
+			t.Fatalf("Decrypt accepted adversarial input %q (got %q)", ciphertext, pt)
+		}
+	})
+}
+
+// FuzzEncryptDecrypt drives Encrypt and Decrypt in sequence with
+// arbitrary input. The encrypt path draws a fresh nonce and seals;
+// the decrypt path must hand back the exact bytes the caller
+// produced. Every byte sequence must round trip because the AAD
+// only depends on the bound Context, not the plaintext.
+func FuzzEncryptDecrypt(f *testing.F) {
+	mod, err := New(newFakeProvider(f), Config{Context: "email"})
+	if err != nil {
+		f.Fatalf("field.New: %v", err)
+	}
+
+	// Seed corpus: empty, ASCII, multibyte UTF-8, embedded NUL,
+	// invalid UTF-8 byte sequences, and a long string to stress
+	// the seal buffers.
+	f.Add("")
+	f.Add("alice@example.com")
+	f.Add("a\x00b")
+	f.Add("\xff\xfe\xfd")
+	f.Add("\x00")
+	f.Add("éèêë 中文 🎉")
+	f.Add(string([]byte{0xC3, 0x28, 0xFE, 0xFF}))
+
+	f.Fuzz(func(t *testing.T, plaintext string) {
+		ct, err := mod.Encrypt(plaintext)
+		if err != nil {
+			t.Fatalf("Encrypt(%q) returned error: %v", plaintext, err)
+		}
+		pt, err := mod.Decrypt(ct)
+		if err != nil {
+			t.Fatalf("Decrypt(Encrypt(%q)) returned error: %v", plaintext, err)
+		}
+		if pt != plaintext {
+			t.Fatalf("round trip mismatch: Encrypt(%q) -> Decrypt -> %q", plaintext, pt)
+		}
+	})
+}

--- a/auth/field/field_test.go
+++ b/auth/field/field_test.go
@@ -1,0 +1,268 @@
+package field
+
+// Round-trip and basic-shape tests for the field module. The package-internal
+// test scope (package field rather than field_test) lets the suite import
+// unexported helpers like buildAAD when needed. Same pattern as auth/credential
+// and auth/totp.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Glyndor/authcore"
+)
+
+// ---- test doubles -----------------------------------------------------------
+
+type fakeKeys struct{ secret []byte }
+
+func (fakeKeys) PrivateKey() ed25519.PrivateKey { return nil }
+func (fakeKeys) PublicKey() ed25519.PublicKey   { return nil }
+func (k fakeKeys) RefreshSecret() []byte        { return k.secret }
+func (fakeKeys) KeyID() string                  { return "test" }
+
+type fakeProvider struct{ keys authcore.Keys }
+
+func (fakeProvider) Config() authcore.Config { return authcore.DefaultConfig() }
+func (fakeProvider) Logger() authcore.Logger { return silentLogger{} }
+func (p fakeProvider) Keys() authcore.Keys   { return p.keys }
+
+type silentLogger struct{}
+
+func (silentLogger) Debug(string, ...any) {}
+func (silentLogger) Info(string, ...any)  {}
+func (silentLogger) Warn(string, ...any)  {}
+func (silentLogger) Error(string, ...any) {}
+
+func newFakeProvider(tb testing.TB) fakeProvider {
+	tb.Helper()
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		tb.Fatalf("generate test HKAC secret: %v", err)
+	}
+	return fakeProvider{keys: fakeKeys{secret: secret}}
+}
+
+// newFld builds a Field for tests. The provider is fresh per call so two
+// modules share a key only when the caller explicitly hands them the
+// same provider.
+func newFld(tb testing.TB, context string) *Field {
+	tb.Helper()
+	mod, err := New(newFakeProvider(tb), Config{Context: context})
+	if err != nil {
+		tb.Fatalf("field.New: %v", err)
+	}
+	return mod
+}
+
+// ---- Name / module wiring ---------------------------------------------------
+
+func TestName(t *testing.T) {
+	if got := newFld(t, "email").Name(); got != "field" {
+		t.Errorf("Name() = %q, want field", got)
+	}
+}
+
+func TestNew_SatisfiesModule(t *testing.T) {
+	var m authcore.Module = newFld(t, "email")
+	if m.Name() != "field" {
+		t.Errorf("module Name() = %q, want field", m.Name())
+	}
+}
+
+// ---- Round trip -------------------------------------------------------------
+
+// TestRoundTrip_HappyPath is the basic Encrypt/Decrypt cycle on a normal
+// string. Removing Decrypt or Encrypt makes the test fail.
+func TestRoundTrip_HappyPath(t *testing.T) {
+	f := newFld(t, "email")
+	ct, err := f.Encrypt("alice@example.com")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	pt, err := f.Decrypt(ct)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if pt != "alice@example.com" {
+		t.Errorf("round trip = %q, want alice@example.com", pt)
+	}
+}
+
+// TestRoundTrip_EmptyString covers the empty plaintext. Empty is a
+// legitimate value (an optional field that the user did not fill) and
+// must round trip like any other value.
+func TestRoundTrip_EmptyString(t *testing.T) {
+	f := newFld(t, "email")
+	ct, err := f.Encrypt("")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	pt, err := f.Decrypt(ct)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if pt != "" {
+		t.Errorf("empty round trip = %q, want empty", pt)
+	}
+}
+
+// TestRoundTrip_LongString covers a plaintext longer than the GCM
+// internals step on. A long string is a stress test of the nonce,
+// AAD, and seal buffers and must round trip cleanly.
+func TestRoundTrip_LongString(t *testing.T) {
+	f := newFld(t, "email")
+	plain := strings.Repeat("a long plaintext ", 1000) // ~18 KB
+	ct, err := f.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	pt, err := f.Decrypt(ct)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if pt != plain {
+		t.Error("long round trip mismatch")
+	}
+}
+
+// TestRoundTrip_InvalidUTF8 covers a plaintext that is not valid UTF-8.
+// Decrypt hands the bytes back to the caller as-is, so an arbitrary
+// byte sequence must survive the round trip untouched.
+func TestRoundTrip_InvalidUTF8(t *testing.T) {
+	f := newFld(t, "email")
+	plain := string([]byte{0x00, 0xC3, 0x28, 0xFE, 0xFF, 0x80, 0x81, 0x82, 0xA0, 0xA1})
+	ct, err := f.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	pt, err := f.Decrypt(ct)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if pt != plain {
+		t.Errorf("invalid-UTF8 round trip = %q, want %q", pt, plain)
+	}
+}
+
+// ---- Nonce uniqueness -------------------------------------------------------
+
+// TestEncrypt_DifferentCiphertextsForSamePlaintext is the nonce test.
+// If Encrypt ever derives the nonce from the plaintext, the two
+// ciphertexts will match; here they must not. Both must also still
+// decrypt back to the same plaintext.
+func TestEncrypt_DifferentCiphertextsForSamePlaintext(t *testing.T) {
+	f := newFld(t, "email")
+	const plain = "alice@example.com"
+
+	ct1, err := f.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt #1: %v", err)
+	}
+	ct2, err := f.Encrypt(plain)
+	if err != nil {
+		t.Fatalf("Encrypt #2: %v", err)
+	}
+	if ct1 == ct2 {
+		t.Fatal("two Encrypt calls of the same plaintext returned the same ciphertext; nonce is being derived or reused")
+	}
+
+	pt1, err := f.Decrypt(ct1)
+	if err != nil {
+		t.Fatalf("Decrypt #1: %v", err)
+	}
+	pt2, err := f.Decrypt(ct2)
+	if err != nil {
+		t.Fatalf("Decrypt #2: %v", err)
+	}
+	if pt1 != plain || pt2 != plain {
+		t.Errorf("round trip mismatch: %q / %q, want %q", pt1, pt2, plain)
+	}
+}
+
+// ---- Decrypt failure modes --------------------------------------------------
+
+// TestDecrypt_TamperedNonce flips one byte in the nonce region (the
+// first 12 bytes of the decoded ciphertext) and asserts the result
+// is ErrDecrypt, not a panic. This is the half of the bit-flip test
+// that hits the nonce.
+func TestDecrypt_TamperedNonce(t *testing.T) {
+	f := newFld(t, "email")
+	ct, err := f.Encrypt("alice@example.com")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	raw, err := base64.RawStdEncoding.DecodeString(ct)
+	if err != nil {
+		t.Fatalf("decode ciphertext: %v", err)
+	}
+	// Flip one bit in byte 0 (well inside the 12-byte nonce).
+	raw[0] ^= 0x01
+	tampered := base64.RawStdEncoding.EncodeToString(raw)
+
+	if _, err := f.Decrypt(tampered); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("Decrypt with tampered nonce: got %v, want ErrDecrypt", err)
+	}
+}
+
+// TestDecrypt_TamperedSealed flips one byte in the sealed region
+// (past the 12-byte nonce) and asserts ErrDecrypt. AAD binding would
+// also be caught here if the byte happened to be in the tag; this
+// is the half of the bit-flip test that hits the sealed payload.
+func TestDecrypt_TamperedSealed(t *testing.T) {
+	f := newFld(t, "email")
+	ct, err := f.Encrypt("alice@example.com")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	raw, err := base64.RawStdEncoding.DecodeString(ct)
+	if err != nil {
+		t.Fatalf("decode ciphertext: %v", err)
+	}
+	// Flip one byte past the nonce, well into the sealed payload.
+	raw[nonceLen+2] ^= 0xFF
+	tampered := base64.RawStdEncoding.EncodeToString(raw)
+
+	if _, err := f.Decrypt(tampered); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("Decrypt with tampered sealed: got %v, want ErrDecrypt", err)
+	}
+}
+
+// TestDecrypt_TruncatedBelowNonce covers input shorter than the
+// 12-byte nonce. The brief is explicit: this must return ErrDecrypt
+// and must not panic or index out of range. The function checks
+// length before slicing.
+func TestDecrypt_TruncatedBelowNonce(t *testing.T) {
+	f := newFld(t, "email")
+	// 5 bytes, base64-encoded to a 7-character string.
+	short := base64.RawStdEncoding.EncodeToString([]byte{1, 2, 3, 4, 5})
+	if _, err := f.Decrypt(short); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("Decrypt(short): got %v, want ErrDecrypt", err)
+	}
+}
+
+// TestDecrypt_EmptyString covers the empty string. It is not valid
+// base64 for any non-empty payload and must return ErrDecrypt.
+func TestDecrypt_EmptyString(t *testing.T) {
+	f := newFld(t, "email")
+	if _, err := f.Decrypt(""); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("Decrypt(\"\"): got %v, want ErrDecrypt", err)
+	}
+}
+
+// TestDecrypt_InvalidBase64 covers input that is not valid base64.
+// The brief requires ErrDecrypt, not a panic. The base64 decoder
+// itself does not panic on bad input; this pins that.
+func TestDecrypt_InvalidBase64(t *testing.T) {
+	f := newFld(t, "email")
+	// RawStdEncoding rejects '='; a long-enough string of invalid
+	// bytes is enough to trigger the decoder error path.
+	bad := "!!!!notbase64!!!!"
+	if _, err := f.Decrypt(bad); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("Decrypt(invalid base64): got %v, want ErrDecrypt", err)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ breaks?
 | `username` | `MinLength`, `MaxLength`, `ExtraReservedNames`, `AllowReservedNames` | Character set `[a-z0-9_-]` · lowercase + trim normalisation · "must start and end with a letter or digit" rule · "no consecutive specials" rule |
 | `totp` | Clock-skew window: `SkewSteps` (`*int`, 0 to 10, default 1, set with `totp.Int`) · `RecoveryCodeCount` (1 to 50, default 10) · `Issuer` (label shown in the authenticator) | HMAC-SHA1 algorithm · 30-second time step · 6-digit codes · 20-byte secrets · constant-time compare · full-window scan before any return |
 | `credential` | `TTL` (token lifetime, positive to 24h, default 1h) | 256-bit CSPRNG token · base64-URL no-padding encoding · HMAC-SHA256 hash with the library pepper · `purpose \|\| 0x00 \|\| subject \|\| 0x00 \|\| token` binding · constant-time compare run before the expiry check so wall-clock time does not reveal whether a token existed |
+| `field` | `Context` (column name the module is protecting, required, no zero-value default) | AES-256-GCM with 12-byte random nonce per call · HKDF-SHA256 derivation of encryption and index keys from the library refresh secret with distinct `authcore/field/aes-256-gcm/v1` and `authcore/field/blind-index/v1` info labels · length-prefixed `Context` bound into both the GCM AAD and the blind index input · HMAC-SHA256 hex blind index · base64-RawStdEncoding of `nonce \|\| sealed` |
 
 A field listed under "closed" cannot be configured: trying to do so would
 either be rejected at compile time or be a deliberate error in the code.

--- a/docs/field.md
+++ b/docs/field.md
@@ -1,0 +1,224 @@
+# Field-level encryption with a blind index
+
+`auth/field` encrypts a single column's value and produces a separate
+"blind index" that lets the database enforce uniqueness on the
+encrypted value without ever seeing the plaintext. The case that
+drives it: store a user's email address encrypted, and still enforce
+one account per address.
+
+The module does three things: it makes the ciphertext unreadable
+(AES-256-GCM with a fresh nonce per call), it makes a stolen
+ciphertext from one column useless against another (the column name
+is bound into the GCM additional authenticated data), and it gives
+the caller a deterministic hash of the plaintext under the same
+binding so a `UNIQUE` index on the index column enforces one
+account per email. The library never stores anything; you own the
+database. See the [error reference](errors.md).
+
+## Setup
+
+```go
+auth, err := authcore.New(authcore.DefaultConfig())
+fld, err := field.New(auth, field.Config{Context: "email"})
+// One module per column. Context is the column name; it is bound
+// into the AAD and the index so a ciphertext from "email" cannot
+// be decrypted as "phone".
+fldPhone, err := field.New(auth, field.Config{Context: "phone"})
+```
+
+`Context` has no default. An empty value is rejected at `New` with
+`field.ErrInvalidConfig`, because silently accepting `""` would
+make every field share one keyspace and the whole point of the
+binding would vanish.
+
+## Encrypted email with uniqueness, end to end
+
+```sql
+-- The table shape. ciphertext stores the encrypted email; idx
+-- stores the blind index. The UNIQUE index on idx is what gives
+-- "one account per address" without the database ever seeing the
+-- plaintext.
+CREATE TABLE users (
+    id    BIGSERIAL PRIMARY KEY,
+    email_ct TEXT NOT NULL,    -- field.Encrypt(plaintext)
+    email_idx TEXT NOT NULL    -- field.BlindIndex(plaintext)
+);
+CREATE UNIQUE INDEX users_email_idx_uniq ON users (email_idx);
+```
+
+```go
+// 1. Normalise the input. The module never normalises; index the
+//    same form you store, every time, or lookups miss. auth/email
+//    and auth/username both do this.
+plain := strings.ToLower(strings.TrimSpace(userInput))
+
+// 2. Encrypt the plaintext for storage. The output drops into a
+//    TEXT column as is; a BYTEA-style column can store the raw
+//    bytes via base64.RawStdEncoding.DecodeString.
+ct, err := fldEmail.Encrypt(plain)
+if err != nil { return serverError() }
+
+// 3. Produce the blind index the UNIQUE constraint runs against.
+idx := fldEmail.BlindIndex(plain)
+
+// 4. Insert. ON CONFLICT (email_idx) DO NOTHING enforces uniqueness
+//    at the database; the application learns whether the row was
+//    taken via RowsAffected.
+res, err := db.Exec(`
+    INSERT INTO users (email_ct, email_idx) VALUES ($1, $2)
+    ON CONFLICT (email_idx) DO NOTHING`,
+    ct, idx)
+if err != nil { return serverError() }
+n, _ := res.RowsAffected()
+if n == 0 { return conflictError() } // generic: "could not create account"
+
+// 5. Login path: hash the candidate, look up the row, then decrypt.
+//    A hit in the blind index proves the ciphertext came from a row
+//    that shared the same plaintext; a miss proves it didn't.
+candidate := fldEmail.BlindIndex(strings.ToLower(strings.TrimSpace(form.Email)))
+row := db.QueryRow(`SELECT email_ct FROM users WHERE email_idx = $1`, candidate)
+var stored string
+if err := row.Scan(&stored); err != nil { return notFound() }
+plain, err := fldEmail.Decrypt(stored)
+if err != nil { return serverError() }
+```
+
+The `ON CONFLICT (email_idx) DO NOTHING` pattern is the whole
+point: the database sees only the index, which it can compare for
+equality, and the ciphertext, which it cannot. The application
+never asks "is this email already in use?" with a plaintext query,
+which would defeat the encryption.
+
+## What you must do on top
+
+The module does three things well: it makes the ciphertext
+unreadable (AES-256-GCM with a fresh 12-byte nonce per call), it
+makes a stolen ciphertext from one column useless against another
+(the column name is bound into the GCM AAD), and it gives the
+caller a deterministic hash so a `UNIQUE` index on the index
+column enforces uniqueness. Four things the module deliberately
+does NOT do, because they belong to the application and
+forgetting any one of them ships a broken field:
+
+1. **Normalisation is the caller's.** `BlindIndex` hashes the
+   bytes it is handed. Lowercase, trim, Unicode fold, strip
+   `+tags` from addresses, whatever the application's
+   "same address" rule is, do it once, in one place, and
+   `BlindIndex` the same form every time. `auth/email` and
+   `auth/username` both do this. A module that normalised
+   silently would make `BlindIndex` disagree with whatever
+   the caller stored, and lookups would miss. The cost of
+   getting this wrong is not "the user sees an error"; it is
+   "the user creates a second account under a different
+   capitalisation", which is the exact failure the column was meant
+   to prevent.
+
+2. **The blind index leaks equality, on purpose.** Anyone with
+   read access to the database can see which rows share an
+   index, and can confirm a guess if they can compute the
+   index, which needs the derived key. The index buys
+   searchability and costs exactly that. Do NOT index a
+   low-entropy field where confirming a guess is the whole
+   attack: a four-digit SMS code, a yes/no flag, a country
+   code. For an email address, the search space is large
+   enough that equality is the right tradeoff. For a PIN, it
+   is not.
+
+3. **Losing the key loses the data.** There is no recovery
+   path. The library-managed refresh secret (the input to the
+   HKDF derivation) is the only thing that can produce the
+   AES key; lose it, and every row is unreadable. Back up the
+   key material the same way you back up the database. See
+   [key management](key-management.md) for sourcing it from
+   a secret manager.
+
+4. **Rotating the key requires re-encrypting every row.**
+   The library does not do it for you, because doing so
+   without a window where the row is decryptable by either
+   the old key or the new one would either require keeping
+   both around or making the migration the caller's problem
+   in a different shape. The shape is: read with the old
+   module, write with the new one, in batches, in a single
+   transaction per row so a partial run leaves no row in
+   a state neither key can read.
+
+   ```go
+   // Migration sketch. Run in batches of 1000 rows; every
+   // row is in a transaction so a crash mid-batch leaves
+   // the rest of the table consistent.
+   for {
+       rows, _ := db.Query(`SELECT id, email_ct FROM users
+                             WHERE email_migrated_at IS NULL
+                             LIMIT 1000`)
+       if !rows.Next() { break }
+       // ... open tx, read with old module, write with new,
+       // set email_migrated_at, commit ...
+   }
+   ```
+
+## Ciphertext shape
+
+- 12 random bytes (96 bits) of nonce from `crypto/rand`, drawn
+  fresh on every `Encrypt`
+- AES-256-GCM over the plaintext, with the bound `Context`
+  (length-prefixed with a big-endian uint32) as the additional
+  authenticated data
+- Output: `base64.RawStdEncoding.EncodeToString(nonce || sealed)`,
+  so it drops into a TEXT column as-is. A `BYTEA`-style column
+  can store the raw bytes via
+  `base64.RawStdEncoding.DecodeString(ciphertext)` instead.
+- The blind index is `hex(HMAC-SHA256(idxKey, len(context)||context
+  || len(value)||value))`, each length a big-endian uint32, so
+  `("a", "bc")` and `("ab", "c")` cannot collide. A separator
+  byte would only disambiguate while no field contained it, and
+  a Go string can contain any byte.
+
+The encryption key and the index key are both derived from
+`Keys().RefreshSecret()` with HKDF-SHA256 and distinct info
+labels (`authcore/field/aes-256-gcm/v1` and
+`authcore/field/blind-index/v1`). The version suffix in the
+info string is deliberate: if the derivation ever has to
+change, the old label stays available so existing rows remain
+decryptable.
+
+## Footguns the caller must handle
+
+Beyond the four above, two smaller traps:
+
+- **Use one module per column.** The same `fld` instance
+  protects one column, named in its `Context`. Two columns
+  need two `field.New` calls with two different `Context`
+  strings. A single module shared across columns would not
+  bind to a column, and the whole point of the AAD would
+  vanish.
+- **Treat `ErrDecrypt` as a server error, not a 404.** A
+  stored ciphertext that does not decrypt is corrupt, was
+  never written by this module, or was written under a
+  different `Context`. None of those is "the user does
+  not exist", and surfacing it as one would let an
+  attacker probe the database by writing rows they know
+  will fail to decrypt. Return a generic 500 and log
+  the offending row id.
+
+## What is fixed and why
+
+The cryptographic layer is **closed**: AES-256-GCM, a
+12-byte random nonce per `Encrypt` from `crypto/rand`, the
+HKDF-SHA256 derivation of the encryption and index keys
+from the library-managed refresh secret, the HMAC-SHA256
+construction of the blind index, the length-prefixed
+binding of the `Context` into both the AES additional
+authenticated data and the index, and the base64
+encoding of the ciphertext are all fixed. Weaken any of
+these and a stolen ciphertext, or a guessed value, can
+recover data the column is meant to protect.
+
+The policy layer is **open with one required field**:
+`Context`, the name of the database column the module
+is protecting. `Context` is not decoration: it is the
+whole point of the AAD binding. A caller who does not
+name the field is telling the module nothing, and
+silently accepting `""` would make every field share
+one keyspace, so `validateConfig` refuses the empty
+string at `New`. See [configuration](configuration.md)
+for the principle.


### PR DESCRIPTION
Closes item 2 of #325. **That was the last one open, so #325 closes with this.**

AES-256-GCM for a single database column, plus an HMAC-SHA256 blind index so the value stays searchable by exact equality without being readable. The case that drives it: store a user's email encrypted and still enforce one account per address.

| Closed | Open |
|---|---|
| AES-256-GCM, 12 byte random nonce per call | `Context`, and it is required |
| HMAC-SHA256 for the blind index | |
| HKDF derivation of both keys | |
| Length-prefixed AAD and index input | |

## Keys are derived, never reused

`Keys().RefreshSecret()` is already the pepper for refresh hashes, api keys, totp recovery codes and credential tokens. Using it directly as an AES key too would put one secret in five jobs, where a weakness in any construction reaches the others.

Both keys come from `crypto/hkdf` (standard library on the pinned toolchain, confirmed before writing the design) under versioned labels, so a future change to the derivation can leave the old label available to decrypt existing rows. Measured on one provider:

```
master secret   eb9a04e93baae0007654afee...
encKey derived  5d334988a119c29c63094ff2...
idxKey derived  7015d342c627348db08ce789...
```

## Context binds a value to its column

`Config.Context` names the field being protected and goes into both the GCM additional authenticated data and the blind index, length-prefixed. A ciphertext lifted from the `email` column will not decrypt as `phone`, and an index for one field never matches another. An empty `Context` is refused: silently accepting `""` would put every field in one keyspace.

Length prefixing rather than a separator byte, for the reason `auth/credential` documents: a separator disambiguates only while no field can contain it, and a Go string can contain any byte.

## The test that no behaviour can see

Nothing in a round trip notices whether the keys were derived. Remove `deriveKey`, use the master secret for both the AEAD and the index, and **every existing test still passes**: encryption still round trips, indexes still match. That is the shape of #229, where seventeen controls could be deleted with the suite staying green.

So `TestDeriveKey_SeparatesTheTwoKeysFromEachOtherAndFromTheMaster` asserts the keys directly: both 32 bytes, neither equal to the master, not equal to each other, and deterministic across calls, because a non-deterministic derivation would lose every stored row on restart. Sabotaged by making `deriveKey` return the master secret, and it is the only test that goes red.

## Sabotages

| Sabotage | Reddens |
|---|---|
| AAD dropped | both cross-context tests |
| nonce derived from the plaintext | the ciphertext-uniqueness test |
| length prefix removed from the index | both collision tests |
| `deriveKey` returns the master secret | the separation test, and only that one |

Three earlier attempts were **inert** because my patterns did not match the code, and a first go at the nonce one broke the build on an unused import. Diffing the file before reading the result caught all four. An inert sabotage reads exactly like a test that works, and a sabotage that does not compile proves nothing.

## Wire format

`base64(nonce || sealed)`. Measured 28 bytes of overhead on a 17 byte plaintext, which is 12 of nonce plus 16 of GCM tag.

## Four things `docs/field.md` states outright

1. **The blind index leaks equality, on purpose.** Anyone with the database sees which rows share a value. Do not index a low-entropy field where confirming a guess is the whole attack.
2. **Normalisation is the caller's.** The module does not lowercase or trim: `auth/email` and `auth/username` already do, and a module that normalised silently would disagree with whatever the caller stored.
3. **Losing the key loses the data.** No recovery path.
4. **Rotating the key means re-encrypting every row**, and the library does not do it for you. The migration shape is written out.

## Verification

`go build`, `go vet`, `gofmt -l` clean, `go test -race ./...` 12 of 12 packages, coverage 90.5 for this package against a floor of 90. Both fuzz targets clean.
