### PR TITLE
docs: say what the refresh secret protects, and stop disowning shipped modules

### DIFF
--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -6,7 +6,7 @@ On first run authcore creates `KeysDir` (default `.authcore`) and generates:
 |---|---|---|---|
 | `ed25519_private.pem` | PKCS#8 PEM | `0600` | Signing key |
 | `ed25519_public.pem` | PKIX PEM | `0644` | Verification key |
-| `refresh_secret.key` | 32-byte hex | `0600` | HMAC-SHA256 key for refresh token hashing |
+| `refresh_secret.key` | 32-byte hex | `0600` | HMAC-SHA256 key for refresh token hashing, **and** the HKDF root for every `auth/field` column key. See below. |
 | `metadata.json` | JSON | `0600` | Records which on-disk layout wrote the directory |
 | `.gitignore` | `*` | `0600` | Prevents accidental commits |
 
@@ -131,6 +131,32 @@ yourself: `Load() (authcore.Keys, error)`.
 The `KeyID()` accessor returns a 16-character hex digest derived from the public
 key. It is embedded in every token's `kid` JOSE header. Verification selects the
 key by `kid` and rejects any token whose `kid` is not one the module accepts.
+
+## The refresh secret carries two jobs, and only one of them is recoverable
+
+`refresh_secret.key` is the HMAC-SHA256 key for refresh token hashing. Since
+`auth/field` shipped it is also the input `auth/field` runs HKDF-SHA256 over to
+derive the AES-256-GCM column key and the blind index key, with a distinct info
+label for each.
+
+That is cryptographic separation, not operational separation, and the
+difference is the whole of this section. The two jobs fail very differently:
+
+- **Lose it as a token hashing key** and every refresh token stops verifying.
+  Users log in again. Annoying, recoverable, over in a day.
+- **Lose it as the `auth/field` root** and every encrypted column is
+  permanently unreadable. There is no recovery path, because there is no copy
+  of the key anywhere else by design.
+
+So back this file up the way you back up the database, not the way you back up
+a session store. And if you use `auth/field`, **do not rotate this file in
+place.** Rotating it is a table migration: read every row with a module built
+on the old secret, write it back with one built on the new secret, in batches,
+one transaction per row. The procedure is written out in
+[field encryption](field.md#footguns-the-caller-must-handle).
+
+If you do not use `auth/field`, rotating it is exactly as cheap as it sounds:
+replace the file, everyone logs in again.
 
 ## Rotating the signing key (zero downtime)
 

--- a/docs/secure-login.md
+++ b/docs/secure-login.md
@@ -172,10 +172,24 @@ authcore does no rate limiting. Add it:
   temporary ban), and surface it without revealing whether the account exists.
 - Apply the same to **password reset** and **MFA** endpoints.
 
-## 8. Out of scope (you provide or skip)
+## 8. What authcore covers here, and what it does not
 
-- **MFA / TOTP**, account lockout policy, password-reset flows, email
-  verification — build on top; authcore does not include them.
+Three of the things this section used to list as your job have shipped since it
+was written. Reach for them rather than hand rolling the flow:
+
+- **MFA / TOTP** is [`auth/totp`](totp.md): codes, drift window, and
+  single-use recovery codes.
+- **Password reset and email verification** are
+  [`auth/credential`](credential.md): single-use tokens, hashed at rest,
+  expiring.
+- **Encrypting an identifier while keeping it unique** is
+  [`auth/field`](field.md): AES-256-GCM plus a blind index a `UNIQUE`
+  constraint can run against.
+
+Still yours:
+
+- **Account lockout and rate limiting.** They need state authcore does not
+  hold, and the right policy is a property of your product.
 - **Breached-password rejection** is intentionally not part of authcore. The
   built-in policy is length + composition only.
 

