### PR TITLE
fix(totp): require a TOTP secret to be the full 20 bytes

### DIFF
--- a/auth/totp/secret_length_test.go
+++ b/auth/totp/secret_length_test.go
@@ -1,0 +1,71 @@
+package totp
+
+import (
+	"encoding/base32"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestDecodeSecretRequiresTheFullLength is the regression for a secret of any
+// length being accepted as an HMAC key.
+//
+// The cases are chosen around the trap that made the gap easy to miss. Short
+// inputs were already rejected before the length check existed, but only when
+// their length was not a multiple of 8, because that is what selected the
+// padded encoding and made them malformed. Every case below whose length is a
+// multiple of 8 decoded cleanly and was accepted at whatever size it produced,
+// so those are the ones that pin the length check rather than the encoding
+// heuristic.
+func TestDecodeSecretRequiresTheFullLength(t *testing.T) {
+	valid := base32.StdEncoding.WithPadding(base32.NoPadding).
+		EncodeToString(make([]byte, secretLen))
+
+	cases := []struct {
+		name  string
+		input string
+		want  bool // want accepted
+	}{
+		{"exactly 20 bytes", valid, true},
+		{"5 bytes, length a multiple of 8", "MZXW6YTB", false},
+		{"5 bytes of zeroes, length a multiple of 8", "AAAAAAAA", false},
+		{"10 bytes, length a multiple of 8", "MZXW6YTBMZXW6YTB", false},
+		{"25 bytes, length a multiple of 8", strings.Repeat("A", 40), false},
+		{"empty", "", false},
+		{"not base32 at all", "!!!!!!!!", false},
+		{"far too long", strings.Repeat("A", 4096), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := decodeSecret(tc.input)
+			switch {
+			case tc.want && err != nil:
+				t.Fatalf("decodeSecret(%q) = %v, want accepted", tc.input, err)
+			case tc.want && len(key) != secretLen:
+				t.Fatalf("decodeSecret(%q) returned %d bytes, want %d", tc.input, len(key), secretLen)
+			case !tc.want && err == nil:
+				t.Fatalf("decodeSecret(%q) accepted a %d-byte key, want ErrInvalidSecret", tc.input, len(key))
+			case !tc.want && !errors.Is(err, ErrInvalidSecret):
+				t.Fatalf("decodeSecret(%q) = %v, want ErrInvalidSecret", tc.input, err)
+			}
+		})
+	}
+}
+
+// TestEnrolledSecretRoundTrips keeps the length check from being tightened
+// past what this package itself mints.
+func TestEnrolledSecretRoundTrips(t *testing.T) {
+	mod := newTOTP(t, Config{})
+	enr, err := mod.Enroll("alice@example.com")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	key, err := decodeSecret(enr.Secret)
+	if err != nil {
+		t.Fatalf("a secret this package minted was rejected: %v", err)
+	}
+	if len(key) != secretLen {
+		t.Errorf("Enroll minted a %d-byte secret, want %d", len(key), secretLen)
+	}
+}

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -327,20 +327,44 @@ func (t *TOTP) hashRecoveryCode(code string) string {
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
-// decodeSecret decodes a base32 secret (with or without padding) into
-// raw bytes. Empty input is invalid: Enroll never produces an empty
-// secret, so an empty value here means a corrupted store.
+// maxEncodedSecretLen is the longest base32 input decodeSecret will look at.
+// A 20-byte secret encodes to 32 characters unpadded and 32 with padding,
+// since 20 bytes is already a whole number of 40-bit base32 groups. The few
+// extra characters leave room for nothing in particular and exist so an
+// oversized input is refused before it is decoded rather than after.
+const maxEncodedSecretLen = 40
+
+// decodeSecret decodes a base32 secret (with or without padding) into raw
+// bytes and requires exactly secretLen of them.
+//
+// The length check is the point. Before it existed the only size test was
+// len(key) == 0, so any secret that decoded to at least one byte was accepted
+// and used as an HMAC key: "MZXW6YTB" decodes to 5 bytes, and a 40-bit TOTP
+// secret is enumerable. Enroll always mints secretLen bytes, so nothing this
+// package generates was affected; the exposure is a secret arriving from
+// outside, migrated from another implementation, pasted by a user, or
+// restored from a store that truncated it.
+//
+// Short inputs did fail before this, which is what made the gap easy to miss,
+// but they failed for the wrong reason. The encoding is chosen by
+// len(s)%8 != 0, so a length that is not a multiple of 8 gets the padded
+// encoding and is rejected as malformed. That reads like a length control and
+// is not one: every length that is a multiple of 8 took the unpadded branch
+// and decoded cleanly at any size.
 func decodeSecret(s string) ([]byte, error) {
-	if s == "" {
+	if s == "" || len(s) > maxEncodedSecretLen {
 		return nil, ErrInvalidSecret
 	}
-	enc := base32.StdEncoding.WithPadding(base32.NoPadding)
-	if len(s)%8 != 0 {
-		// Tolerate padded input as well.
-		enc = base32.StdEncoding
-	}
-	key, err := enc.DecodeString(s)
-	if err != nil || len(key) == 0 {
+	// One encoding is enough now, and that is a consequence of the length
+	// check rather than a separate decision. secretLen is 20 bytes, which is
+	// exactly four 40-bit base32 groups, so it encodes to 32 characters with
+	// no padding and the padded and unpadded forms of a valid secret are
+	// byte-identical. The branch that used to switch encodings on
+	// len(s)%8 != 0 could therefore no longer produce an accepted result:
+	// every input it selected the padded encoding for is one the length check
+	// rejects anyway. Measured before removing it.
+	key, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(s)
+	if err != nil || len(key) != secretLen {
 		return nil, ErrInvalidSecret
 	}
 	return key, nil


### PR DESCRIPTION
`decodeSecret` enforced no length. Its only size test was `len(key) == 0`, so any secret that decoded to at least one byte was accepted and used as an HMAC key. `secretLen` has been declared as 20 three functions away the whole time and nothing compared against it.

Measured on develop at 6396536:

| input | decoded | accepted before |
|---|---|---|
| `MZXW6YTB` | 5 bytes | yes |
| `AAAAAAAA` | 5 bytes | yes |
| `MZXW6YTBMZXW6YTB` | 10 bytes | yes |

A 5-byte secret is a 40-bit keyspace, and `generateTOTP` produced codes from it without complaint.

`Enroll` always mints `secretLen` bytes, so nothing this package generates was affected. The exposure is a secret arriving from outside: migrated from another TOTP implementation, pasted by a user, or restored from a store that truncated it.

## The trap, because it is what the tests are built around

Short inputs did fail before this, and they failed for the wrong reason. The encoding was selected by `len(s)%8 != 0`, so a length that is not a multiple of 8 got the padded encoding and was rejected as malformed base32. That reads like a length control and is not one. Every length that is a multiple of 8 took the unpadded branch and decoded cleanly at whatever size it produced.

The four subtests that go red when the old `len(key) == 0` check is restored are exactly the multiple-of-8 cases, which is what makes them a test of the length check rather than of the encoding heuristic.

## The encoding branch is gone too

That is a consequence of the length check, not a separate decision, and I measured it before removing anything: 20 bytes is exactly four 40-bit base32 groups, so it encodes to 32 characters with no padding and the padded and unpadded forms of a valid secret are byte-identical. The branch could therefore no longer select an encoding for any input the length check would accept. Leaving it would have left a tolerance that tolerates nothing.

The encoded input is also capped before decoding rather than after.

## Provenance

Found by a MiniMax-M3 pass over the package. Its conclusion was right and its reproduction was wrong: it offered `MY` as an accepted one-byte secret, and `MY` is rejected, by the padding heuristic above. Running its example alone would have closed this as a false positive.

Closes #357