### PR TITLE
fix(oauth): keep the redirect guards when the caller supplies a client

### DIFF
--- a/auth/oauth/config.go
+++ b/auth/oauth/config.go
@@ -78,8 +78,26 @@ func applyDefaults(cfg Config) Config {
 	if len(cfg.Scopes) == 0 {
 		cfg.Scopes = defaultScopes
 	}
-	if cfg.HTTPClient == nil {
+	// A caller supplies a client for its transport, its timeout or its proxy.
+	// None of those intentions include turning off the redirect guards, and
+	// installing the safe client only when the field is nil is what used to
+	// turn them off: safeRedirect is four controls at once, and every one of
+	// them was lost on the token, JWKS, userinfo and discovery fetches the
+	// moment a caller set this field. The token exchange carries the client
+	// secret and receives the ID token, so those are the fetches that least
+	// tolerate an unguarded redirect.
+	//
+	// The copy is deliberate. Forcing the policy onto the caller's own
+	// *http.Client would change how that client behaves everywhere else in
+	// their program, which is a second surprise rather than a fix. They keep
+	// Transport, Timeout and Jar, which is what they supplied it for.
+	switch {
+	case cfg.HTTPClient == nil:
 		cfg.HTTPClient = newSafeHTTPClient()
+	default:
+		guarded := *cfg.HTTPClient
+		guarded.CheckRedirect = safeRedirect
+		cfg.HTTPClient = &guarded
 	}
 	return cfg
 }
@@ -208,5 +226,15 @@ func requireHTTPS(label, raw string) error {
 
 // isLoopbackHost reports whether host is a loopback address (dev-only http).
 func isLoopbackHost(host string) bool {
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	if host == "localhost" {
+		return true
+	}
+	// Match the whole loopback range rather than the two literals people
+	// usually type. 127.0.0.0/8 is all loopback, and a development server
+	// bound to 127.0.0.2 to dodge a port collision is as local as 127.0.0.1.
+	// Failing to recognise it refused the documented plaintext exception, so
+	// this was a usability gap rather than a hole, but the definition should
+	// be the one the standard library already has.
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/auth/oauth/redirect_policy_test.go
+++ b/auth/oauth/redirect_policy_test.go
@@ -1,0 +1,67 @@
+package oauth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestSuppliedClientKeepsTheRedirectGuards is the regression for the case where
+// a caller-supplied client arrived with CheckRedirect nil, which silently
+// removed the hop cap, the https requirement, the private-host SSRF guard and
+// the cross-origin guard from every fetch this package makes.
+func TestSuppliedClientKeepsTheRedirectGuards(t *testing.T) {
+	own := &http.Client{Timeout: 3 * time.Second}
+	cfg := applyDefaults(Config{HTTPClient: own})
+
+	if cfg.HTTPClient.CheckRedirect == nil {
+		t.Fatal("a caller-supplied client came back with no redirect policy")
+	}
+	if cfg.HTTPClient.Timeout != 3*time.Second {
+		t.Errorf("the caller's timeout was discarded: got %v, want 3s", cfg.HTTPClient.Timeout)
+	}
+}
+
+// TestTheCallersOwnClientIsNotMutated pins the other half of the fix. Forcing
+// the policy onto the caller's client would change how it behaves everywhere
+// else in their program, so the package works on a copy.
+func TestTheCallersOwnClientIsNotMutated(t *testing.T) {
+	own := &http.Client{Timeout: 3 * time.Second}
+	cfg := applyDefaults(Config{HTTPClient: own})
+
+	if own.CheckRedirect != nil {
+		t.Error("the caller's own client was mutated")
+	}
+	if cfg.HTTPClient == own {
+		t.Error("the package kept the caller's client rather than a copy")
+	}
+}
+
+// TestDefaultClientStillCarriesThePolicy guards the path that was already
+// correct, so a refactor cannot fix one case by breaking the other.
+func TestDefaultClientStillCarriesThePolicy(t *testing.T) {
+	if applyDefaults(Config{}).HTTPClient.CheckRedirect == nil {
+		t.Error("the default client has no redirect policy")
+	}
+}
+
+// TestLoopbackExceptionCoversTheWholeRange covers the plaintext exception.
+// Only loopback may be http; everything else must still be refused.
+func TestLoopbackExceptionCoversTheWholeRange(t *testing.T) {
+	for host, want := range map[string]bool{
+		"localhost":          true,
+		"127.0.0.1":          true,
+		"127.0.0.2":          true,
+		"127.1.2.3":          true,
+		"::1":                true,
+		"10.0.0.1":           false,
+		"192.168.1.1":        false,
+		"example.com":        false,
+		"localhost.evil.com": false,
+		"":                   false,
+	} {
+		if got := isLoopbackHost(host); got != want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}


### PR DESCRIPTION
`applyDefaults` installed the safe client only when `cfg.HTTPClient` was nil, so a caller who supplied one kept their transport and lost `CheckRedirect` entirely.

Measured on develop at 6396536: `applyDefaults(Config{HTTPClient: &http.Client{}})` returns `CheckRedirect == nil`, `applyDefaults(Config{})` returns it set.

`safeRedirect` is four controls, not one:

- a five hop cap
- https on every redirect target
- refusal of a loopback, private, link-local or unspecified address, which is the SSRF guard
- refusal of a cross-origin redirect

All four went together, on every fetch the package makes: token exchange, JWKS, userinfo, discovery. The token exchange carries the client secret and receives the ID token, so those are the fetches that least tolerate an unguarded redirect.

A caller supplies a client for its transport, its timeout or its proxy. None of those intentions include turning off SSRF protection, and nothing told them it had happened. `standards/security` is explicit that the most restrictive configuration is the active one and that users opt in to looseness, never to safety.

## The copy is the second half of the fix

`applyDefaults` now shallow copies a supplied client and forces the policy on the copy. Forcing it onto the caller own `*http.Client` would change how that client behaves everywhere else in their program, which is a different surprise rather than a fix. They keep `Transport`, `Timeout` and `Jar`, which is what they supplied it for.

Both halves are checked in the failing direction, separately: removing the forcing fails the guard test, and mutating the caller client instead of copying fails the no-mutation test.

## isLoopbackHost, riding along

It matched three literals, so a development server bound to `127.0.0.2` to dodge a port collision was refused the documented plaintext exception. That fails closed, so it was a usability gap rather than a hole, but the package already had the right definition a few lines away: `isPrivateHost` uses `net.IP.IsLoopback()` and the two disagreed about what loopback means.

It uses `net.IP.IsLoopback()` now. The tests pin that the exception does not widen past loopback: `10.0.0.1`, `192.168.1.1` and `localhost.evil.com` stay refused.

## Provenance

Both found by a MiniMax-M3 pass over the package. It rated the client one a hardening suggestion rather than a defect, on the grounds that the behaviour is documented in a doc comment. I disagree and filed it as a defect: a one-line comment in a long file is not how a caller learns that four security controls just turned off, and the standard treats a disabled security default as a defect regardless of whether it is written down.

Closes #364
Closes #365