### PR TITLE
fix(keymanager): redact key material from every fmt verb

### DIFF
--- a/internal/keymanager/redact.go
+++ b/internal/keymanager/redact.go
@@ -1,0 +1,73 @@
+package keymanager
+
+import (
+	"fmt"
+	"io"
+)
+
+// redacted is the placeholder printed in place of any secret field.
+const redacted = "REDACTED"
+
+// Compile-time proof that *KeyManager controls its own formatting. Without
+// these, fmt reflects over the struct and prints every field, unexported
+// ones included.
+var (
+	_ fmt.Formatter  = (*KeyManager)(nil)
+	_ fmt.Stringer   = (*KeyManager)(nil)
+	_ fmt.GoStringer = (*KeyManager)(nil)
+)
+
+// Format renders the key manager without any secret material.
+//
+// Unexported fields stop a caller reaching the private key and the refresh
+// secret through the type. They do not stop fmt, which reflects past
+// exportedness: before this method existed, %v and %+v printed both secrets
+// as decimal byte slices and %#v printed them in hex. A single diagnostic
+// line such as log.Printf("%+v", ac.Keys()) put the Ed25519 signing key into
+// log storage, and possession of that key is token forgery.
+//
+// fmt.Formatter takes precedence over every other formatting interface and
+// applies to every verb, which is why the redaction lives here rather than in
+// String alone: a String method would have left %#v leaking in hex. Verbs
+// that make no sense for this type render as a Go %!verb error rather than
+// falling back to reflection, because that fallback is the leak.
+func (km *KeyManager) Format(f fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if f.Flag('#') {
+			_, _ = io.WriteString(f, km.GoString())
+			return
+		}
+		_, _ = io.WriteString(f, km.String())
+	case 's', 'q':
+		if verb == 'q' {
+			_, _ = fmt.Fprintf(f, "%q", km.String())
+			return
+		}
+		_, _ = io.WriteString(f, km.String())
+	default:
+		_, _ = fmt.Fprintf(f, "%%!%c(keymanager.KeyManager)", verb)
+	}
+}
+
+// String describes the key manager by the two things that are safe to print:
+// where its material lives and which signing key is active.
+func (km *KeyManager) String() string {
+	if km == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("keymanager.KeyManager{dir:%q, keyID:%q, privateKey:%s, publicKey:%s, refreshSecret:%s}",
+		km.dir, km.keyID, redacted, redacted, redacted)
+}
+
+// GoString covers the %#v verb, which is a separate rendering path in fmt and
+// prints byte slices in hex rather than decimal. A redaction test that looks
+// for the secret in one encoding passes over it in the other, so both paths
+// are redacted here and both are asserted in the tests.
+func (km *KeyManager) GoString() string {
+	if km == nil {
+		return "(*keymanager.KeyManager)(nil)"
+	}
+	return fmt.Sprintf("&keymanager.KeyManager{dir:%q, keyID:%q, privateKey:%s, publicKey:%s, refreshSecret:%s}",
+		km.dir, km.keyID, redacted, redacted, redacted)
+}

