### PR TITLE
fix(keymanager): refuse to write key material through a symlink

### DIFF
--- a/internal/keymanager/fsguard.go
+++ b/internal/keymanager/fsguard.go
@@ -1,0 +1,112 @@
+package keymanager
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// This file holds the filesystem rules the key directory is written under.
+// There are two of them and they deliberately point in opposite directions.
+//
+// Writes refuse to follow a symlink. Nothing legitimate creates a managed key
+// file through a link, and following one hands an attacker who can write into
+// KeysDir before authcore first runs a choice of where the freshly generated
+// private key lands. That is not exotic for this library: a mounted container
+// volume, a provisioning script, a restored backup or a Compose file can all
+// populate the directory first.
+//
+// Reads keep following symlinks, and that is not an oversight. The documented
+// Kubernetes deployment mounts a Secret at KeysDir, and Kubernetes projects a
+// Secret volume as a tree of symlinks, so a loader that refused links would
+// break every replica following the deployment guide in docs/key-management.md.
+// Read-following is also the weaker exposure: the read path already caps the
+// file at 4 KiB and validates the key pair, and a caller who can redirect a
+// read can equally replace the file itself.
+
+// fileState is what a presence check can conclude about a managed filename.
+type fileState int
+
+const (
+	// fileAbsent means nothing exists at the path, not even a broken link.
+	fileAbsent fileState = iota
+	// filePresent means something exists that the loader can work with.
+	filePresent
+	// fileHostile means something exists that must not be written through.
+	fileHostile
+)
+
+// inspect classifies a managed filename inside dir.
+//
+// It uses Stat, which resolves a symlink and so reports a dangling one as
+// absent. That reads like the bug rather than the fix, and it was measured
+// rather than assumed: a dangling link classified as absent sends the caller
+// down the generate path and into createExclusive, which refuses it and says
+// so, naming the link and what to do about it. Classifying it as present here
+// instead makes the consistency check fire first, and that error tells the
+// operator to "delete all key files", which since auth/field shipped is the
+// advice that destroys every encrypted column. The worse message is not worth
+// a control that O_EXCL already provides.
+func inspect(dir, name string) (fileState, error) {
+	path := filepath.Join(dir, name)
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return fileAbsent, nil
+	}
+	if err != nil {
+		return fileHostile, fmt.Errorf("inspecting %q: %w", path, err)
+	}
+	switch {
+	case fi.Mode()&os.ModeSymlink != 0:
+		// A link is reportable rather than fatal here. It is refused at the
+		// write, and tolerated at the read, which is the Kubernetes case.
+		return filePresent, nil
+	case fi.Mode().IsRegular():
+		return filePresent, nil
+	default:
+		return fileHostile, fmt.Errorf(
+			"%q is a %s, not a regular file; authcore refuses to treat it as key material",
+			path, fi.Mode().Type())
+	}
+}
+
+// exists reports whether a managed filename has something at it, counting a
+// dangling symlink as something. A classification error is reported as present
+// so the caller fails closed rather than generating over an unreadable entry.
+func exists(dir, name string) bool {
+	state, err := inspect(dir, name)
+	return state != fileAbsent || err != nil
+}
+
+// createExclusive writes data to a file that must not already exist.
+//
+// O_CREATE|O_EXCL is the whole control, and it is the right one here because
+// it is portable. It fails with EEXIST when the path is a symlink, dangling
+// ones included, so the write cannot be redirected out of the key directory.
+// O_NOFOLLOW would state the property more loudly but lives in syscall rather
+// than os and is not defined on Windows, and this library ships to Windows
+// consumers, so the portable flag that already has the property is the one to
+// rely on.
+//
+// It also closes the narrower race the exclusion used to leave open: a regular
+// file appearing between the presence check and the write kept its own
+// permissions, so a 0644 file planted at that moment received the private key.
+// Creation now fails instead.
+func createExclusive(path string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf(
+				"refusing to write %q: something already exists there. If it is a "+
+					"symlink, authcore never writes key material through one: remove it "+
+					"and let authcore create the file, or point KeysDir at the real "+
+					"directory: %w", path, err)
+		}
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/internal/keymanager/fsguard_test.go
+++ b/internal/keymanager/fsguard_test.go
@@ -1,0 +1,134 @@
+package keymanager
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type silentLog struct{}
+
+func (silentLog) Info(string, ...any)  {}
+func (silentLog) Warn(string, ...any)  {}
+func (silentLog) Error(string, ...any) {}
+func (silentLog) Debug(string, ...any) {}
+
+// TestNewRefusesADanglingSymlink is the regression for the defect this file
+// exists for. A dangling link at a managed filename used to be classified as
+// absent by os.Stat, so every presence check agreed the directory was empty
+// and the freshly generated private key was written at the link target,
+// outside KeysDir entirely.
+func TestNewRefusesADanglingSymlink(t *testing.T) {
+	for _, name := range []string{filePrivateKey, filePublicKey, fileRefreshSecret} {
+		t.Run(name, func(t *testing.T) {
+			base := t.TempDir()
+			dir := filepath.Join(base, "keys")
+			outside := filepath.Join(base, "outside")
+			mustMkdir(t, dir, 0700)
+			mustMkdir(t, outside, 0755)
+
+			target := filepath.Join(outside, "captured")
+			if err := os.Symlink(target, filepath.Join(dir, name)); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := New(dir, silentLog{})
+			if err == nil {
+				t.Fatal("New succeeded through a dangling symlink")
+			}
+			// The message is part of the fix. An operator who reaches this
+			// must not be told to delete all key files, which is the advice
+			// that destroys every auth/field column.
+			if !strings.Contains(err.Error(), "symlink") {
+				t.Errorf("the error does not mention the symlink: %v", err)
+			}
+			if strings.Contains(err.Error(), "delete all key files") {
+				t.Errorf("the error gives the destructive advice: %v", err)
+			}
+			if _, statErr := os.Lstat(target); statErr == nil {
+				t.Errorf("something was written outside KeysDir at %s", target)
+			}
+		})
+	}
+}
+
+// TestNewRefusesANonRegularFile covers the other way a planted entry reaches
+// the write path.
+func TestNewRefusesANonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, filePrivateKey), 0700); err != nil {
+		t.Fatal(err)
+	}
+	_, err := New(dir, silentLog{})
+	if err == nil {
+		t.Fatal("New succeeded with a directory where the private key belongs")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+}
+
+// TestCreateExclusiveRefusesAnExistingFile covers the narrower race the old
+// code lost: a regular file appearing between the presence check and the
+// write kept its own permissions, so a world-readable file planted at that
+// moment received the private key.
+func TestCreateExclusiveRefusesAnExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, filePrivateKey)
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := createExclusive(path, []byte("secret"), 0600); err == nil {
+		t.Fatal("createExclusive overwrote an existing file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Errorf("the existing file was written to anyway: %q", data)
+	}
+}
+
+// TestSymlinkedKeysStillLoad is the counterweight, and it is the reason reads
+// were left following links.
+//
+// docs/key-management.md tells the operator to mount a Kubernetes Secret at
+// KeysDir, and Kubernetes projects a Secret volume as a tree of symlinks. A
+// loader that refused links would pass a security review and break every
+// replica following the deployment guide, so this test pins the case: an
+// existing key set reached through symlinks loads, and loads the same keys.
+func TestSymlinkedKeysStillLoad(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	mounted := filepath.Join(base, "mounted")
+	mustMkdir(t, real, 0700)
+	mustMkdir(t, mounted, 0700)
+
+	original, err := New(real, silentLog{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{filePrivateKey, filePublicKey, fileRefreshSecret, fileMetadata} {
+		if err := os.Symlink(filepath.Join(real, name), filepath.Join(mounted, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	viaLinks, err := New(mounted, silentLog{})
+	if err != nil {
+		t.Fatalf("a Kubernetes-style symlinked key set failed to load: %v", err)
+	}
+	if viaLinks.KeyID() != original.KeyID() {
+		t.Errorf("loaded a different key through the links: %s vs %s", viaLinks.KeyID(), original.KeyID())
+	}
+}
+
+func mustMkdir(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/keymanager/generate.go
+++ b/internal/keymanager/generate.go
@@ -62,10 +62,14 @@ func checkKeyDirConsistency(dir string) error {
 	files := []string{filePrivateKey, filePublicKey, fileRefreshSecret}
 	var present, missing []string
 	for _, name := range files {
-		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
-			present = append(present, name)
-		} else {
+		state, err := inspect(dir, name)
+		if err != nil {
+			return err
+		}
+		if state == fileAbsent {
 			missing = append(missing, name)
+		} else {
+			present = append(present, name)
 		}
 	}
 	if len(present) > 0 && len(missing) > 0 {
@@ -86,16 +90,16 @@ func loadOrGenerateEd25519(dir string, log logger) (ed25519.PrivateKey, ed25519.
 	privPath := filepath.Join(dir, filePrivateKey)
 	pubPath := filepath.Join(dir, filePublicKey)
 
-	_, privErr := os.Stat(privPath)
-	_, pubErr := os.Stat(pubPath)
+	privFound := exists(dir, filePrivateKey)
+	pubFound := exists(dir, filePublicKey)
 
 	switch {
-	case privErr == nil && pubErr == nil:
+	case privFound && pubFound:
 		// Both files exist — load and validate them.
 		log.Info("authcore/keymanager: loading existing Ed25519 key pair from %s", dir)
 		return loadEd25519(privPath, pubPath)
 
-	case privErr != nil && pubErr != nil:
+	case !privFound && !pubFound:
 		// Neither exists — generate a fresh pair.
 		log.Warn("authcore/keymanager: Ed25519 key pair not found, generating new keys in %s", dir)
 		return generateAndSaveEd25519(privPath, pubPath)
@@ -157,7 +161,7 @@ func writePrivateKey(path string, key ed25519.PrivateKey) error {
 		return fmt.Errorf("marshal Ed25519 private key: %w", err)
 	}
 	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
-	return os.WriteFile(path, pem.EncodeToMemory(block), 0600)
+	return createExclusive(path, pem.EncodeToMemory(block), 0600)
 }
 
 // writePublicKey serialises key to PKIX PEM and writes it with mode 0644.
@@ -167,7 +171,7 @@ func writePublicKey(path string, key ed25519.PublicKey) error {
 		return fmt.Errorf("marshal Ed25519 public key: %w", err)
 	}
 	block := &pem.Block{Type: "PUBLIC KEY", Bytes: der}
-	return os.WriteFile(path, pem.EncodeToMemory(block), 0644) //nolint:gosec // public key intended to be world-readable
+	return createExclusive(path, pem.EncodeToMemory(block), 0644) //nolint:gosec // public key intended to be world-readable
 
 }
 
@@ -232,7 +236,7 @@ func decodeEd25519PublicPEM(data []byte, src string) (ed25519.PublicKey, error) 
 func loadOrGenerateRefreshSecret(dir string, log logger) ([]byte, error) {
 	path := filepath.Join(dir, fileRefreshSecret)
 
-	if _, err := os.Stat(path); err == nil {
+	if exists(dir, fileRefreshSecret) {
 		log.Info("authcore/keymanager: loading existing refresh secret from %s", dir)
 		return loadRefreshSecret(path)
 	}
@@ -250,7 +254,7 @@ func generateAndSaveRefreshSecret(path string) ([]byte, error) {
 	}
 	// Hex-encode so the file survives editors that mangle binary content.
 	content := hex.EncodeToString(secret) + "\n"
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+	if err := createExclusive(path, []byte(content), 0600); err != nil {
 		return nil, fmt.Errorf("write refresh secret to %q: %w", path, err)
 	}
 	return secret, nil

--- a/internal/keymanager/keymanager.go
+++ b/internal/keymanager/keymanager.go
@@ -220,8 +220,8 @@ func tightenDirMode(dir string) error {
 // not already exist. It is idempotent.
 func ensureGitignore(dir string) error {
 	path := filepath.Join(dir, fileGitignore)
-	if _, err := os.Stat(path); err == nil {
+	if exists(dir, fileGitignore) {
 		return nil // already present
 	}
-	return os.WriteFile(path, []byte(gitignoreContent), 0600)
+	return createExclusive(path, []byte(gitignoreContent), 0600)
 }


### PR DESCRIPTION
A dangling symlink at a managed filename was classified as absent by `os.Stat`, so every presence check agreed the directory was empty and the freshly generated Ed25519 private key was written at the link target, outside `KeysDir`. Reproduced against all three managed files.

The attack needs something to populate `KeysDir` before authcore first runs, which for this library is ordinary rather than exotic: a mounted container volume, a provisioning script, a restored backup, a Compose file.

Every managed write now goes through `createExclusive`, opening with `O_CREATE|O_EXCL`. POSIX requires that to fail with `EEXIST` when the path is a symlink, dangling ones included. It also closes the narrower race the old code left open: a regular file appearing between the presence check and the write kept its own permissions, so a 0644 file planted at that moment received the private key.

`O_NOFOLLOW` would state the property more loudly, but it lives in `syscall` rather than `os` and is undefined on Windows, and this library ships to Windows consumers. The portable flag that already has the property is the one to rely on.

## Reads still follow symlinks, on purpose

`docs/key-management.md` tells the operator to mount a Kubernetes Secret at `KeysDir`, and Kubernetes projects a Secret volume as a tree of symlinks. A loader that refused links would pass a security review and break every replica following the deployment guide. `TestSymlinkedKeysStillLoad` pins that case: an existing key set reached entirely through links loads, and loads the same key id.

Read-following is the weaker exposure anyway. The read path already caps at 4 KiB and validates the pair, and anyone who can redirect a read can equally replace the file.

## Two things I had wrong until I sabotaged them

I wrote this with `Lstat` in the presence check, believing that was the fix, and the commit would have said so. Reverting it to `Stat` left the dangling-symlink test green, so `Lstat` was never load-bearing. Reverting `O_EXCL` turns all three subtests red. `O_EXCL` is the control.

Measuring the two then inverted which is better. With `Lstat` the consistency check fires first and the operator is told to "delete all key files" — advice that, since `auth/field` shipped, destroys every encrypted column. With `Stat` the failure reaches `createExclusive`, which names the symlink and says what to do. So `inspect` uses `Stat`, and the test now asserts the message: that it mentions the symlink, and that it does not give the destructive advice.

Closes #342