--- a/docs_scope_test.go
+++ b/docs_scope_test.go
@@ -1,0 +1,164 @@
+package authcore_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scopeDenials are the phrases the docs use to tell a reader that something is
+// their job rather than the library's.
+var scopeDenials = []string{
+	"does not include",
+	"not part of authcore",
+	"authcore does not",
+	"you provide or skip",
+	"build on top",
+}
+
+// TestDocsDoNotDisownAShippedModule fails when a bullet in the documentation
+// denies that authcore covers something and names a module that ships.
+//
+// This existed as a real defect: section 8 of docs/secure-login.md listed
+// "MFA / TOTP" as out of scope for two releases after auth/totp shipped, so
+// the recipe page sent readers to hand roll a module sitting audited in the
+// same tree. A stale feature list is silent; a sentence like that makes a
+// positive claim that the module does not exist.
+//
+// Where this stops working, stated rather than discovered later: it matches
+// the directory name. The same bullet also disowned "password-reset flows and
+// email verification", which is auth/credential under a description rather
+// than a name, and no name match catches that. This test would have caught one
+// of the two instances. Do not read a green run as proof the docs describe the
+// current module set.
+func TestDocsDoNotDisownAShippedModule(t *testing.T) {
+	modules := shippedModules(t)
+
+	files, err := filepath.Glob("docs/*.md")
+	if err != nil {
+		t.Fatalf("globbing docs: %v", err)
+	}
+	files = append(files, "README.md")
+
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		for _, block := range bulletBlocks(string(raw)) {
+			lower := strings.ToLower(block.text)
+			if !containsAny(lower, scopeDenials) {
+				continue
+			}
+			for _, module := range modules {
+				if mentionsModule(lower, module) {
+					t.Errorf("%s:%d says authcore does not cover %q, but auth/%s ships:\n\t%s",
+						path, block.line, module, module, strings.ReplaceAll(block.text, "\n", "\n\t"))
+				}
+			}
+		}
+	}
+}
+
+// shippedModules lists the directory names under auth/.
+func shippedModules(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir("auth")
+	if err != nil {
+		t.Fatalf("reading auth/: %v", err)
+	}
+	var modules []string
+	for _, e := range entries {
+		if e.IsDir() {
+			modules = append(modules, strings.ToLower(e.Name()))
+		}
+	}
+	if len(modules) == 0 {
+		t.Fatal("found no modules under auth/, which means this test stopped measuring anything")
+	}
+	return modules
+}
+
+type bulletBlock struct {
+	line int
+	text string
+}
+
+// bulletBlocks groups each markdown bullet with its wrapped continuation
+// lines. The defect this test guards against had the module name on the first
+// line of a bullet and the denial on the second, so neither a line-by-line nor
+// a paragraph-wide scan sees it as one statement.
+func bulletBlocks(content string) []bulletBlock {
+	var blocks []bulletBlock
+	var current *bulletBlock
+
+	flush := func() {
+		if current != nil {
+			blocks = append(blocks, *current)
+			current = nil
+		}
+	}
+
+	for i, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		isBullet := strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ")
+		isContinuation := current != nil && line != trimmed && trimmed != ""
+
+		switch {
+		case isBullet:
+			flush()
+			current = &bulletBlock{line: i + 1, text: trimmed}
+		case isContinuation:
+			current.text += "\n" + trimmed
+		default:
+			flush()
+		}
+	}
+	flush()
+	return blocks
+}
+
+// mentionsModule reports whether text names the module as its own token.
+//
+// A plain substring match is too loose here and said so on its first run:
+// "Breached-password rejection is intentionally not part of authcore" is a
+// true statement about a feature auth/password deliberately lacks (#133,
+// #118), and a substring match read it as a denial that auth/password exists.
+// A hyphen or a letter on either side means the word is part of a compound,
+// not a reference to the module. A slash is a boundary rather than a word
+// byte, so a docs line naming auth/totp still matches.
+func mentionsModule(text, module string) bool {
+	for offset := 0; ; {
+		i := strings.Index(text[offset:], module)
+		if i < 0 {
+			return false
+		}
+		start := offset + i
+		end := start + len(module)
+		if !isWordByte(text, start-1) && !isWordByte(text, end) {
+			return true
+		}
+		offset = start + 1
+	}
+}
+
+// isWordByte reports whether the byte at i continues a word. Out of range
+// counts as a boundary.
+func isWordByte(text string, i int) bool {
+	if i < 0 || i >= len(text) {
+		return false
+	}
+	c := text[i]
+	return c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+func containsAny(haystack string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Two pages had drifted from the code in the same direction: both describe a smaller library than the one that ships.

**`docs/key-management.md`** called `refresh_secret.key` the "HMAC-SHA256 key for refresh token hashing" and stopped there. Since `auth/field` shipped, that file is also what `auth/field` runs HKDF-SHA256 over to derive the AES-256-GCM column key and the blind index key, so it is the root of every encrypted column in the consumer database. The page an operator reads before touching key material never said so. It carries a "Rotating the signing key (zero downtime)" section for the Ed25519 pair and had no counterpart for this file, and six lines above the table it tells the reader to delete key files to regenerate.

`docs/field.md` already had the warning and linked here. The warning existed in one direction only, and the missing direction is the one the operator is standing in when they do the destructive thing: rotating a token hashing secret has an understood worst case, everyone logs in again, and under the current wiring the same action is irreversible data loss.

**`docs/secure-login.md`** section 8 listed MFA / TOTP, password-reset flows and email verification as the reader own job. `auth/totp` and `auth/credential` cover all three. The recipe page whose closing line is "authcore removes the cryptographic mistakes" was sending people to hand roll exactly that.

## On the test

It guards the second class rather than the instance, and its limit is written into the test rather than left to be found later. It matches the directory name under `auth/`, so it would have caught "MFA / TOTP" and would not have caught "password-reset flows", which is `auth/credential` under a description. One of the two instances. A green run is not evidence the docs describe the current module set.

Its first run failed on a sentence that is true: "Breached-password rejection is intentionally not part of authcore" is correct and deliberate, per #133 and #118, and a plain substring match read it as a denial that `auth/password` exists. The matcher is token bounded now, with a hyphen counting as part of a word and a slash counting as a boundary so `auth/totp` still matches.

I checked it fails in the direction that matters by restoring the exact bullet that was on develop and watching it go red naming `auth/totp`.

This is a docs and test change, so by the release rule it is a change a consumer receives and should ride the next tag rather than being held.

Closes #345
Closes #346