--- a/internal/keymanager/redact_test.go
+++ b/internal/keymanager/redact_test.go
@@ -1,0 +1,111 @@
+package keymanager
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// sentinelKeys builds key material whose bytes are recognisable, so a test can
+// assert the material is absent from a rendering without ever printing a real
+// key. The values are not valid Ed25519 material and are never used to sign.
+func sentinelKeys() *KeyManager {
+	priv := make(ed25519.PrivateKey, ed25519.PrivateKeySize)
+	pub := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	secret := make([]byte, 32)
+	for i := range priv {
+		priv[i] = 0xA7
+	}
+	for i := range pub {
+		pub[i] = 0xB3
+	}
+	for i := range secret {
+		secret[i] = 0xC5
+	}
+	return &KeyManager{
+		dir:           "/tmp/keys",
+		privateKey:    priv,
+		publicKey:     pub,
+		refreshSecret: secret,
+		keyID:         "sentinel",
+	}
+}
+
+// TestFormattingRedactsEveryEncoding is the regression for the leak where
+// %v and %+v printed the private key and the refresh secret as decimal byte
+// slices while %#v printed them in hex.
+//
+// The encodings are the point of this test. A marker written for one of them
+// walks straight past the same secret in the other, so both are asserted for
+// every verb.
+func TestFormattingRedactsEveryEncoding(t *testing.T) {
+	km := sentinelKeys()
+
+	// The same sentinel byte in the two encodings fmt uses for a byte slice.
+	markers := map[string]string{
+		"private key, decimal":    "167 167 167 167",
+		"private key, hex":        "0xa7, 0xa7, 0xa7, 0xa7",
+		"refresh secret, decimal": "197 197 197 197",
+		"refresh secret, hex":     "0xc5, 0xc5, 0xc5, 0xc5",
+		"public key, decimal":     "179 179 179 179",
+		"public key, hex":         "0xb3, 0xb3, 0xb3, 0xb3",
+	}
+
+	for _, verb := range []string{"%v", "%+v", "%#v", "%s", "%q", "%d"} {
+		out := fmt.Sprintf(verb, km)
+		for name, marker := range markers {
+			if strings.Contains(out, marker) {
+				t.Errorf("%s leaked the %s", verb, name)
+			}
+		}
+	}
+}
+
+// TestFormattingRedactsThroughAWrapper covers the case that actually happens:
+// nobody formats the key manager on purpose, they format a struct that holds
+// it, or a slice of interfaces containing it.
+func TestFormattingRedactsThroughAWrapper(t *testing.T) {
+	km := sentinelKeys()
+	wrapper := struct {
+		Name string
+		Keys *KeyManager
+	}{Name: "startup", Keys: km}
+
+	for _, verb := range []string{"%v", "%+v", "%#v"} {
+		out := fmt.Sprintf(verb, wrapper)
+		if strings.Contains(out, "167 167 167") || strings.Contains(out, "0xa7, 0xa7") {
+			t.Errorf("%s of a wrapping struct leaked the private key", verb)
+		}
+	}
+}
+
+// TestFormattingStillIdentifiesTheManager guards the other direction: a
+// redaction that prints nothing useful gets replaced by whoever next needs to
+// debug a startup, and the leak comes back with it.
+func TestFormattingStillIdentifiesTheManager(t *testing.T) {
+	km := sentinelKeys()
+	for _, verb := range []string{"%v", "%+v", "%#v", "%s"} {
+		out := fmt.Sprintf(verb, km)
+		if !strings.Contains(out, "/tmp/keys") {
+			t.Errorf("%s does not name the key directory: %s", verb, out)
+		}
+		if !strings.Contains(out, "sentinel") {
+			t.Errorf("%s does not name the key id: %s", verb, out)
+		}
+		if !strings.Contains(out, redacted) {
+			t.Errorf("%s does not say the secrets were redacted: %s", verb, out)
+		}
+	}
+}
+
+// TestFormattingANilManagerDoesNotPanic covers the diagnostic path taken when
+// initialisation failed, which is exactly when someone reaches for a print.
+func TestFormattingANilManagerDoesNotPanic(t *testing.T) {
+	var km *KeyManager
+	for _, verb := range []string{"%v", "%+v", "%#v", "%s"} {
+		if out := fmt.Sprintf(verb, km); out == "" {
+			t.Errorf("%s of a nil manager rendered nothing", verb)
+		}
+	}
+}


### PR DESCRIPTION
Formatting the value returned by `Keys()` printed the Ed25519 private key and the refresh secret. The fields are unexported, which stops a caller reaching them through the type and does nothing about `fmt`, which reflects past exportedness.

Measured on develop at 6396536, before the fix:

| verb | private key | refresh secret |
|---|---|---|
| `%v` | leaked, decimal | leaked, decimal |
| `%+v` | leaked, decimal | leaked, decimal |
| `%#v` | leaked, hex | leaked, hex |

`%s` was clean only because it produced a `%!s(...)` error string, so it was never a control.

`*KeyManager` now implements `fmt.Formatter`. That interface takes precedence over every other formatting path and applies to every verb, which is why the redaction lives there rather than in `String` alone: a `String` method would have left `%#v` leaking, because Go-syntax formatting renders byte slices in hex through a different path. Verbs that do not apply to this type render as a Go `%!verb` error rather than falling back to reflection, since that fallback is the leak.

The rendering still names the key directory and the key id, so the diagnostic that made somebody reach for the print in the first place still answers. A redaction that prints nothing useful gets deleted by the next person debugging a startup, and the leak comes back with it.

On the tests, two things worth stating rather than assuming.

The assertions cover both encodings for every verb. That is not thoroughness for its own sake: while measuring the original defect, a probe that searched for the secret as decimal bytes reported `%#v` clean, because it prints `0xa7` where `%v` prints `167`. One marker only ever catches one encoding.

I checked they fail when the control is removed. Making `Format` fall back to printing the fields turns four of them red naming the leaked secret, and I confirmed the edit changed the file and still compiled before reading the red, so the failure is about the redaction rather than about a broken build.

Closes #341