### PR TITLE
ci(audit): run the security audit on pull requests, and bound the G505 exclusion

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,13 @@
 name: Security audit
 
 on:
+  # The schedule is what catches an advisory published after a merge. The
+  # pull_request trigger is what stops a merge outrunning the audit by a week:
+  # auth/totp landed and shipped in v1.13.0 hours before the Monday cron found
+  # its crypto/sha1 import, so the release was tagged before the audit had an
+  # opinion. Both triggers are needed; neither replaces the other.
+  pull_request:
+    branches: [main, develop]
   schedule:
     - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
   workflow_dispatch:
@@ -17,4 +24,10 @@ jobs:
       # G115 mirrors the .golangci.yml exclusion for UUID/time math.
       # G101 is a false positive on the OAuth provider preset URLs (a field named
       # *TokenURL* holding a public endpoint, not a credential).
-      gosec-exclude: "G104,G115,G306,G101"
+      # G505 is auth/totp importing crypto/sha1. RFC 6238 defines TOTP over
+      # HMAC-SHA1 and every authenticator app implements that, so anything else
+      # is a module nobody can pair with. SHA-1 collision attacks do not carry
+      # to HMAC. The import is annotated in code too, but standalone gosec
+      # ignores //nolint pragmas, which is why the exclusions above exist.
+      # sha1_import_test.go asserts no second package picks up this exclusion.
+      gosec-exclude: "G104,G115,G306,G101,G505"

--- a/sha1_import_test.go
+++ b/sha1_import_test.go
@@ -1,0 +1,84 @@
+package authcore_test
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// sha1AllowedIn is the set of packages permitted to import crypto/sha1.
+//
+// auth/totp is on it because RFC 6238 defines TOTP over HMAC-SHA1 and every
+// authenticator app implements that, so a module using anything else is one
+// nobody can pair with. SHA-1 collision attacks do not carry to HMAC.
+var sha1AllowedIn = map[string]string{
+	"auth/totp": "RFC 6238 TOTP is HMAC-SHA1; collision attacks do not apply to HMAC",
+}
+
+// TestSHA1IsImportedOnlyWhereItIsJustified keeps the G505 exclusion in
+// audit.yml from covering more than it was granted for.
+//
+// The exclusion exists because standalone gosec ignores the //nolint pragma on
+// the import in auth/totp, so the finding cannot be silenced at the call site
+// the way it is for the linter. Excluding the rule repository-wide is the only
+// mechanism available, and a repository-wide exclusion with nothing watching it
+// is a control that reads as present and permits everything. This is what
+// watches it: a second package reaching for crypto/sha1 fails here, on its own
+// pull request, and has to argue for itself in this map rather than inherit a
+// justification written about TOTP.
+func TestSHA1IsImportedOnlyWhereItIsJustified(t *testing.T) {
+	fset := token.NewFileSet()
+	seen := map[string]bool{}
+
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// examples/ are separate modules and are not covered by the audit
+			// workflow, which runs against this module.
+			if d.Name() == ".git" || d.Name() == "examples" || d.Name() == "testdata" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, imp := range file.Imports {
+			target, err := strconv.Unquote(imp.Path.Value)
+			if err != nil || target != "crypto/sha1" {
+				continue
+			}
+			pkg := filepath.ToSlash(filepath.Dir(path))
+			seen[pkg] = true
+			if _, ok := sha1AllowedIn[pkg]; !ok {
+				t.Errorf("%s imports crypto/sha1, which the G505 exclusion in "+
+					"audit.yml silences repository-wide. Justify it in "+
+					"sha1AllowedIn or use a different hash.", path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
+	}
+
+	// The other direction: an allowance that no longer describes the tree is an
+	// exclusion nobody is accountable for, so it should be removed along with
+	// the G505 entry in audit.yml.
+	for pkg := range sha1AllowedIn {
+		if !seen[pkg] {
+			t.Errorf("%s no longer imports crypto/sha1; drop it from sha1AllowedIn "+
+				"and drop G505 from gosec-exclude in audit.yml", pkg)
+		}
+	}
+}


### PR DESCRIPTION
`audit.yml` ran on `schedule` and `workflow_dispatch` only, so gosec and govulncheck never gated a pull request and the audit learned what had merged on the following Monday.

That stopped being theoretical this morning. `auth/totp` merged (#335), imports `crypto/sha1`, and shipped in **v1.13.0**. The first scheduled audit after it, at 11:51 UTC, went red on `auth/totp/totp.go:52` with `G505 (CWE-327)`. The tag was already cut.

Both triggers earn their place and neither replaces the other: `pull_request` stops a merge outrunning the audit by a week, and the schedule is what catches an advisory published after a merge.

## The SHA-1 stays

RFC 6238 defines TOTP over HMAC-SHA1 and every authenticator app implements that, so a module using anything else is one nobody can pair with, and SHA-1 collision attacks do not carry to HMAC. The import was already annotated in code. Standalone gosec ignores `//nolint` pragmas, which is exactly why G104, G306, G115 and G101 sit in `gosec-exclude` despite carrying the same annotations. G505 was never added when `auth/totp` landed.

## Bounding the exclusion

`gosec-exclude` is repository-wide, so silencing G505 for `auth/totp` silences it for everything, and an exclusion with nothing watching it is the shape this repository keeps finding: a control that reads as present and permits everything.

`sha1_import_test.go` bounds it. `crypto/sha1` is allowed in `auth/totp` and nowhere else, so a second package reaching for it fails on its own pull request and has to argue for itself rather than inherit a justification written about TOTP. It fails in the other direction too: an allowance that no longer describes the tree is flagged, so the exclusion gets removed along with the import instead of outliving it.

I checked it fails in the direction that matters: a blank `crypto/sha1` import added to `auth/jwt` turns it red naming the file, and the sabotage compiled, so the red is about the import rather than a broken build.

## What this does not fix

`audit freshness` has been failing on every pull request for a month, correctly, and it is not a required check on develop, where the required set is `dco`, `go / Lint & test` and `line-limit`. Before today the audit was red for three consecutive weeks on real govulncheck findings, GO-2026-6218, GO-2026-6090 and GO-2026-5972, all reachable from `oauth.Client.Exchange` and `keymanager.decodeEd25519PublicPEM`, now closed by the go 1.26.6 directive. A check that reports a real problem on every pull request and blocks nothing is one people learn to scroll past, and that is how three weeks of live standard library vulnerabilities stayed on the board.

Making it required is a ruleset change, so it is yours rather than mine. #354 carries it.

Closes #354